### PR TITLE
Fix naming inconsistencies with `set{Entity}()` vs `set{Entity}Id()`

### DIFF
--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/CreateSimpleContract.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/CreateSimpleContract.java
@@ -64,7 +64,7 @@ public final class CreateSimpleContract {
         System.out.println("new contract ID: " + newContractId);
 
         var contractCallResult = new ContractCallQuery(client).setGas(30000)
-            .setContract(newContractId)
+            .setContractId(newContractId)
             .setFunctionParameters(CallParams.function("greet"))
             .execute();
 

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/CreateStatefulContract.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/CreateStatefulContract.java
@@ -65,7 +65,7 @@ public final class CreateStatefulContract {
 
         System.out.println("new contract ID: " + newContractId);
 
-        var contractCallResult = new ContractCallQuery(client).setContract(newContractId)
+        var contractCallResult = new ContractCallQuery(client).setContractId(newContractId)
             .setFunctionParameters(CallParams.function("get_message"))
             .execute();
 
@@ -77,13 +77,13 @@ public final class CreateStatefulContract {
         var message = contractCallResult.getString();
         System.out.println("contract returned message: " + message);
 
-        new ContractExecuteTransaction(client).setContract(newContractId)
+        new ContractExecuteTransaction(client).setContractId(newContractId)
             .setFunctionParameters(CallParams.function("set_message")
                 .add("hello from hedera again!")
             )
             .execute();
 
-        var contractUpdateResult = new ContractCallQuery(client).setContract(newContractId)
+        var contractUpdateResult = new ContractCallQuery(client).setContractId(newContractId)
             .setFunctionParameters(CallParams.function("get_message"))
             .execute();
 
@@ -92,7 +92,7 @@ public final class CreateStatefulContract {
             return;
         }
 
-        var contractCallResult2 = new ContractCallQuery(client).setContract(newContractId)
+        var contractCallResult2 = new ContractCallQuery(client).setContractId(newContractId)
             .setFunctionParameters(CallParams.function("get_message"))
             .execute();
 

--- a/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -182,7 +182,7 @@ public final class Transaction extends HederaCall<com.hedera.hashgraph.sdk.proto
 
     public TransactionRecord executeForRecord() throws HederaException, HederaNetworkException {
         return executeAndWaitFor(
-            id -> new TransactionRecordQuery(getClient()).setTransaction(id)
+            id -> new TransactionRecordQuery(getClient()).setTransactionId(id)
                 .execute(),
             TransactionRecord::getReceipt
         );
@@ -200,7 +200,7 @@ public final class Transaction extends HederaCall<com.hedera.hashgraph.sdk.proto
 
     public void executeForRecordAsync(Consumer<TransactionRecord> onSuccess, Consumer<HederaThrowable> onError) {
         var handler = new AsyncRetryHandler<>(
-                (id, onSuccess_, onError_) -> new TransactionRecordQuery(getClient()).setTransaction(id)
+                (id, onSuccess_, onError_) -> new TransactionRecordQuery(getClient()).setTransactionId(id)
                     .executeAsync(onSuccess_, onError_),
                 TransactionRecord::getReceipt, onSuccess, onError
         );

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionRecordQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionRecordQuery.java
@@ -19,7 +19,7 @@ public class TransactionRecordQuery extends QueryBuilder<TransactionRecord> {
         return builder.getHeaderBuilder();
     }
 
-    public TransactionRecordQuery setTransaction(TransactionId transaction) {
+    public TransactionRecordQuery setTransactionId(TransactionId transaction) {
         builder.setTransactionID(transaction.toProto());
         return this;
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountClaimQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountClaimQuery.java
@@ -25,7 +25,7 @@ public final class AccountClaimQuery extends QueryBuilder<CryptoGetClaimResponse
         return builder.getHeaderBuilder();
     }
 
-    public AccountClaimQuery setAccount(AccountId account) {
+    public AccountClaimQuery setAccountId(AccountId account) {
         builder.setAccountID(account.toProto());
         return this;
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountRecordsQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountRecordsQuery.java
@@ -17,7 +17,7 @@ public class AccountRecordsQuery extends QueryBuilder<CryptoGetAccountRecordsRes
         super(null);
     }
 
-    public AccountRecordsQuery setAccount(AccountId accountId) {
+    public AccountRecordsQuery setAccountId(AccountId accountId) {
         builder.setAccountID(accountId.toProto());
         return this;
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountStakersQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountStakersQuery.java
@@ -17,7 +17,7 @@ public class AccountStakersQuery extends QueryBuilder<CryptoGetStakersResponse> 
         super(null);
     }
 
-    public AccountStakersQuery setAccount(AccountId accountId) {
+    public AccountStakersQuery setAccountId(AccountId accountId) {
         builder.setAccountID(accountId.toProto());
         return this;
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractBytecodeQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractBytecodeQuery.java
@@ -22,14 +22,14 @@ public final class ContractBytecodeQuery extends QueryBuilder<ContractGetBytecod
         return builder.getHeaderBuilder();
     }
 
-    public ContractBytecodeQuery setContract(ContractId contract) {
+    public ContractBytecodeQuery setContractId(ContractId contract) {
         builder.setContractID(contract.toProto());
         return this;
     }
 
     @Override
     protected void doValidate() {
-        require(builder.hasContractID(), ".setContract() required");
+        require(builder.hasContractID(), ".setContractId() required");
     }
 
     @Override

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCallQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCallQuery.java
@@ -43,7 +43,7 @@ public class ContractCallQuery extends QueryBuilder<FunctionResult> {
         );
     }
 
-    public ContractCallQuery setContract(ContractId id) {
+    public ContractCallQuery setContractId(ContractId id) {
         builder.setContractID(id.toProto());
         return this;
     }
@@ -70,6 +70,6 @@ public class ContractCallQuery extends QueryBuilder<FunctionResult> {
 
     @Override
     protected void doValidate() {
-        require(builder.hasContractID(), ".setContract() required");
+        require(builder.hasContractID(), ".setContractId() required");
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractExecuteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractExecuteTransaction.java
@@ -23,7 +23,7 @@ public final class ContractExecuteTransaction extends TransactionBuilder<Contrac
         super(null);
     }
 
-    public ContractExecuteTransaction setContract(ContractId contractId) {
+    public ContractExecuteTransaction setContractId(ContractId contractId) {
         builder.setContractID(contractId.toProto());
         return this;
     }
@@ -55,6 +55,6 @@ public final class ContractExecuteTransaction extends TransactionBuilder<Contrac
 
     @Override
     protected void doValidate() {
-        require(builder.hasContractID(), ".setContract() required");
+        require(builder.hasContractID(), ".setContractId() required");
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractInfoQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractInfoQuery.java
@@ -22,7 +22,7 @@ public final class ContractInfoQuery extends QueryBuilder<ContractInfo> {
         return builder.getHeaderBuilder();
     }
 
-    public ContractInfoQuery setContract(ContractId contract) {
+    public ContractInfoQuery setContractId(ContractId contract) {
         builder.setContractID(contract.toProto());
         return this;
     }
@@ -39,6 +39,6 @@ public final class ContractInfoQuery extends QueryBuilder<ContractInfo> {
 
     @Override
     protected void doValidate() {
-        require(builder.hasContractID(), ".setContract() required");
+        require(builder.hasContractID(), ".setContractId() required");
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractRecordsQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractRecordsQuery.java
@@ -17,7 +17,7 @@ public class ContractRecordsQuery extends QueryBuilder<ContractGetRecordsRespons
         super(null);
     }
 
-    public ContractRecordsQuery setContract(ContractId contractId) {
+    public ContractRecordsQuery setContractId(ContractId contractId) {
         builder.setContractID(contractId.toProto());
         return this;
     }
@@ -39,6 +39,6 @@ public class ContractRecordsQuery extends QueryBuilder<ContractGetRecordsRespons
 
     @Override
     protected void doValidate() {
-        require(builder.hasContractID(), ".setContract() required");
+        require(builder.hasContractID(), ".setContractId() required");
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractUpdateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractUpdateTransaction.java
@@ -26,7 +26,7 @@ public class ContractUpdateTransaction extends TransactionBuilder<ContractUpdate
         super(null);
     }
 
-    public ContractUpdateTransaction setContract(ContractId contract) {
+    public ContractUpdateTransaction setContractId(ContractId contract) {
         builder.setContractID(contract.toProto());
         return this;
     }
@@ -64,6 +64,6 @@ public class ContractUpdateTransaction extends TransactionBuilder<ContractUpdate
 
     @Override
     protected void doValidate() {
-        require(builder.hasContractID(), ".setContract() required");
+        require(builder.hasContractID(), ".setContractId() required");
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractUpdateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractUpdateTransaction.java
@@ -52,7 +52,7 @@ public class ContractUpdateTransaction extends TransactionBuilder<ContractUpdate
         return this;
     }
 
-    public ContractUpdateTransaction setFile(FileId file) {
+    public ContractUpdateTransaction setFileId(FileId file) {
         builder.setFileID(file.toProto());
         return this;
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileUpdateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileUpdateTransaction.java
@@ -22,7 +22,7 @@ public class FileUpdateTransaction extends TransactionBuilder<FileUpdateTransact
         super(null);
     }
 
-    public FileUpdateTransaction setFile(FileId file) {
+    public FileUpdateTransaction setFileId(FileId file) {
         builder.setFileID(file.toProto());
 
         return this;

--- a/src/test/groovy/com/hedera/hashgraph/sdk/contract/ContractExecuteTransactionTest.groovy
+++ b/src/test/groovy/com/hedera/hashgraph/sdk/contract/ContractExecuteTransactionTest.groovy
@@ -18,7 +18,7 @@ class ContractExecuteTransactionTest extends Specification {
 transaction builder failed validation:
 .setTransactionId() required
 .setNodeAccountId() required
-.setContract() required"""
+.setContractId() required"""
 	}
 
 	def "Transaction can be built"() {

--- a/src/test/groovy/com/hedera/hashgraph/sdk/contract/ContractUpdateTransactionTest.groovy
+++ b/src/test/groovy/com/hedera/hashgraph/sdk/contract/ContractUpdateTransactionTest.groovy
@@ -20,7 +20,7 @@ class ContractUpdateTransactionTest extends Specification {
 transaction builder failed validation:
 .setTransactionId() required
 .setNodeAccountId() required
-.setContract() required"""
+.setContractId() required"""
 	}
 
 	// FIXME: Can't set adminKey


### PR DESCRIPTION
closes #97 

cc @mehcode @bchevallereau