### PR TITLE
Following up on issue #177.

### DIFF
--- a/src/main/java/com/hedera/hashgraph/sdk/CallParams.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/CallParams.java
@@ -191,7 +191,8 @@ public final class CallParams<Kind> {
                 "bytesN cannot have a length greater than 32; given length: " + fixedLen);
         }
 
-        addParamType("bytes[" + fixedLen + "]");
+        //addParamType("bytes[" + fixedLen + "]");
+        addParamType("bytes" + fixedLen );
         // the bytesN type is fixed size
         args.add(new Argument(rightPad32(ByteString.copyFrom(param)), false));
 

--- a/src/main/java/com/hedera/hashgraph/sdk/CallParams.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/CallParams.java
@@ -192,7 +192,7 @@ public final class CallParams<Kind> {
         }
 
         //addParamType("bytes[" + fixedLen + "]");
-        addParamType("bytes" + fixedLen );
+        addParamType("bytes" + fixedLen);
         // the bytesN type is fixed size
         args.add(new Argument(rightPad32(ByteString.copyFrom(param)), false));
 


### PR DESCRIPTION
Incorrect tag for the type to the Solidity Interface. It needs to go as bytes32, not bytes[32]