### PR TITLE
deprecate operations with hidden/unclear costs

### DIFF
--- a/src/main/java/com/hedera/hashgraph/sdk/QueryBuilder.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/QueryBuilder.java
@@ -62,7 +62,11 @@ public abstract class QueryBuilder<Resp, T extends QueryBuilder<Resp, T>> extend
      * was provided to the {@link Client} used to construct this instance.
      *
      * @return {@code this} for fluent usage.
+     *
+     * @deprecated query cost should be calculated by requesting it from the node so this function's
+     * signature is insufficient to abstract over that operation.
      */
+    @Deprecated(forRemoval = true)
     public T setPaymentDefault() {
         return setPaymentDefault(getCost());
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -271,7 +271,11 @@ public final class Transaction extends HederaCall<com.hederahashgraph.api.proto.
      * @throws HederaException for any response code that is not {@link ResponseCodeEnum#SUCCESS}
      * @throws HederaNetworkException
      * @throws RuntimeException if an {@link java.lang.InterruptedException} is thrown while waiting for the receipt.
+     * @deprecated querying for records has a cost separate from executing the transaction and so
+     * should be done in an explicit step
+     *
      */
+    @Deprecated(forRemoval = true)
     public TransactionRecord executeForRecord() throws HederaException, HederaNetworkException {
         return executeAndWaitFor(
             receipt -> new TransactionRecordQuery(getClient()).setTransactionId(getId()).execute());
@@ -291,6 +295,11 @@ public final class Transaction extends HederaCall<com.hederahashgraph.api.proto.
         executeForReceiptAsync(r -> onSuccess.accept(this, r), e -> onError.accept(this, e));
     }
 
+    /**
+     * @deprecated querying for records has a cost separate from executing the transaction and so
+     * should be done in an explicit step
+     */
+    @Deprecated(forRemoval = true)
     public void executeForRecordAsync(Consumer<TransactionRecord> onSuccess, Consumer<HederaThrowable> onError) {
         final var recordQuery = new TransactionRecordQuery(getClient())
             .setTransactionId(getId())
@@ -304,9 +313,10 @@ public final class Transaction extends HederaCall<com.hederahashgraph.api.proto.
     }
 
     /**
-     * Equivalent to {@link #executeForRecordAsync(Consumer, Consumer)} but providing {@code this}
-     * to the callback for additional context.
+     * @deprecated querying for records has a cost separate from executing the transaction and so
+     * should be done in an explicit step
      */
+    @Deprecated(forRemoval = true)
     public final void executeForRecordAsync(BiConsumer<Transaction, TransactionRecord> onSuccess, BiConsumer<Transaction, HederaThrowable> onError) {
         executeForRecordAsync(r -> onSuccess.accept(this, r), e -> onError.accept(this, e));
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
@@ -191,18 +191,29 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
         build().executeForReceiptAsync(r -> onSuccess.accept((T) this, r), e -> onError.accept((T) this, e));
     }
 
+    /**
+     * @deprecated querying for records has a cost separate from executing the transaction and so
+     * should be done in an explicit step
+     */
+    @Deprecated(forRemoval = true)
     public final TransactionRecord executeForRecord() throws HederaException, HederaNetworkException {
         return build().executeForRecord();
     }
 
+    /**
+     * @deprecated querying for records has a cost separate from executing the transaction and so
+     * should be done in an explicit step
+     */
+    @Deprecated(forRemoval = true)
     public final void executeForRecordAsync(Consumer<TransactionRecord> onSuccess, Consumer<HederaThrowable> onError) {
         build().executeForRecordAsync(onSuccess, onError);
     }
 
     /**
-     * Equivalent to {@link #executeForRecordAsync(Consumer, Consumer)} but providing {@code this}
-     * to the callback for additional context.
+     * @deprecated querying for records has a cost separate from executing the transaction and so
+     * should be done in an explicit step
      */
+    @Deprecated(forRemoval = true)
     public final void executeForRecordAsync(BiConsumer<T, TransactionRecord> onSuccess, BiConsumer<T, HederaThrowable> onError) {
         //noinspection unchecked
         build().executeForRecordAsync(r -> onSuccess.accept((T) this, r), e -> onError.accept((T) this, e));


### PR DESCRIPTION
* deprecates `Transaction[Builder].executeForRecord*()` because querying a record has a cost separate from executing the transaction and should be done in a subsequent step
* deprecates `QueryBuilder.setPaymentDefault()` (no args) because we need to request COST_ANSWER from the node and the function's signature is insufficient to represent that operation