### PR TITLE
Added IdUtils and fromString methods

### DIFF
--- a/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
@@ -11,6 +11,7 @@ public final class IdUtil {
     public interface WithIdNums<R> {
         R apply(long shardNum, long realmNum, long entityNum);
     }
+
     public static <R> R parseIdString(String id, WithIdNums<R> withIdNums) {
         var rawNums = Splitter.on('.')
             .split(id)

--- a/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
@@ -14,6 +14,4 @@ public final class IdUtil {
             Long.parseLong(rawNums.next())
         };
     }
-
-
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
@@ -12,7 +12,7 @@ public final class IdUtil {
             .split(id)
             .iterator();
 
-        return new long[]{
+        return new long[] {
             Long.parseLong(rawNums.next()),
             Long.parseLong(rawNums.next()),
             Long.parseLong(rawNums.next())

--- a/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
@@ -1,0 +1,19 @@
+package com.hedera.hashgraph.sdk;
+
+import com.google.common.base.Splitter;
+
+public final class IdUtil {
+    public static long[] parseIdString(String id) {
+        var rawNums = Splitter.on('.')
+            .split(id)
+            .iterator();
+
+       return new long[] {
+            Long.parseLong(rawNums.next()),
+            Long.parseLong(rawNums.next()),
+            Long.parseLong(rawNums.next())
+        };
+    }
+
+
+}

--- a/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
@@ -4,14 +4,15 @@ import com.google.common.base.Splitter;
 
 public final class IdUtil {
 
-    private IdUtil() {  }
+    private IdUtil() {
+    }
 
     public static long[] parseIdString(String id) {
         var rawNums = Splitter.on('.')
             .split(id)
             .iterator();
 
-        return new long[] {
+        return new long[]{
             Long.parseLong(rawNums.next()),
             Long.parseLong(rawNums.next()),
             Long.parseLong(rawNums.next())

--- a/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
@@ -12,7 +12,7 @@ public final class IdUtil {
             .split(id)
             .iterator();
 
-        return new long[] {
+        return new long[]{
             Long.parseLong(rawNums.next()),
             Long.parseLong(rawNums.next()),
             Long.parseLong(rawNums.next())

--- a/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
@@ -12,10 +12,6 @@ public final class IdUtil {
             .split(id)
             .iterator();
 
-        return new long[]{
-            Long.parseLong(rawNums.next()),
-            Long.parseLong(rawNums.next()),
-            Long.parseLong(rawNums.next())
-        };
+        return new long[]{Long.parseLong(rawNums.next()), Long.parseLong(rawNums.next()), Long.parseLong(rawNums.next())};
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
@@ -7,11 +7,6 @@ public final class IdUtil {
     private IdUtil() {
     }
 
-    @FunctionalInterface
-    public interface WithIdNums<R> {
-        R apply(long shardNum, long realmNum, long entityNum);
-    }
-
     public static <R> R parseIdString(String id, WithIdNums<R> withIdNums) {
         var rawNums = Splitter.on('.')
             .split(id)
@@ -23,5 +18,10 @@ public final class IdUtil {
             throw new IllegalArgumentException("Invalid Id format, should be in format {shardNum}.{realmNum}.{idNum}");
         }
         return newId;
+    }
+
+    @FunctionalInterface
+    public interface WithIdNums<R> {
+        R apply(long shardNum, long realmNum, long entityNum);
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
@@ -3,12 +3,15 @@ package com.hedera.hashgraph.sdk;
 import com.google.common.base.Splitter;
 
 public final class IdUtil {
+
+    private IdUtil() {  }
+
     public static long[] parseIdString(String id) {
         var rawNums = Splitter.on('.')
             .split(id)
             .iterator();
 
-       return new long[] {
+        return new long[] {
             Long.parseLong(rawNums.next()),
             Long.parseLong(rawNums.next()),
             Long.parseLong(rawNums.next())

--- a/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/IdUtil.java
@@ -7,11 +7,20 @@ public final class IdUtil {
     private IdUtil() {
     }
 
-    public static long[] parseIdString(String id) {
+    @FunctionalInterface
+    public interface WithIdNums<R> {
+        R apply(long shardNum, long realmNum, long entityNum);
+    }
+    public static <R> R parseIdString(String id, WithIdNums<R> withIdNums) {
         var rawNums = Splitter.on('.')
             .split(id)
             .iterator();
-
-        return new long[]{Long.parseLong(rawNums.next()), Long.parseLong(rawNums.next()), Long.parseLong(rawNums.next())};
+        R newId;
+        try {
+            newId = withIdNums.apply(Long.parseLong(rawNums.next()), Long.parseLong(rawNums.next()), Long.parseLong(rawNums.next()));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid Id format, should be in format {shardNum}.{realmNum}.{idNum}");
+        }
+        return newId;
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountId.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountId.java
@@ -2,6 +2,7 @@ package com.hedera.hashgraph.sdk.account;
 
 import com.google.common.base.Splitter;
 import com.hedera.hashgraph.sdk.Entity;
+import com.hedera.hashgraph.sdk.IdUtil;
 import com.hedera.hashgraph.sdk.SolidityUtil;
 import com.hedera.hashgraph.sdk.proto.AccountID;
 import com.hedera.hashgraph.sdk.proto.AccountIDOrBuilder;
@@ -25,16 +26,14 @@ public final class AccountId implements Entity {
 
     /** Constructs an `AccountId` from a string formatted as <shardNum>.<realmNum>.<accountNum> */
     public static AccountId fromString(String account) throws IllegalArgumentException {
-        var rawNums = Splitter.on('.')
-            .split(account)
-            .iterator();
 
+        long[] rawNums = IdUtil.parseIdString(account);
         var newAccount = AccountID.newBuilder();
 
         try {
-            newAccount.setRealmNum(Integer.parseInt(rawNums.next()));
-            newAccount.setShardNum(Integer.parseInt(rawNums.next()));
-            newAccount.setAccountNum(Integer.parseInt(rawNums.next()));
+            newAccount.setRealmNum(rawNums[0]);
+            newAccount.setShardNum(rawNums[1]);
+            newAccount.setAccountNum(rawNums[2]);
         } catch (Exception e) {
             throw new IllegalArgumentException("Invalid Id format, should be in format {shardNum}.{realmNum}.{accountNum}");
         }

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountId.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountId.java
@@ -26,19 +26,7 @@ public final class AccountId implements Entity {
 
     /** Constructs an `AccountId` from a string formatted as <shardNum>.<realmNum>.<accountNum> */
     public static AccountId fromString(String account) throws IllegalArgumentException {
-
-        long[] rawNums = IdUtil.parseIdString(account);
-        var newAccount = AccountID.newBuilder();
-
-        try {
-            newAccount.setRealmNum(rawNums[0]);
-            newAccount.setShardNum(rawNums[1]);
-            newAccount.setAccountNum(rawNums[2]);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Invalid Id format, should be in format {shardNum}.{realmNum}.{accountNum}");
-        }
-
-        return new AccountId(newAccount);
+        return IdUtil.parseIdString(account, AccountId::new);
     }
 
     public AccountId(AccountIDOrBuilder accountId) {

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractId.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractId.java
@@ -25,19 +25,7 @@ public final class ContractId implements Key, Entity {
 
     /** Constructs a `ContractId` from a string formatted as <shardNum>.<realmNum>.<contractNum> */
     public static ContractId fromString(String account) throws IllegalArgumentException {
-
-        long[] rawNums = IdUtil.parseIdString(account);
-        var newContract = ContractID.newBuilder();
-
-        try {
-            newContract.setRealmNum(rawNums[0]);
-            newContract.setShardNum(rawNums[1]);
-            newContract.setContractNum(rawNums[2]);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Invalid Id format, should be in format {shardNum}.{realmNum}.{contractNum}");
-        }
-
-        return new ContractId(newContract);
+        return IdUtil.parseIdString(account, ContractId::new);
     }
 
     public static ContractId fromSolidityAddress(String address) {

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractId.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractId.java
@@ -34,7 +34,7 @@ public final class ContractId implements Key, Entity {
             newContract.setShardNum(rawNums[1]);
             newContract.setContractNum(rawNums[2]);
         } catch (Exception e) {
-            throw new IllegalArgumentException("Invalid Id format, should be in format {shardNum}.{realmNum}.{accountNum}");
+            throw new IllegalArgumentException("Invalid Id format, should be in format {shardNum}.{realmNum}.{contractNum}");
         }
 
         return new ContractId(newContract);

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractId.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractId.java
@@ -2,6 +2,7 @@ package com.hedera.hashgraph.sdk.contract;
 
 import com.hedera.hashgraph.sdk.Entity;
 import com.hedera.hashgraph.sdk.SolidityUtil;
+import com.hedera.hashgraph.sdk.IdUtil;
 import com.hedera.hashgraph.sdk.crypto.Key;
 import com.hedera.hashgraph.sdk.proto.ContractID;
 import com.hedera.hashgraph.sdk.proto.ContractIDOrBuilder;
@@ -20,6 +21,23 @@ public final class ContractId implements Key, Entity {
 
     public ContractId(ContractIDOrBuilder contractID) {
         this(contractID.getShardNum(), contractID.getRealmNum(), contractID.getContractNum());
+    }
+
+    /** Constructs a `ContractId` from a string formatted as <shardNum>.<realmNum>.<contractNum> */
+    public static ContractId fromString(String account) throws IllegalArgumentException {
+
+        long[] rawNums = IdUtil.parseIdString(account);
+        var newContract = ContractID.newBuilder();
+
+        try {
+            newContract.setRealmNum(rawNums[0]);
+            newContract.setShardNum(rawNums[1]);
+            newContract.setContractNum(rawNums[2]);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid Id format, should be in format {shardNum}.{realmNum}.{accountNum}");
+        }
+
+        return new ContractId(newContract);
     }
 
     public static ContractId fromSolidityAddress(String address) {

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileId.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileId.java
@@ -1,6 +1,7 @@
 package com.hedera.hashgraph.sdk.file;
 
 import com.hedera.hashgraph.sdk.Entity;
+import com.hedera.hashgraph.sdk.IdUtil;
 import com.hedera.hashgraph.sdk.SolidityUtil;
 import com.hedera.hashgraph.sdk.proto.FileID;
 import com.hedera.hashgraph.sdk.proto.FileIDOrBuilder;
@@ -19,6 +20,23 @@ public final class FileId implements Entity {
 
     public FileId(FileIDOrBuilder fileId) {
         this(fileId.getShardNum(), fileId.getRealmNum(), fileId.getFileNum());
+    }
+
+    /** Constructs a `FileId` from a string formatted as <shardNum>.<realmNum>.<contractNum> */
+    public static FileId fromString(String account) throws IllegalArgumentException {
+
+        long[] rawNums = IdUtil.parseIdString(account);
+        var newFile = FileID.newBuilder();
+
+        try {
+            newFile.setRealmNum(rawNums[0]);
+            newFile.setShardNum(rawNums[1]);
+            newFile.setFileNum(rawNums[2]);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid Id format, should be in format {shardNum}.{realmNum}.{accountNum}");
+        }
+
+        return new FileId(newFile);
     }
 
     public static FileId fromSolidityAddress(String address) {

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileId.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileId.java
@@ -33,7 +33,7 @@ public final class FileId implements Entity {
             newFile.setShardNum(rawNums[1]);
             newFile.setFileNum(rawNums[2]);
         } catch (Exception e) {
-            throw new IllegalArgumentException("Invalid Id format, should be in format {shardNum}.{realmNum}.{accountNum}");
+            throw new IllegalArgumentException("Invalid Id format, should be in format {shardNum}.{realmNum}.{fileNum}");
         }
 
         return new FileId(newFile);

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileId.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileId.java
@@ -22,21 +22,9 @@ public final class FileId implements Entity {
         this(fileId.getShardNum(), fileId.getRealmNum(), fileId.getFileNum());
     }
 
-    /** Constructs a `FileId` from a string formatted as <shardNum>.<realmNum>.<contractNum> */
+    /** Constructs a `FileId` from a string formatted as <shardNum>.<realmNum>.<fileNum> */
     public static FileId fromString(String account) throws IllegalArgumentException {
-
-        long[] rawNums = IdUtil.parseIdString(account);
-        var newFile = FileID.newBuilder();
-
-        try {
-            newFile.setRealmNum(rawNums[0]);
-            newFile.setShardNum(rawNums[1]);
-            newFile.setFileNum(rawNums[2]);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Invalid Id format, should be in format {shardNum}.{realmNum}.{fileNum}");
-        }
-
-        return new FileId(newFile);
+        return IdUtil.parseIdString(account, FileId::new);
     }
 
     public static FileId fromSolidityAddress(String address) {

--- a/src/test/java/com/hedera/hashgraph/sdk/IdUtilTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/IdUtilTest.java
@@ -1,0 +1,49 @@
+package com.hedera.hashgraph.sdk;
+
+import com.hedera.hashgraph.sdk.account.AccountId;
+import com.hedera.hashgraph.sdk.contract.ContractId;
+import com.hedera.hashgraph.sdk.file.FileId;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IdUtilTest {
+    @Test
+    @DisplayName("parses id string correctly")
+    void testParseString() {
+        long[] correctArray = {0,0,0};
+        long[] returnedArray = IdUtil.parseIdString("0.0.0");
+        assertEquals( correctArray[0], returnedArray[0]);
+        assertEquals( correctArray[1], returnedArray[1]);
+        assertEquals( correctArray[2], returnedArray[2]);
+    }
+
+    @Test
+    @DisplayName("creates account id from string correctly")
+    void testAccountIdFromString() {
+        AccountId accountFromString = AccountId.fromString("0.0.400");
+        assertEquals( 0, accountFromString.getRealmNum());
+        assertEquals( 0, accountFromString.getShardNum());
+        assertEquals( 400, accountFromString.getAccountNum());
+    }
+
+    @Test
+    @DisplayName("creates contract id from string correctly")
+    void testContractIdFromString() {
+        ContractId contractFromString = ContractId.fromString("0.0.400");
+        assertEquals( 0, contractFromString.getRealmNum());
+        assertEquals( 0, contractFromString.getShardNum());
+        assertEquals( 400, contractFromString.getContractNum());
+    }
+
+    @Test
+    @DisplayName("creates file id from string correctly")
+    void testFileIdFromString() {
+        FileId fileFromString = FileId.fromString("0.0.400");
+        assertEquals( 0, fileFromString.getRealmNum());
+        assertEquals( 0, fileFromString.getShardNum());
+        assertEquals( 400, fileFromString.getFileNum());
+    }
+}

--- a/src/test/java/com/hedera/hashgraph/sdk/IdUtilTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/IdUtilTest.java
@@ -10,15 +10,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class IdUtilTest {
-    @Test
-    @DisplayName("parses id string correctly")
-    void testParseString() {
-        long[] correctArray = {0,0,0};
-        long[] returnedArray = IdUtil.parseIdString("0.0.0");
-        assertEquals( correctArray[0], returnedArray[0]);
-        assertEquals( correctArray[1], returnedArray[1]);
-        assertEquals( correctArray[2], returnedArray[2]);
-    }
 
     @Test
     @DisplayName("creates account id from string correctly")

--- a/src/test/java/com/hedera/hashgraph/sdk/IdUtilTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/IdUtilTest.java
@@ -71,7 +71,7 @@ class IdUtilTest {
             message,
             assertThrows(
                 IllegalArgumentException.class,
-                () -> IdUtil.parseIdString("0.1.plus", FileId::new)).getMessage());
+                () -> IdUtil.parseIdString("0.1", FileId::new)).getMessage());
     }
 
 

--- a/src/test/java/com/hedera/hashgraph/sdk/IdUtilTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/IdUtilTest.java
@@ -7,7 +7,10 @@ import com.hedera.hashgraph.sdk.file.FileId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 
 class IdUtilTest {
 
@@ -37,4 +40,39 @@ class IdUtilTest {
         assertEquals( 0, fileFromString.getShardNum());
         assertEquals( 400, fileFromString.getFileNum());
     }
+
+    @Test
+    @DisplayName("incorrect account id from string should fail")
+    void testBadAccountIdFromStringFails() {
+        final var message = "Invalid Id format, should be in format {shardNum}.{realmNum}.{idNum}";
+        assertEquals(
+            message,
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> IdUtil.parseIdString("a.0.400", AccountId::new)).getMessage());
+    }
+
+    @Test
+    @DisplayName("incorrect contract id from string should fail")
+    void testBadContractIdFromStringFails() {
+        final var message = "Invalid Id format, should be in format {shardNum}.{realmNum}.{idNum}";
+        assertEquals(
+            message,
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> IdUtil.parseIdString("0.!.400", ContractId::new)).getMessage());
+    }
+
+    @Test
+    @DisplayName("incorrect file id from string should fail")
+    void testBadFileIdFromStringFails() {
+        final var message = "Invalid Id format, should be in format {shardNum}.{realmNum}.{idNum}";
+        assertEquals(
+            message,
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> IdUtil.parseIdString("0.1.plus", FileId::new)).getMessage());
+    }
+
+
 }


### PR DESCRIPTION
Pull request for [Issue #163](https://github.com/hashgraph/hedera-sdk-java/issues/163)

I created an IdUtil file that holds one method for parsing ID strings. I then added a fromString method for both ContractId and FileId that implements this parsing function. I also refactored the existing AccountId.fromString method to use the parsing function as well. There is a test file included that passes for all four methods.

I recognize that having a separate IdUtil file for a 12 line method may be overkill. Ideally, I'd like to pull more of the fromString functionality into the same static utility method but the way each ID is uniquely built makes that impractical. I'm interested if there is a better solution that can be suggested.
