### PR TITLE
FunctionResult: implement more result getters

### DIFF
--- a/src/test/java/com/hedera/hashgraph/sdk/FunctionResultTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/FunctionResultTest.java
@@ -7,18 +7,24 @@ import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FunctionResultTest {
 
-    private static final String callResultHex = "" +
-        "00000000000000000000000000000000000000000000000000000000ffffffff" +
-        "0000000000000000000000000000000000000000000000000000000000000060" +
-        "00000000000000000000000000000000000000000000000000000000000000a0" +
-        "000000000000000000000000000000000000000000000000000000000000000d" +
-        "48656c6c6f2c20776f726c642100000000000000000000000000000000000000" +
-        "0000000000000000000000000000000000000000000000000000000000000014" +
-        "48656c6c6f2c20776f726c642c20616761696e21000000000000000000000000";
+    private static final String callResultHex = ""
+        + "00000000000000000000000000000000000000000000000000000000ffffffff"
+        + "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        + "00000000000000000000000011223344556677889900aabbccddeeff00112233"
+        + "00000000000000000000000000000000000000000000000000000000000000a0"
+        + "00000000000000000000000000000000000000000000000000000000000000e0"
+        + "000000000000000000000000000000000000000000000000000000000000000d"
+        + "48656c6c6f2c20776f726c642100000000000000000000000000000000000000"
+        + "0000000000000000000000000000000000000000000000000000000000000014"
+        + "48656c6c6f2c20776f726c642c20616761696e21000000000000000000000000";
 
     private static final byte[] callResult = Hex.decode(callResultHex);
 
@@ -30,8 +36,18 @@ class FunctionResultTest {
                 .setContractCallResult(ByteString.copyFrom(callResult))
         );
 
-        assertEquals(result.getInt(0), -1);
-        assertEquals(result.getString(1), "Hello, world!");
-        assertEquals(result.getString(2), "Hello, world, again!");
+        // interpretation varies based on width
+        assertTrue(result.getBool(0));
+        assertEquals(-1, result.getInt(0));
+        assertEquals((1L << 32) - 1, result.getLong(0));
+        assertEquals(BigInteger.ONE.shiftLeft(32).subtract(BigInteger.ONE), result.getBigInt(0));
+
+        assertEquals(BigInteger.ONE.shiftLeft(255).subtract(BigInteger.ONE), result.getBigInt(1));
+
+        assertArrayEquals(Hex.decode("11223344556677889900aabbccddeeff00112233"),
+            result.getAddress(2).toByteArray());
+
+        assertEquals("Hello, world!", result.getString(3));
+        assertEquals("Hello, world, again!", result.getString(4));
     }
 }


### PR DESCRIPTION
closes #150

@gregscullard I added the following, are there any important ones that we're missing?

* `getBool()`
* `getBytes()`
* `getLong()`
* `getBigInt()`
* `getAddress()`
* `getRawValue()` (returning a 32-byte string)

I'm on the fence about returning `ByteString` in these APIs; converting to a byte array unfortunately requires a copy. It is possible to return a `java.nio.ByteBuffer` but reading from that also requires copying.

I'm also on the fence about keeping the overloaded `get*()` methods which return the 0th value interpreted as that type; I'm not sure how much convenience they add over doing `get[Bool, etc.](0)`.

cc @mehcode 