### PR TITLE
enables generation of a transaction protobuf that hasnt been signed

### DIFF
--- a/src/main/java/com/hedera/hashgraph/sdk/SystemDeleteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/SystemDeleteTransaction.java
@@ -9,17 +9,14 @@ import com.hederahashgraph.api.proto.java.SystemDeleteTransactionBody;
 
 import io.grpc.MethodDescriptor;
 
+import javax.annotation.Nullable;
 import java.time.Instant;
 
 public final class SystemDeleteTransaction extends TransactionBuilder<SystemDeleteTransaction> {
     private final SystemDeleteTransactionBody.Builder builder = bodyBuilder.getSystemDeleteBuilder();
 
-    public SystemDeleteTransaction(Client client) {
+    public SystemDeleteTransaction(@Nullable Client client) {
         super(client);
-    }
-
-    SystemDeleteTransaction() {
-        super(null);
     }
 
     public SystemDeleteTransaction setID(FileId fileId) {

--- a/src/main/java/com/hedera/hashgraph/sdk/SystemUndeleteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/SystemUndeleteTransaction.java
@@ -9,19 +9,17 @@ import com.hederahashgraph.api.proto.java.SystemUndeleteTransactionBody;
 
 import io.grpc.MethodDescriptor;
 
+import javax.annotation.Nullable;
+
 public final class SystemUndeleteTransaction extends TransactionBuilder<SystemUndeleteTransaction> {
 
     private final SystemUndeleteTransactionBody.Builder builder = bodyBuilder.getSystemUndeleteBuilder();
 
-    public SystemUndeleteTransaction(Client client) {
+    public SystemUndeleteTransaction(@Nullable Client client) {
         super(client);
     }
 
-    SystemUndeleteTransaction() {
-        super(null);
-    }
-
-    public SystemUndeleteTransaction setID(FileId fileId) {
+    public AdminUndeleteTransaction setID(FileId fileId) {
         builder.setFileID(fileId.toProto());
         return this;
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/SystemUndeleteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/SystemUndeleteTransaction.java
@@ -19,7 +19,7 @@ public final class SystemUndeleteTransaction extends TransactionBuilder<SystemUn
         super(client);
     }
 
-    public AdminUndeleteTransaction setID(FileId fileId) {
+    public SystemUndeleteTransaction setID(FileId fileId) {
         builder.setFileID(fileId.toProto());
         return this;
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -152,7 +152,7 @@ public final class Transaction extends HederaCall<com.hedera.hashgraph.sdk.proto
     }
 
     protected void validate(boolean requireSignature) {
-        if(requireSignature) {
+        if (requireSignature) {
             validate();
             return;
         }

--- a/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -107,8 +107,8 @@ public final class Transaction extends HederaCall<com.hedera.hashgraph.sdk.proto
         return inner.build();
     }
 
-    public com.hedera.hashgraph.sdk.proto.Transaction toUnsignedProto() {
-        validateUnsigned();
+    public com.hedera.hashgraph.sdk.proto.Transaction toProto(boolean requireSignature) {
+        validate(requireSignature);
         return inner.build();
     }
 
@@ -151,7 +151,12 @@ public final class Transaction extends HederaCall<com.hedera.hashgraph.sdk.proto
         checkValidationErrors("Transaction failed validation");
     }
 
-    protected void validateUnsigned() {
+    protected void validate(boolean requireSignature) {
+        if(requireSignature) {
+            validate();
+            return;
+        }
+
         checkValidationErrors("Transaction failed validation");
     }
 
@@ -238,8 +243,8 @@ public final class Transaction extends HederaCall<com.hedera.hashgraph.sdk.proto
         return toProto().toByteArray();
     }
 
-    public byte[] toBytesUnsigned() {
-        return toUnsignedProto().toByteArray();
+    public byte[] toBytes(boolean requiresSignature) {
+        return toProto(requiresSignature).toByteArray();
     }
 
     private Client getClient() {

--- a/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -107,6 +107,11 @@ public final class Transaction extends HederaCall<com.hedera.hashgraph.sdk.proto
         return inner.build();
     }
 
+    public com.hedera.hashgraph.sdk.proto.Transaction toUnsignedProto() {
+        validateUnsigned();
+        return inner.build();
+    }
+
     @Override
     protected MethodDescriptor<com.hedera.hashgraph.sdk.proto.Transaction, TransactionResponse> getMethod() {
         return methodDescriptor;
@@ -143,6 +148,10 @@ public final class Transaction extends HederaCall<com.hedera.hashgraph.sdk.proto
             }
         }
 
+        checkValidationErrors("Transaction failed validation");
+    }
+
+    protected void validateUnsigned() {
         checkValidationErrors("Transaction failed validation");
     }
 
@@ -227,6 +236,10 @@ public final class Transaction extends HederaCall<com.hedera.hashgraph.sdk.proto
 
     public byte[] toBytes() {
         return toProto().toByteArray();
+    }
+
+    public byte[] toBytesUnsigned() {
+        return toUnsignedProto().toByteArray();
     }
 
     private Client getClient() {

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
@@ -95,8 +95,8 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
         return build().toProto();
     }
 
-    public final com.hedera.hashgraph.sdk.proto.Transaction toUnsignedProto() {
-        return build().toUnsignedProto();
+    public final com.hedera.hashgraph.sdk.proto.Transaction toProto(boolean requireSignature) {
+        return build().toProto(requireSignature);
     }
 
     @Override
@@ -148,8 +148,8 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
         return build().toBytes();
     }
 
-    public final byte[] toBytesUnsigned() {
-        return build().toBytesUnsigned();
+    public final byte[] toBytes(boolean requiresSignature) {
+        return build().toBytes(requiresSignature);
     }
 
     // Work around for java not recognized that this is completely safe

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
@@ -95,6 +95,10 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
         return build().toProto();
     }
 
+    public final com.hedera.hashgraph.sdk.proto.Transaction toUnsignedProto() {
+        return build().toUnsignedProto();
+    }
+
     @Override
     protected void validate() {
         var bodyBuilder = this.bodyBuilder;
@@ -142,6 +146,10 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
 
     public final byte[] toBytes() {
         return build().toBytes();
+    }
+
+    public final byte[] toBytesUnsigned() {
+        return build().toBytesUnsigned();
     }
 
     // Work around for java not recognized that this is completely safe

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountAddClaimTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountAddClaimTransaction.java
@@ -18,7 +18,7 @@ public final class AccountAddClaimTransaction extends TransactionBuilder<Account
         super(client);
     }
 
-    AccountAddClaimTransaction() {
+    public AccountAddClaimTransaction() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountAddClaimTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountAddClaimTransaction.java
@@ -8,18 +8,16 @@ import com.hedera.hashgraph.sdk.proto.Claim;
 import com.hedera.hashgraph.sdk.proto.*;
 import io.grpc.MethodDescriptor;
 
+import javax.annotation.Nullable;
+
 // corresponds to `CryptoAddClaimTransaction`
 public final class AccountAddClaimTransaction extends TransactionBuilder<AccountAddClaimTransaction> {
     private final CryptoAddClaimTransactionBody.Builder builder = bodyBuilder.getCryptoAddClaimBuilder();
     private final Claim.Builder claim = builder.getClaimBuilder();
     private final KeyList.Builder keyList = claim.getKeysBuilder();
 
-    public AccountAddClaimTransaction(Client client) {
+    public AccountAddClaimTransaction(@Nullable Client client) {
         super(client);
-    }
-
-    public AccountAddClaimTransaction() {
-        super(null);
     }
 
     public AccountAddClaimTransaction setAccountId(AccountId id) {

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountBalanceQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountBalanceQuery.java
@@ -5,15 +5,13 @@ import com.hedera.hashgraph.sdk.QueryBuilder;
 import com.hedera.hashgraph.sdk.proto.*;
 import io.grpc.MethodDescriptor;
 
+import javax.annotation.Nullable;
+
 // `CryptoGetAccountBalanceQuery`
 public final class AccountBalanceQuery extends QueryBuilder<Long, AccountBalanceQuery> {
     private final CryptoGetAccountBalanceQuery.Builder builder = inner.getCryptogetAccountBalanceBuilder();
 
-    public AccountBalanceQuery() {
-        super(null);
-    }
-
-    public AccountBalanceQuery(Client client) {
+    public AccountBalanceQuery(@Nullable Client client) {
         super(client);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountBalanceQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountBalanceQuery.java
@@ -9,7 +9,7 @@ import io.grpc.MethodDescriptor;
 public final class AccountBalanceQuery extends QueryBuilder<Long, AccountBalanceQuery> {
     private final CryptoGetAccountBalanceQuery.Builder builder = inner.getCryptogetAccountBalanceBuilder();
 
-    AccountBalanceQuery() {
+    public AccountBalanceQuery() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountClaimQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountClaimQuery.java
@@ -15,7 +15,7 @@ public final class AccountClaimQuery extends QueryBuilder<CryptoGetClaimResponse
         builder = inner.getCryptoGetClaimBuilder();
     }
 
-    AccountClaimQuery() {
+    public AccountClaimQuery() {
         super(null);
         builder = inner.getCryptoGetClaimBuilder();
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountCreateTransaction.java
@@ -8,6 +8,7 @@ import com.hedera.hashgraph.sdk.crypto.Key;
 import com.hedera.hashgraph.sdk.proto.*;
 import io.grpc.MethodDescriptor;
 
+import javax.annotation.Nullable;
 import java.time.Duration;
 
 // Corresponds to `CryptoCreateTransaction`
@@ -21,12 +22,8 @@ public final class AccountCreateTransaction extends TransactionBuilder<AccountCr
         .setSendRecordThreshold(Long.MAX_VALUE)
         .setReceiveRecordThreshold(Long.MAX_VALUE);
 
-    public AccountCreateTransaction(Client client) {
+    public AccountCreateTransaction(@Nullable Client client) {
         super(client);
-    }
-
-    public AccountCreateTransaction() {
-        super(null);
     }
 
     @Override

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountCreateTransaction.java
@@ -25,7 +25,7 @@ public final class AccountCreateTransaction extends TransactionBuilder<AccountCr
         super(client);
     }
 
-    AccountCreateTransaction() {
+    public AccountCreateTransaction() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountDeleteClaimTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountDeleteClaimTransaction.java
@@ -9,16 +9,14 @@ import com.hedera.hashgraph.sdk.proto.Transaction;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
 import io.grpc.MethodDescriptor;
 
+import javax.annotation.Nullable;
+
 // `CryptoDeleteClaimTransaction`
 public class AccountDeleteClaimTransaction extends TransactionBuilder<AccountDeleteClaimTransaction> {
     private final CryptoDeleteClaimTransactionBody.Builder builder = bodyBuilder.getCryptoDeleteClaimBuilder();
 
-    public AccountDeleteClaimTransaction(Client client) {
+    public AccountDeleteClaimTransaction(@Nullable Client client) {
         super(client);
-    }
-
-    public AccountDeleteClaimTransaction() {
-        super(null);
     }
 
     public AccountDeleteClaimTransaction setAccountToDeleteFrom(AccountId accountId) {

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountDeleteClaimTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountDeleteClaimTransaction.java
@@ -17,7 +17,7 @@ public class AccountDeleteClaimTransaction extends TransactionBuilder<AccountDel
         super(client);
     }
 
-    AccountDeleteClaimTransaction() {
+    public AccountDeleteClaimTransaction() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountDeleteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountDeleteTransaction.java
@@ -8,16 +8,14 @@ import com.hedera.hashgraph.sdk.proto.Transaction;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
 import io.grpc.MethodDescriptor;
 
+import javax.annotation.Nullable;
+
 // `CryptoDeleteTransaction`
 public class AccountDeleteTransaction extends TransactionBuilder<AccountDeleteTransaction> {
     private final CryptoDeleteTransactionBody.Builder builder = bodyBuilder.getCryptoDeleteBuilder();
 
-    public AccountDeleteTransaction(Client client) {
+    public AccountDeleteTransaction(@Nullable Client client) {
         super(client);
-    }
-
-    public AccountDeleteTransaction() {
-        super(null);
     }
 
     public AccountDeleteTransaction setTransferAccountId(AccountId transferAccountId) {

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountDeleteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountDeleteTransaction.java
@@ -16,7 +16,7 @@ public class AccountDeleteTransaction extends TransactionBuilder<AccountDeleteTr
         super(client);
     }
 
-    AccountDeleteTransaction() {
+    public AccountDeleteTransaction() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountUpdateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountUpdateTransaction.java
@@ -11,6 +11,7 @@ import com.hedera.hashgraph.sdk.proto.Transaction;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
 import io.grpc.MethodDescriptor;
 
+import javax.annotation.Nullable;
 import java.time.Duration;
 import java.time.Instant;
 
@@ -18,12 +19,8 @@ import java.time.Instant;
 public final class AccountUpdateTransaction extends TransactionBuilder<AccountUpdateTransaction> {
     private final CryptoUpdateTransactionBody.Builder builder = bodyBuilder.getCryptoUpdateAccountBuilder();
 
-    public AccountUpdateTransaction(Client client) {
+    public AccountUpdateTransaction(@Nullable Client client) {
         super(client);
-    }
-
-    public AccountUpdateTransaction() {
-        super(null);
     }
 
     public AccountUpdateTransaction setAccountForUpdate(AccountId accountId) {

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountUpdateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountUpdateTransaction.java
@@ -22,7 +22,7 @@ public final class AccountUpdateTransaction extends TransactionBuilder<AccountUp
         super(client);
     }
 
-    AccountUpdateTransaction() {
+    public AccountUpdateTransaction() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/account/CryptoTransferTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/CryptoTransferTransaction.java
@@ -15,7 +15,7 @@ public final class CryptoTransferTransaction extends TransactionBuilder<CryptoTr
         super(client);
     }
 
-    CryptoTransferTransaction() {
+    public CryptoTransferTransaction() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/account/CryptoTransferTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/CryptoTransferTransaction.java
@@ -6,17 +6,14 @@ import com.hedera.hashgraph.sdk.proto.*;
 import io.grpc.MethodDescriptor;
 
 import javax.annotation.Nonnegative;
+import javax.annotation.Nullable;
 
 public final class CryptoTransferTransaction extends TransactionBuilder<CryptoTransferTransaction> {
     private final CryptoTransferTransactionBody.Builder builder = bodyBuilder.getCryptoTransferBuilder();
     private final TransferList.Builder transferList = builder.getTransfersBuilder();
 
-    public CryptoTransferTransaction(Client client) {
+    public CryptoTransferTransaction(@Nullable Client client) {
         super(client);
-    }
-
-    public CryptoTransferTransaction() {
-        super(null);
     }
 
     public CryptoTransferTransaction addSender(AccountId senderId, @Nonnegative long value) {

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCreateTransaction.java
@@ -18,7 +18,7 @@ public class ContractCreateTransaction extends TransactionBuilder<ContractCreate
         super(client);
     }
 
-    ContractCreateTransaction() {
+    public ContractCreateTransaction() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCreateTransaction.java
@@ -11,15 +11,13 @@ import com.hedera.hashgraph.sdk.file.FileId;
 import com.hedera.hashgraph.sdk.proto.*;
 import io.grpc.MethodDescriptor;
 
+import javax.annotation.Nullable;
+
 public class ContractCreateTransaction extends TransactionBuilder<ContractCreateTransaction> {
     private final ContractCreateTransactionBody.Builder builder = bodyBuilder.getContractCreateInstanceBuilder();
 
-    public ContractCreateTransaction(Client client) {
+    public ContractCreateTransaction(@Nullable Client client) {
         super(client);
-    }
-
-    public ContractCreateTransaction() {
-        super(null);
     }
 
     @Override

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractExecuteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractExecuteTransaction.java
@@ -10,17 +10,15 @@ import com.hedera.hashgraph.sdk.proto.Transaction;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
 import io.grpc.MethodDescriptor;
 
+import javax.annotation.Nullable;
+
 /** Call a function in the contract, updating its internal state in the hashgraph. */
 // `ContractCallTransaction`
 public final class ContractExecuteTransaction extends TransactionBuilder<ContractExecuteTransaction> {
     private final ContractCallTransactionBody.Builder builder = bodyBuilder.getContractCallBuilder();
 
-    public ContractExecuteTransaction(Client client) {
+    public ContractExecuteTransaction(@Nullable Client client) {
         super(client);
-    }
-
-    public ContractExecuteTransaction() {
-        super(null);
     }
 
     public ContractExecuteTransaction setContractId(ContractId contractId) {

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractExecuteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractExecuteTransaction.java
@@ -19,7 +19,7 @@ public final class ContractExecuteTransaction extends TransactionBuilder<Contrac
         super(client);
     }
 
-    ContractExecuteTransaction() {
+    public ContractExecuteTransaction() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractUpdateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractUpdateTransaction.java
@@ -22,7 +22,7 @@ public class ContractUpdateTransaction extends TransactionBuilder<ContractUpdate
         super(client);
     }
 
-    ContractUpdateTransaction() {
+    public ContractUpdateTransaction() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractUpdateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractUpdateTransaction.java
@@ -12,18 +12,16 @@ import com.hedera.hashgraph.sdk.proto.SmartContractServiceGrpc;
 import com.hedera.hashgraph.sdk.proto.Transaction;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
 import io.grpc.MethodDescriptor;
+
+import javax.annotation.Nullable;
 import java.time.Duration;
 import java.time.Instant;
 
 public class ContractUpdateTransaction extends TransactionBuilder<ContractUpdateTransaction> {
     private final ContractUpdateTransactionBody.Builder builder = bodyBuilder.getContractUpdateInstanceBuilder();
 
-    public ContractUpdateTransaction(Client client) {
+    public ContractUpdateTransaction(@Nullable Client client) {
         super(client);
-    }
-
-    public ContractUpdateTransaction() {
-        super(null);
     }
 
     public ContractUpdateTransaction setContractId(ContractId contract) {

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileAppendTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileAppendTransaction.java
@@ -9,15 +9,13 @@ import com.hedera.hashgraph.sdk.proto.Transaction;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
 import io.grpc.MethodDescriptor;
 
+import javax.annotation.Nullable;
+
 public final class FileAppendTransaction extends TransactionBuilder<FileAppendTransaction> {
     private final FileAppendTransactionBody.Builder builder = bodyBuilder.getFileAppendBuilder();
 
-    public FileAppendTransaction(Client client) {
+    public FileAppendTransaction(@Nullable Client client) {
         super(client);
-    }
-
-    FileAppendTransaction() {
-        super(null);
     }
 
     public FileAppendTransaction setFileId(FileId fileId) {

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileCreateTransaction.java
@@ -8,18 +8,15 @@ import com.hedera.hashgraph.sdk.crypto.Key;
 import com.hedera.hashgraph.sdk.proto.*;
 import io.grpc.MethodDescriptor;
 
+import javax.annotation.Nullable;
 import java.time.Instant;
 
 public final class FileCreateTransaction extends TransactionBuilder<FileCreateTransaction> {
     private final FileCreateTransactionBody.Builder builder = bodyBuilder.getFileCreateBuilder();
     private final KeyList.Builder keyList = builder.getKeysBuilder();
 
-    public FileCreateTransaction(Client client) {
+    public FileCreateTransaction(@Nullable Client client) {
         super(client);
-    }
-
-    FileCreateTransaction() {
-        super(null);
     }
 
     public FileCreateTransaction setExpirationTime(Instant expiration) {

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileDeleteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileDeleteTransaction.java
@@ -8,15 +8,13 @@ import com.hedera.hashgraph.sdk.proto.Transaction;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
 import io.grpc.MethodDescriptor;
 
+import javax.annotation.Nullable;
+
 public final class FileDeleteTransaction extends TransactionBuilder<FileDeleteTransaction> {
     private final FileDeleteTransactionBody.Builder builder = bodyBuilder.getFileDeleteBuilder();
 
-    public FileDeleteTransaction(Client client) {
+    public FileDeleteTransaction(@Nullable Client client) {
         super(client);
-    }
-
-    FileDeleteTransaction() {
-        super(null);
     }
 
     public FileDeleteTransaction setFileId(FileId fileId) {

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileUpdateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileUpdateTransaction.java
@@ -8,18 +8,15 @@ import com.hedera.hashgraph.sdk.crypto.Key;
 import com.hedera.hashgraph.sdk.proto.*;
 import io.grpc.MethodDescriptor;
 
+import javax.annotation.Nullable;
 import java.time.Instant;
 
 public class FileUpdateTransaction extends TransactionBuilder<FileUpdateTransaction> {
     private final FileUpdateTransactionBody.Builder builder = bodyBuilder.getFileUpdateBuilder();
     private final KeyList.Builder keyList = builder.getKeysBuilder();
 
-    public FileUpdateTransaction(Client client) {
+    public FileUpdateTransaction(@Nullable Client client) {
         super(client);
-    }
-
-    FileUpdateTransaction() {
-        super(null);
     }
 
     public FileUpdateTransaction setFileId(FileId file) {


### PR DESCRIPTION
closes #101 

This introduces the ability to generate unsigned protobufs and byte arrays through the use of `unsigned` variants of `Validate`, `toProto`, and `toBytes`