### PR TITLE
Added validation

### DIFF
--- a/src/main/java/com/hedera/sdk/account/HederaAccount.java
+++ b/src/main/java/com/hedera/sdk/account/HederaAccount.java
@@ -489,6 +489,7 @@ public class HederaAccount implements Serializable {
 		transaction.keySignatureList = sigsForTransaction;
 		
 		// issue the transaction
+		Utilities.throwIfNull("Node", this.node);
 		HederaTransactionResult hederaTransactionResult = this.node.accountCreate(transaction);
 		hederaTransactionResult.hederaTransactionID = transactionID;
 		// return
@@ -529,6 +530,7 @@ public class HederaAccount implements Serializable {
 		transaction.keySignatureList = sigsForTransaction;
 		
 		// issue the transaction
+		Utilities.throwIfNull("Node", this.node);
 		HederaTransactionResult hederaTransactionResult = this.node.accountTransfer(transaction);
 		hederaTransactionResult.hederaTransactionID = transactionID;
 		// return
@@ -569,6 +571,7 @@ public class HederaAccount implements Serializable {
 		transaction.keySignatureList = sigsForTransaction;
 		
 		// issue the transaction
+		Utilities.throwIfNull("Node", this.node);
 		HederaTransactionResult hederaTransactionResult = this.node.accountUpdate(transaction);
 		hederaTransactionResult.hederaTransactionID = transactionID;
 
@@ -610,6 +613,7 @@ public class HederaAccount implements Serializable {
 		transaction.keySignatureList = sigsForTransaction;
 		
 		// issue the transaction
+		Utilities.throwIfNull("Node", this.node);
 		HederaTransactionResult hederaTransactionResult = this.node.addClaim(transaction);
 		hederaTransactionResult.hederaTransactionID = transactionID;
 
@@ -650,6 +654,7 @@ public class HederaAccount implements Serializable {
 		query.queryData = queryBalance.build();
 		
 		// query now set, send to network
+		Utilities.throwIfNull("Node", this.node);
 		Response response = this.node.getAccountBalance(query);
 
 		if (response == null) {
@@ -666,9 +671,7 @@ public class HederaAccount implements Serializable {
 
 		if (this.precheckResult == HederaPrecheckResult.OK) {
 			this.balance = queryResponse.getBalance();
-			// cost
 			this.cost = responseHeader.getCost();
-			//state proof
 			this.stateProof = responseHeader.getStateProof().toByteArray();
 		} else {
 			result = false;
@@ -764,6 +767,7 @@ public class HederaAccount implements Serializable {
 		query.queryData = queryRecords.build();
 		
 		// query now set, send to network
+		Utilities.throwIfNull("Node", this.node);
 		Response response = this.node.getAccountRecords(query);
 		if (response == null) {
 			Utilities.printResponseFailure("HederaAccount.getRecords");
@@ -867,6 +871,7 @@ public class HederaAccount implements Serializable {
 		query.queryData = accountGetInfoQuery.build();
 		
 		// query now set, send to network
+		Utilities.throwIfNull("Node", this.node);
 		Response response = this.node.getAccountInfo(query);
 
 		if (response == null) {
@@ -1185,12 +1190,19 @@ public class HederaAccount implements Serializable {
 		this.accountKey = new HederaKey(keyType, publicKey);
 		this.initialBalance = initialBalance;
 
+		// validate inputs
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
+		Utilities.throwIfAccountIDInvalid("txQueryDefaults.payingAccountID", this.txQueryDefaults.payingAccountID);
+		Utilities.throwIfAccountIDInvalid("txQueryDefaults.node.AccountID", this.txQueryDefaults.node.getAccountID());
+		
 		// set transport
 		this.node = this.txQueryDefaults.node;
 		
 		// create a transaction ID (starts now with accountID of the paying account id)
 		this.hederaTransactionID = new HederaTransactionID(this.txQueryDefaults.payingAccountID);
 		
+
 		// get the body for the transaction so we can sign it
 		TransactionBody createBody = this.bodyToSignForCreate(
 				this.hederaTransactionID
@@ -1218,6 +1230,9 @@ public class HederaAccount implements Serializable {
 	
 	private HederaKeySignatureList signBody(byte[] message) {
 		// get the signature for the body
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.payingKeyPair", this.txQueryDefaults.payingKeyPair);
+		
 		byte[] signedBody = this.txQueryDefaults.payingKeyPair.signMessage(message);
 		// create a Hedera Signature for it
 		HederaSignature payingSignature = new HederaSignature(this.txQueryDefaults.payingKeyPair.getKeyType(), signedBody);
@@ -1252,9 +1267,16 @@ public class HederaAccount implements Serializable {
 		HederaTransactionResult transactionResult = new HederaTransactionResult();
 		transactionResult.setError();
 		
+		// validate inputs
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
+		Utilities.throwIfNull("txQueryDefaults.payingKeyPair", this.txQueryDefaults.payingKeyPair);
+		Utilities.throwIfAccountIDInvalid("txQueryDefaults.payingAccountID", this.txQueryDefaults.payingAccountID);
+		Utilities.throwIfAccountIDInvalid("node.AccountID", this.node.getAccountID());
+
 		// set transport
 		this.node = this.txQueryDefaults.node;
-		
+
 		// create a transaction ID (starts now with accountID of the paying account id)
 		this.hederaTransactionID = new HederaTransactionID(this.txQueryDefaults.payingAccountID);
 
@@ -1269,6 +1291,8 @@ public class HederaAccount implements Serializable {
 		
 		accountAmounts.add(fromAccountAmount);
 		accountAmounts.add(toAccountAmount);
+
+		Utilities.throwIfAccountIDInvalid("Node", this.node.getAccountID());
 		
 		// get the body for the transaction so we can sign it
 		TransactionBody transferBody = this.bodyToSignForTransfer(
@@ -1335,11 +1359,19 @@ public class HederaAccount implements Serializable {
 		HederaTransactionResult transactionResult = new HederaTransactionResult();
 		transactionResult.setError();
 		
+		// validate inputs
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
+		Utilities.throwIfAccountIDInvalid("txQueryDefaults.payingAccountID", this.txQueryDefaults.payingAccountID);
+		Utilities.throwIfAccountIDInvalid("node.AccountID", this.node.getAccountID());
+
 		// set transport
 		this.node = this.txQueryDefaults.node;
 		
 		// create a transaction ID (starts now with accountID of the paying account id)
 		this.hederaTransactionID = new HederaTransactionID(this.txQueryDefaults.payingAccountID);
+
+		Utilities.throwIfAccountIDInvalid("Node", this.node.getAccountID());
 
 		// get the body for the transaction so we can sign it
 		TransactionBody claimBody = this.bodyToSignForAddClaim(
@@ -1398,6 +1430,8 @@ public class HederaAccount implements Serializable {
 	public long getBalance() throws InterruptedException {
 	   	logger.trace("Start - getBalance");
 		// set transport
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
 		this.node = this.txQueryDefaults.node;
 		
 		HederaTransaction transferTransaction = new HederaTransaction(this.txQueryDefaults,this.node.accountBalanceQueryFee);
@@ -1444,7 +1478,10 @@ public class HederaAccount implements Serializable {
 	public boolean getInfo() throws InterruptedException {
 	   	logger.trace("Start - getInfo");
 		// set transport
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
 		this.node = this.txQueryDefaults.node;
+
 		HederaTransaction transferTransaction = new HederaTransaction(this.txQueryDefaults, this.node.accountInfoQueryFee);
 	   	logger.trace("End - getInfo");
 		return this.getInfoAnswerOnly(transferTransaction);
@@ -1514,11 +1551,20 @@ public class HederaAccount implements Serializable {
 		HederaTransactionResult transactionResult = new HederaTransactionResult();
 		transactionResult.setError();
 		
+		// validate inputs
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
+		Utilities.throwIfNull("txQueryDefaults.payingKeyPair", this.txQueryDefaults.payingKeyPair);
+		Utilities.throwIfAccountIDInvalid("txQueryDefaults.payingAccountID", this.txQueryDefaults.payingAccountID);
+		Utilities.throwIfAccountIDInvalid("node.AccountID", this.node.getAccountID());
+
 		// set transport
 		this.node = this.txQueryDefaults.node;
 		
 		// create a transaction ID (starts now with accountID of the paying account id)
 		this.hederaTransactionID = new HederaTransactionID(this.txQueryDefaults.payingAccountID);
+
+		Utilities.throwIfAccountIDInvalid("Node", this.node.getAccountID());
 
 		// build body
 		// get the body for the transaction so we can sign it
@@ -1609,7 +1655,10 @@ public class HederaAccount implements Serializable {
 	public List<HederaTransactionRecord> getRecords() throws InterruptedException {
 	   	logger.trace("Start - getRecords");
 		// set transport
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
 		this.node = this.txQueryDefaults.node;
+		
 		HederaTransaction transferTransaction = new HederaTransaction(this.txQueryDefaults, this.node.accountGetRecordsQueryFee);
 		getRecordsAnswerOnly(transferTransaction);
 	   	logger.trace("End - getRecords");
@@ -1627,6 +1676,9 @@ public class HederaAccount implements Serializable {
 	 */
 	public List<HederaTransactionRecord> getRecords(long shardNum, long realmNum, long accountNum) throws InterruptedException {
 		HederaAccount recordAccount = new HederaAccount(shardNum, realmNum, accountNum);
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("node", this.node);
+		
 		HederaTransaction transferTransaction = new HederaTransaction(this.txQueryDefaults, this.node.accountGetRecordsQueryFee);
 		if (getRecords(transferTransaction, QueryResponseType.ANSWER_ONLY, recordAccount.getHederaAccountID())) {
 			return this.records;

--- a/src/main/java/com/hedera/sdk/common/Utilities.java
+++ b/src/main/java/com/hedera/sdk/common/Utilities.java
@@ -274,4 +274,39 @@ public class Utilities {
 	public static void printResponseFailure(String location) {
 		logger.error("***** " + location + " FAILED to get response *****");
 	}
+	/**
+	 * Throws an exception if the supplied node object is null
+	 * @param objectType a string describing the object being checked which will be included in the error message
+	 * @param object the object to check
+	 * @throws IllegalStateException thrown if the object is null
+	 */
+	public static void throwIfNull(String objectType, Object object) {
+		if (object == null) {
+		   	logger.trace("throwIfNull");
+		   	String error = objectType + " is null";
+		   	logger.error(error);
+			throw new IllegalStateException(error);
+		}
+	}
+	/**
+	 * Throws an exception if the supplied accountID object is invalid
+	 * @param accountType a string describing the accountID being checked which will be included in the error message
+	 * @param accountID {@link HederaAccountID} to check
+	 * @throws IllegalStateException thrown if the accountID is invalid
+	 */
+	public static void throwIfAccountIDInvalid(String accountType, HederaAccountID accountID) {
+		if (accountID == null) {
+		   	logger.trace("throwIfAccountIDInvalid");
+		   	String error = accountType + " AccountID is null.";
+		   	logger.error(error);
+			throw new IllegalStateException(error);
+		} else {
+			if ((accountID.shardNum < 0) || (accountID.realmNum < 0) || (accountID.accountNum <= 0)) {
+			   	logger.trace("throwIfAccountIDInvalid");
+			   	String error = accountType + " AccountID shard and realm must be greater or equal to 0 and accountNum greater than 0.";
+			   	logger.error(error);
+				throw new IllegalStateException(error);
+			}
+		}
+	}
 }

--- a/src/main/java/com/hedera/sdk/contract/HederaContract.java
+++ b/src/main/java/com/hedera/sdk/contract/HederaContract.java
@@ -306,6 +306,7 @@ public class HederaContract implements Serializable {
 		transaction.signatureList = sigsForTransaction;
 		
 		// issue the transaction
+		Utilities.throwIfNull("Node", this.node);
 		HederaTransactionResult hederaTransactionResult = this.node.contractCall(transaction);
 		hederaTransactionResult.hederaTransactionID = transactionID;
 		// return
@@ -395,6 +396,7 @@ public class HederaContract implements Serializable {
 		transaction.signatureList = sigsForTransaction;
 		
 		// issue the transaction
+		Utilities.throwIfNull("Node", this.node);
 		HederaTransactionResult hederaTransactionResult = this.node.contractCreate(transaction);
 		hederaTransactionResult.hederaTransactionID = transactionID;
 		// return
@@ -501,6 +503,7 @@ public class HederaContract implements Serializable {
 		transaction.keySignatureList = sigsForTransaction;
 		
 		// issue the transaction
+		Utilities.throwIfNull("Node", this.node);
 		HederaTransactionResult hederaTransactionResult = this.node.contractUpdate(transaction);
 		hederaTransactionResult.hederaTransactionID = transactionID;
 		// return
@@ -599,6 +602,7 @@ public class HederaContract implements Serializable {
 		query.queryData = getInfoQuery.build();
 		
 		// query now set, send to network
+		Utilities.throwIfNull("Node", this.node);
 		Response response = this.node.getContractByteCode(query);
 		if (response == null) {
 			Utilities.printResponseFailure("HederaContrat.getByteCode");
@@ -702,6 +706,7 @@ public class HederaContract implements Serializable {
 		query.queryData = getInfoQuery.build();
 		
 		// query now set, send to network
+		Utilities.throwIfNull("Node", this.node);
 		Response response = this.node.getContractInfo(query);
 		if (response == null) {
 			Utilities.printResponseFailure("HederaContrat.getInfo");
@@ -830,6 +835,7 @@ public class HederaContract implements Serializable {
 		query.queryData = callLocalQuery.build();
 		
 		// query now set, send to network
+		Utilities.throwIfNull("Node", this.node);
 		Response response = this.node.contractCallLocal(query);
 		if (response == null) {
 			Utilities.printResponseFailure("HederaContrat.callLocal");
@@ -993,9 +999,16 @@ public class HederaContract implements Serializable {
 		this.constructionParameters = constructorParameters;
 		this.autoRenewPeriod = autoRenewPeriod;
 		
+		// validate inputs
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
+		Utilities.throwIfNull("txQueryDefaults.payingKeyPair", this.txQueryDefaults.payingKeyPair);
+		Utilities.throwIfAccountIDInvalid("txQueryDefaults.payingAccountID", this.txQueryDefaults.payingAccountID);
+		Utilities.throwIfAccountIDInvalid("txQueryDefaults.node.AccountID", this.txQueryDefaults.node.getAccountID());
+
 		// set transport
 		this.node = this.txQueryDefaults.node;
-		
+
 		// create a transaction ID (starts now with accountID of the paying account id)
 		this.hederaTransactionID = new HederaTransactionID(this.txQueryDefaults.payingAccountID);
 
@@ -1066,6 +1079,12 @@ public class HederaContract implements Serializable {
 		this.expirationTime = expirationTime;
 		this.autoRenewPeriod = autoRenewPeriod;
 		
+		// validate inputs
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
+		Utilities.throwIfNull("txQueryDefaults.payingKeyPair", this.txQueryDefaults.payingKeyPair);
+		Utilities.throwIfAccountIDInvalid("node.AccountID", this.node.getAccountID());
+
 		// set transport
 		this.node = this.txQueryDefaults.node;
 		
@@ -1141,9 +1160,16 @@ public class HederaContract implements Serializable {
 		this.amount = amount;
 		this.functionParameters = functionParameters.clone();
 				
+		// validate inputs
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
+		Utilities.throwIfNull("txQueryDefaults.payingKeyPair", this.txQueryDefaults.payingKeyPair);
+		Utilities.throwIfAccountIDInvalid("txQueryDefaults.payingAccountID", this.txQueryDefaults.payingAccountID);
+		Utilities.throwIfAccountIDInvalid("node.AccountID", this.node.getAccountID());
+
 		// set transport
 		this.node = this.txQueryDefaults.node;
-		
+
 		// create a transaction ID (starts now with accountID of the paying account id)
 		this.hederaTransactionID = new HederaTransactionID(this.txQueryDefaults.payingAccountID);
 
@@ -1226,7 +1252,10 @@ public class HederaContract implements Serializable {
 	public boolean getInfo() throws InterruptedException {
 	  logger.trace("Start - getInfo");
 		// set transport
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("Node", this.txQueryDefaults.node);
 		this.node = this.txQueryDefaults.node;
+		Utilities.throwIfNull("Node", this.node);
 		HederaTransaction transferTransaction = new HederaTransaction(this.txQueryDefaults, this.node.contractGetInfoQueryFee);
 	  logger.trace("End - getInfo");
 		return this.getInfoAnswerOnly(transferTransaction);
@@ -1263,6 +1292,8 @@ public class HederaContract implements Serializable {
 	public byte[] getByteCode() throws InterruptedException {
 	  logger.trace("Start - getByteCode");
 		// set transport
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("Node", this.txQueryDefaults.node);
 		this.node = this.txQueryDefaults.node;
 		
 		HederaTransaction transferTransaction = new HederaTransaction(this.txQueryDefaults,this.node.contractGetByteCodeQueryFee);
@@ -1306,6 +1337,11 @@ public class HederaContract implements Serializable {
 	 */
 	public HederaContractFunctionResult callLocal(long gas, byte[] functionParameters, long maxResultSize) throws InterruptedException {
 	  logger.trace("Start - callLocal");
+
+		// validate inputs
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
+
 		// set transport
 		this.node = this.txQueryDefaults.node;
 		

--- a/src/main/java/com/hedera/sdk/file/HederaFile.java
+++ b/src/main/java/com/hedera/sdk/file/HederaFile.java
@@ -394,6 +394,8 @@ public class HederaFile implements Serializable {
 		transaction.signatureList = sigsForTransaction;
 
 		// issue the transaction
+		Utilities.throwIfNull("Node", this.node);
+		
 		HederaTransactionResult hederaTransactionResult = this.node.fileCreate(transaction);
 		hederaTransactionResult.hederaTransactionID = transactionID;
 		// return
@@ -438,6 +440,8 @@ public class HederaFile implements Serializable {
 		transaction.signatureList = sigsForTransaction;
 
 		// issue the transaction
+		Utilities.throwIfNull("Node", this.node);
+
 		HederaTransactionResult hederaTransactionResult = this.node.fileDelete(transaction);
 		hederaTransactionResult.hederaTransactionID = transactionID;
 		logger.trace("End - delete");
@@ -482,6 +486,8 @@ public class HederaFile implements Serializable {
 		transaction.signatureList = sigsForTransaction;
 
 		// issue the transaction
+		Utilities.throwIfNull("Node", this.node);
+
 		HederaTransactionResult hederaTransactionResult = this.node.fileUpdate(transaction);
 		hederaTransactionResult.hederaTransactionID = transactionID;
 
@@ -526,6 +532,8 @@ public class HederaFile implements Serializable {
 		transaction.signatureList = sigsForTransaction;
 
 		// issue the transaction
+		Utilities.throwIfNull("Node", this.node);
+
 		HederaTransactionResult hederaTransactionResult = this.node.fileAppend(transaction);
 		hederaTransactionResult.hederaTransactionID = transactionID;
 
@@ -696,6 +704,8 @@ public class HederaFile implements Serializable {
 		query.queryData = fileGetContents.build();
 
 		// query now set, send to network
+		Utilities.throwIfNull("Node", this.node);
+
 		Response response = this.node.getFileContents(query);
 
 		FileGetContentsResponse.Builder fileContentsResponse = response.getFileGetContents().toBuilder();
@@ -814,6 +824,8 @@ public class HederaFile implements Serializable {
 		query.queryData = fileGetInfoQuery.build();
 
 		// query now set, send to network
+		Utilities.throwIfNull("Node", this.node);
+
 		Response response = this.node.getFileInfo(query);
 
 		FileGetInfoResponse.Builder fileGetInfoResponse = response.getFileGetInfo().toBuilder();
@@ -1212,6 +1224,13 @@ public class HederaFile implements Serializable {
 		this.realmNum = realmNum;
 		this.contents = contents.clone();
 
+		// validate inputs
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
+		Utilities.throwIfNull("txQueryDefaults.payingKeyPair", this.txQueryDefaults.payingKeyPair);
+		Utilities.throwIfAccountIDInvalid("Node", this.txQueryDefaults.node.getAccountID());
+		Utilities.throwIfAccountIDInvalid("txQueryDefaults.payingAccountID", this.txQueryDefaults.payingAccountID);
+
 		// set transport
 		this.node = this.txQueryDefaults.node;
 
@@ -1276,6 +1295,13 @@ public class HederaFile implements Serializable {
 		// initialise the result
 		HederaTransactionResult transactionResult = new HederaTransactionResult();
 		transactionResult.setError();
+
+		// validate inputs
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
+		Utilities.throwIfAccountIDInvalid("Node", this.txQueryDefaults.node.getAccountID());
+		Utilities.throwIfNull("txQueryDefaults.payingKeyPair", this.txQueryDefaults.payingKeyPair);
+		Utilities.throwIfAccountIDInvalid("txQueryDefaults.payingKeyPair", this.txQueryDefaults.payingAccountID);
 
 		// set transport
 		this.node = this.txQueryDefaults.node;
@@ -1354,6 +1380,13 @@ public class HederaFile implements Serializable {
 		HederaTransactionResult transactionResult = new HederaTransactionResult();
 		transactionResult.setError();
 
+		// validate inputs
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
+		Utilities.throwIfAccountIDInvalid("Node", this.txQueryDefaults.node.getAccountID());
+		Utilities.throwIfNull("txQueryDefaults.payingKeyPair", this.txQueryDefaults.payingKeyPair);
+		Utilities.throwIfAccountIDInvalid("txQueryDefaults.payingKeyPair", this.txQueryDefaults.payingAccountID);
+		
 		// set transport
 		this.node = this.txQueryDefaults.node;
 
@@ -1463,6 +1496,13 @@ public class HederaFile implements Serializable {
 			this.contents = null;
 		}
 
+		// validate inputs
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
+		Utilities.throwIfAccountIDInvalid("Node", this.txQueryDefaults.node.getAccountID());
+		Utilities.throwIfNull("txQueryDefaults.payingKeyPair", this.txQueryDefaults.payingKeyPair);
+		Utilities.throwIfAccountIDInvalid("txQueryDefaults.payingKeyPair", this.txQueryDefaults.payingAccountID);
+
 		// set transport
 		this.node = this.txQueryDefaults.node;
 
@@ -1545,9 +1585,14 @@ public class HederaFile implements Serializable {
 	 */
 	public byte[] getContents() throws InterruptedException {
 		logger.trace("Start - getContents");
+		
+		// validate inputs
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
+		
 		// set transport
 		this.node = this.txQueryDefaults.node;
-
+		
 		HederaTransaction transferTransaction = new HederaTransaction(this.txQueryDefaults,
 				this.node.fileGetContentsQueryFee);
 
@@ -1591,8 +1636,13 @@ public class HederaFile implements Serializable {
 	 */
 	public boolean getInfo() throws InterruptedException {
 		logger.trace("Start - getInfo");
+		// validate inputs
+		Utilities.throwIfNull("txQueryDefaults", this.txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
+		
 		// set transport
 		this.node = this.txQueryDefaults.node;
+
 		HederaTransaction transferTransaction = new HederaTransaction(this.txQueryDefaults, this.node.fileGetInfoQueryFee);
 		logger.trace("End - getInfo");
 		return this.getInfoAnswerOnly(transferTransaction);

--- a/src/main/java/com/hedera/sdk/node/HederaNode.java
+++ b/src/main/java/com/hedera/sdk/node/HederaNode.java
@@ -1042,6 +1042,8 @@ public class HederaNode implements Serializable {
 			if (!host.equals("") && (port != 0)) {
 				// open a grpcChannel
 				grpcChannel = ManagedChannelBuilder.forAddress(this.host, this.port).usePlaintext().build();
+			} else {
+				throw new IllegalStateException("Invalid Node IP or Port");
 			}
 		}
 	}

--- a/src/main/java/com/hedera/sdk/query/HederaQueryBySolidityID.java
+++ b/src/main/java/com/hedera/sdk/query/HederaQueryBySolidityID.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import com.hedera.sdk.common.HederaAccountID;
 import com.hedera.sdk.common.HederaContractID;
 import com.hedera.sdk.common.HederaPrecheckResult;
+import com.hedera.sdk.common.Utilities;
 import com.hedera.sdk.node.HederaNode;
 import com.hedera.sdk.query.HederaQuery.QueryType;
 import com.hedera.sdk.query.HederaQueryHeader.QueryResponseType;
@@ -110,6 +111,7 @@ public class HederaQueryBySolidityID implements Serializable {
 		query.queryData = getBySolidityIDQuery.build();
 		
 		// query now set, send to network
+		Utilities.throwIfNull("Node", this.node);
 		Response response = this.node.getContractBySolidityId(query);
 
 		GetBySolidityIDResponse.Builder getBySolidityIDResponse = response.getGetBySolidityID().toBuilder();

--- a/src/main/java/com/hedera/sdk/transaction/HederaTransaction.java
+++ b/src/main/java/com/hedera/sdk/transaction/HederaTransaction.java
@@ -9,6 +9,7 @@ import com.hedera.sdk.common.HederaKeySignature;
 import com.hedera.sdk.common.HederaKeySignatureList;
 import com.hedera.sdk.common.HederaPrecheckResult;
 import com.hedera.sdk.common.HederaTransactionRecord;
+import com.hedera.sdk.common.Utilities;
 import com.hedera.sdk.node.HederaNode;
 import com.hedera.sdk.common.HederaSignature;
 import com.hedera.sdk.common.HederaSignatureList;
@@ -202,6 +203,7 @@ public class HederaTransaction implements Serializable {
 			query.queryData = getReceiptQuery.build();
 			
 			// query now set, send to network
+			Utilities.throwIfNull("Node", this.node);
 			response = this.node.getTransactionReceipt(query);
 			if (response != null &&  response.getTransactionGetReceipt() != null ) {
 				break;
@@ -249,6 +251,7 @@ public class HederaTransaction implements Serializable {
 		query.queryData = getQuery.build();
 		
 		// query now set, send to network
+		Utilities.throwIfNull("Node", this.node);
 		Response response = this.node.getTransactionRecord(query);
 		TransactionGetRecordResponse getResponse = response.getTransactionGetRecord();
 
@@ -387,6 +390,12 @@ public class HederaTransaction implements Serializable {
 		accountAmounts.add(toAccountAmount);
 		
 		HederaAccount account = new HederaAccount();
+		// validate inputs
+		Utilities.throwIfNull("txQueryDefaults", txQueryDefaults);
+		Utilities.throwIfNull("txQueryDefaults.node", txQueryDefaults.node);
+		Utilities.throwIfAccountIDInvalid("txQueryDefaults.node.getAccountID()", txQueryDefaults.node.getAccountID());
+		Utilities.throwIfNull("txQueryDefaults.payingKeyPair", txQueryDefaults.payingKeyPair);
+		
 		account.txQueryDefaults = txQueryDefaults;
 		account.setNode(txQueryDefaults.node);
 		


### PR DESCRIPTION
#9 Additional validation for node, txQueryDefaults, txQueryDefaults.node, txQueryDefaults.node.getAccountID and txQueryDefaults.payingKeyPair.

Generic utilities created to validate an accountID and check for a null object which throw IllegalStateException with an explanation message in the event validation fails.

Utilities used in HederaAccount, HederaContract, HederaFile, HederaNode, HederaQueryBySolidityID and HederaTransaction to perform the necessary validation.