### PR TITLE
Null pointer fails test HederaAccount.java

### DIFF
--- a/src/main/java/com/hedera/sdk/account/HederaAccount.java
+++ b/src/main/java/com/hedera/sdk/account/HederaAccount.java
@@ -1272,7 +1272,7 @@ public class HederaAccount implements Serializable {
 		Utilities.throwIfNull("txQueryDefaults.node", this.txQueryDefaults.node);
 		Utilities.throwIfNull("txQueryDefaults.payingKeyPair", this.txQueryDefaults.payingKeyPair);
 		Utilities.throwIfAccountIDInvalid("txQueryDefaults.payingAccountID", this.txQueryDefaults.payingAccountID);
-		Utilities.throwIfAccountIDInvalid("node.AccountID", this.node.getAccountID());
+		Utilities.throwIfAccountIDInvalid("node.AccountID",      this.node.getAccountID() == null ? this.txQueryDefaults.node.getAccountID() :this.node.getAccountID()    );
 
 		// set transport
 		this.node = this.txQueryDefaults.node;


### PR DESCRIPTION
When 
txQueryDefaults = ExampleUtilities.getTxQueryDefaults();
HederaAccount accountXferTo = new HederaAccount();
accountXferTo.setHederaAccountID(new HederaAccountID(0, 0, 1045));
AccountSend.send(a1, accountXferTo, 100);


Then null pointer test fails on send

        


