### PR TITLE
fix example compilation on JDK 8

### DIFF
--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/ExampleHelper.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/ExampleHelper.java
@@ -4,7 +4,6 @@ import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.account.AccountId;
 import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
 
-import java.util.Map;
 import java.util.Objects;
 
 import io.github.cdimascio.dotenv.Dotenv;
@@ -33,7 +32,7 @@ public final class ExampleHelper {
     public static Client createHederaClient() {
         // To connect to a network with more nodes, add additional entries to the network map
         String nodeAddress = Objects.requireNonNull(getEnv().get("NODE_ADDRESS"));
-        Client client = new Client(Map.of(getNodeId(), nodeAddress));
+        Client client = new Client(getNodeId(), nodeAddress);
 
         // Defaults the operator account ID and key such that all generated transactions will be paid for
         // by this account and be signed by this key


### PR DESCRIPTION
This broke when I added `openjdk8` in the Travis config but wouldn't say why: https://travis-ci.org/hashgraph/hedera-sdk-java/jobs/584817474

I'm inclined to say it's an issue with Maven 3.6.0 because it works fine with 3.6.2 on my machine.