### PR TITLE
Remove redundant nextBytes call.

### DIFF
--- a/sdk/src/main/java/com/hedera/sdk/common/Utilities.java
+++ b/sdk/src/main/java/com/hedera/sdk/common/Utilities.java
@@ -62,11 +62,7 @@ public class Utilities {
 	 */
 	public static long getLongRandom() {
 
-		Random random = new SecureRandom();
-		byte[] randomInt64 = new byte[16]; // 16 bytes = 64 bits = Int64 
-		random.nextBytes(randomInt64);
-
-		return random.nextLong();
+		return new SecureRandom().nextLong();
 	}
 	/**
 	 * Helper function to generate a {@link HederaKeySignature} for a given 


### PR DESCRIPTION
At first I was wondering how 16 bytes = 64 bits, but unless my understanding of how SecureRandom.nextLong works is wrong, it isn't necessary anyway.