### PR TITLE
Mitigate duplicate transaction errors when calling `Transaction.executeForRecordAsync()`

### DIFF
--- a/src/main/java/com/hedera/hashgraph/sdk/HederaCall.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/HederaCall.java
@@ -143,6 +143,7 @@ public abstract class HederaCall<Req, RawResp, Resp> {
 
         @Override
         public void onCompleted() {
+            // we don't care about this callback
         }
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/HederaCall.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/HederaCall.java
@@ -1,6 +1,13 @@
 package com.hedera.hashgraph.sdk;
 
 import com.google.protobuf.ByteString;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -8,13 +15,11 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ClientCalls;
 import io.grpc.stub.StreamObserver;
 
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
-
 public abstract class HederaCall<Req, RawResp, Resp> {
-    private @Nullable List<String> validationErrors;
+    private @Nullable
+    List<String> validationErrors;
+
+    private boolean isExecuted = false;
 
     protected abstract io.grpc.MethodDescriptor<Req, RawResp> getMethod();
 
@@ -29,39 +34,22 @@ public abstract class HederaCall<Req, RawResp, Resp> {
     }
 
     public final Resp execute() throws HederaException, HederaNetworkException {
+        if (isExecuted) {
+            throw new IllegalStateException("call already executed");
+        }
+        isExecuted = true;
+
         return mapResponse(ClientCalls.blockingUnaryCall(newClientCall(), toProto()));
     }
 
     public final void executeAsync(Consumer<Resp> onSuccess, Consumer<HederaThrowable> onError) {
-        ClientCalls.asyncUnaryCall(newClientCall(), toProto(), new StreamObserver<>() {
-            @Override
-            public void onNext(RawResp value) {
-                try {
-                    var response = mapResponse(value);
-                    onSuccess.accept(response);
-                } catch (HederaException e) {
-                    onError.accept(e);
-                }
-            }
+        if (isExecuted) {
+            throw new IllegalStateException("call already executed");
+        }
+        isExecuted = true;
 
-            @Override
-            public void onError(Throwable t) {
-                HederaThrowable exception;
-
-                if (t instanceof StatusRuntimeException) {
-                    exception = new HederaNetworkException((StatusRuntimeException) t);
-                } else if (t instanceof HederaThrowable) {
-                    exception = (HederaThrowable) t;
-                } else {
-                    throw new RuntimeException("unhandled exception type", t);
-                }
-
-                onError.accept(exception);
-            }
-
-            @Override
-            public void onCompleted() { }
-        });
+        ClientCalls.asyncUnaryCall(newClientCall(), toProto(),
+            new CallStreamObserver(onSuccess, onError));
     }
 
     protected abstract void validate();
@@ -111,5 +99,50 @@ public abstract class HederaCall<Req, RawResp, Resp> {
 
     protected void require(@Nullable String setValue, String errMsg) {
         require(setValue != null && setValue.isEmpty(), errMsg);
+    }
+
+    private final class CallStreamObserver implements StreamObserver<RawResp> {
+
+        private final Consumer<Resp> onSuccess;
+        private final Consumer<HederaThrowable> onError;
+
+        private volatile boolean onNextCalled = false;
+
+        private CallStreamObserver(Consumer<Resp> onSuccess, Consumer<HederaThrowable> onError) {
+            this.onSuccess = onSuccess;
+            this.onError = onError;
+        }
+
+        @Override
+        public void onNext(RawResp value) {
+            if (onNextCalled) return;
+            onNextCalled = true;
+
+            try {
+                var response = mapResponse(value);
+                onSuccess.accept(response);
+            } catch (HederaException e) {
+                onError.accept(e);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            HederaThrowable exception;
+
+            if (t instanceof StatusRuntimeException) {
+                exception = new HederaNetworkException((StatusRuntimeException) t);
+            } else if (t instanceof HederaThrowable) {
+                exception = (HederaThrowable) t;
+            } else {
+                throw new RuntimeException("unhandled exception type", t);
+            }
+
+            onError.accept(exception);
+        }
+
+        @Override
+        public void onCompleted() {
+        }
     }
 }


### PR DESCRIPTION
cc @mehcode @mike-burrage-hedera

closes #130 