### PR TITLE
(breaking) rename `Key` to `PublicKey` and make it an abstract class

### DIFF
--- a/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -6,7 +6,7 @@ import com.hedera.hashgraph.sdk.account.AccountId;
 import com.hedera.hashgraph.sdk.account.AccountInfo;
 import com.hedera.hashgraph.sdk.account.AccountInfoQuery;
 import com.hedera.hashgraph.sdk.account.CryptoTransferTransaction;
-import com.hedera.hashgraph.sdk.crypto.Key;
+import com.hedera.hashgraph.sdk.crypto.PublicKey;
 import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
 
 import java.util.HashMap;
@@ -193,7 +193,7 @@ public final class Client implements AutoCloseable {
     // Simplified interface intended for high-level, opinionated operation
     //
 
-    public AccountId createAccount(Key publicKey, long initialBalance) throws HederaException, HederaNetworkException {
+    public AccountId createAccount(PublicKey publicKey, long initialBalance) throws HederaException, HederaNetworkException {
         TransactionReceipt receipt = new AccountCreateTransaction(this).setKey(publicKey)
             .setInitialBalance(initialBalance)
             .executeForReceipt();
@@ -201,7 +201,7 @@ public final class Client implements AutoCloseable {
         return receipt.getAccountId();
     }
 
-    public void createAccountAsync(Key publicKey, long initialBalance, Consumer<AccountId> onSuccess, Consumer<HederaThrowable> onError) {
+    public void createAccountAsync(PublicKey publicKey, long initialBalance, Consumer<AccountId> onSuccess, Consumer<HederaThrowable> onError) {
         new AccountCreateTransaction(this).setKey(publicKey)
             .setInitialBalance(initialBalance)
             .executeForReceiptAsync(receipt -> onSuccess.accept(receipt.getAccountId()), onError);

--- a/src/main/java/com/hedera/hashgraph/sdk/GetByKeyQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/GetByKeyQuery.java
@@ -1,6 +1,6 @@
 package com.hedera.hashgraph.sdk;
 
-import com.hedera.hashgraph.sdk.crypto.Key;
+import com.hedera.hashgraph.sdk.crypto.PublicKey;
 import com.hederahashgraph.api.proto.java.GetByKeyResponse;
 import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.QueryHeader;
@@ -40,7 +40,7 @@ public final class GetByKeyQuery extends QueryBuilder<GetByKeyResponse, GetByKey
         require(builder.hasKey(), ".setKey() required");
     }
 
-    public GetByKeyQuery setKey(Key publicKey) {
+    public GetByKeyQuery setKey(PublicKey publicKey) {
         builder.setKey(publicKey.toKeyProto());
         return this;
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountAddClaimTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountAddClaimTransaction.java
@@ -3,7 +3,7 @@ package com.hedera.hashgraph.sdk.account;
 import com.google.protobuf.ByteString;
 import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.TransactionBuilder;
-import com.hedera.hashgraph.sdk.crypto.Key;
+import com.hedera.hashgraph.sdk.crypto.PublicKey;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Claim;
 import com.hederahashgraph.api.proto.java.CryptoAddClaimTransactionBody;
@@ -38,7 +38,7 @@ public final class AccountAddClaimTransaction extends TransactionBuilder<Account
         return this;
     }
 
-    public AccountAddClaimTransaction addKey(Key key) {
+    public AccountAddClaimTransaction addKey(PublicKey key) {
         keyList.addKeys(key.toKeyProto());
         return this;
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountCreateTransaction.java
@@ -4,7 +4,7 @@ import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.DurationHelper;
 import com.hedera.hashgraph.sdk.TransactionBuilder;
 import com.hedera.hashgraph.sdk.TransactionId;
-import com.hedera.hashgraph.sdk.crypto.Key;
+import com.hedera.hashgraph.sdk.crypto.PublicKey;
 import com.hederahashgraph.api.proto.java.CryptoCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.RealmID;
 import com.hederahashgraph.api.proto.java.ShardID;
@@ -54,7 +54,7 @@ public final class AccountCreateTransaction extends TransactionBuilder<AccountCr
         return super.setTransactionId(transactionId);
     }
 
-    public AccountCreateTransaction setKey(Key publicKey) {
+    public AccountCreateTransaction setKey(PublicKey publicKey) {
         builder.setKey(publicKey.toKeyProto());
         return this;
     }
@@ -105,7 +105,7 @@ public final class AccountCreateTransaction extends TransactionBuilder<AccountCr
         return this;
     }
 
-    public AccountCreateTransaction setNewRealmAdminKey(Key publicKey) {
+    public AccountCreateTransaction setNewRealmAdminKey(PublicKey publicKey) {
         builder.setNewRealmAdminKey(publicKey.toKeyProto());
         return this;
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountInfo.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountInfo.java
@@ -2,7 +2,7 @@ package com.hedera.hashgraph.sdk.account;
 
 import com.hedera.hashgraph.sdk.DurationHelper;
 import com.hedera.hashgraph.sdk.TimestampHelper;
-import com.hedera.hashgraph.sdk.crypto.Key;
+import com.hedera.hashgraph.sdk.crypto.PublicKey;
 import com.hederahashgraph.api.proto.java.CryptoGetInfoResponse;
 import com.hederahashgraph.api.proto.java.Response;
 
@@ -37,8 +37,8 @@ public class AccountInfo {
         return inner.getProxyReceived();
     }
 
-    public Key getKey() {
-        return Key.fromProtoKey(inner.getKey());
+    public PublicKey getKey() {
+        return PublicKey.fromProtoKey(inner.getKey());
     }
 
     public long getBalance() {

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountUpdateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountUpdateTransaction.java
@@ -4,7 +4,7 @@ import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.DurationHelper;
 import com.hedera.hashgraph.sdk.TimestampHelper;
 import com.hedera.hashgraph.sdk.TransactionBuilder;
-import com.hedera.hashgraph.sdk.crypto.Key;
+import com.hedera.hashgraph.sdk.crypto.PublicKey;
 import com.hederahashgraph.api.proto.java.CryptoUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionResponse;
@@ -30,7 +30,7 @@ public final class AccountUpdateTransaction extends TransactionBuilder<AccountUp
         return this;
     }
 
-    public AccountUpdateTransaction setKey(Key key) {
+    public AccountUpdateTransaction setKey(PublicKey key) {
         builder.setKey(key.toKeyProto());
         return this;
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/account/Claim.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/Claim.java
@@ -1,7 +1,7 @@
 package com.hedera.hashgraph.sdk.account;
 
 import com.hedera.hashgraph.sdk.Entity;
-import com.hedera.hashgraph.sdk.crypto.Key;
+import com.hedera.hashgraph.sdk.crypto.PublicKey;
 import com.hederahashgraph.api.proto.java.AccountID;
 
 import java.util.List;
@@ -25,11 +25,11 @@ public final class Claim implements Entity {
             .toByteArray();
     }
 
-    public List<Key> getKeys() {
+    public List<PublicKey> getKeys() {
         return this.inner.getKeys()
             .getKeysList()
             .stream()
-            .map(Key::fromProtoKey)
+            .map(PublicKey::fromProtoKey)
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCreateTransaction.java
@@ -6,7 +6,7 @@ import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.DurationHelper;
 import com.hedera.hashgraph.sdk.TransactionBuilder;
 import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.crypto.Key;
+import com.hedera.hashgraph.sdk.crypto.PublicKey;
 import com.hedera.hashgraph.sdk.file.FileId;
 import com.hederahashgraph.api.proto.java.ContractCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.RealmID;
@@ -41,7 +41,7 @@ public class ContractCreateTransaction extends TransactionBuilder<ContractCreate
         return this;
     }
 
-    public ContractCreateTransaction setAdminKey(Key adminKey) {
+    public ContractCreateTransaction setAdminKey(PublicKey adminKey) {
         builder.setAdminKey(adminKey.toKeyProto());
         return this;
     }
@@ -90,7 +90,7 @@ public class ContractCreateTransaction extends TransactionBuilder<ContractCreate
         return this;
     }
 
-    public ContractCreateTransaction setNewRealmAdminKey(Key newRealmAdminKey) {
+    public ContractCreateTransaction setNewRealmAdminKey(PublicKey newRealmAdminKey) {
         builder.setNewRealmAdminKey(newRealmAdminKey.toKeyProto());
         return this;
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractId.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractId.java
@@ -3,13 +3,13 @@ package com.hedera.hashgraph.sdk.contract;
 import com.hedera.hashgraph.sdk.Entity;
 import com.hedera.hashgraph.sdk.IdUtil;
 import com.hedera.hashgraph.sdk.SolidityUtil;
-import com.hedera.hashgraph.sdk.crypto.Key;
+import com.hedera.hashgraph.sdk.crypto.PublicKey;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.ContractIDOrBuilder;
 
 import java.util.Objects;
 
-public final class ContractId implements Key, Entity {
+public final class ContractId extends PublicKey implements Entity {
     private final ContractID.Builder inner;
 
     public ContractId(long shardNum, long realmNum, long contractNum) {

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractInfo.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractInfo.java
@@ -3,7 +3,7 @@ package com.hedera.hashgraph.sdk.contract;
 import com.hedera.hashgraph.sdk.DurationHelper;
 import com.hedera.hashgraph.sdk.TimestampHelper;
 import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.crypto.Key;
+import com.hedera.hashgraph.sdk.crypto.PublicKey;
 import com.hederahashgraph.api.proto.java.ContractGetInfoResponse;
 import com.hederahashgraph.api.proto.java.Response;
 
@@ -37,8 +37,8 @@ public final class ContractInfo {
     }
 
     @Nullable
-    public Key getAdminKey() {
-        return inner.hasAdminKey() ? Key.fromProtoKey(inner.getAdminKey()) : null;
+    public PublicKey getAdminKey() {
+        return inner.hasAdminKey() ? PublicKey.fromProtoKey(inner.getAdminKey()) : null;
     }
 
     public Instant getExpirationTime() {

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractUpdateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractUpdateTransaction.java
@@ -5,7 +5,7 @@ import com.hedera.hashgraph.sdk.DurationHelper;
 import com.hedera.hashgraph.sdk.TimestampHelper;
 import com.hedera.hashgraph.sdk.TransactionBuilder;
 import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.crypto.Key;
+import com.hedera.hashgraph.sdk.crypto.PublicKey;
 import com.hedera.hashgraph.sdk.file.FileId;
 import com.hederahashgraph.api.proto.java.ContractUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.Transaction;
@@ -37,7 +37,7 @@ public class ContractUpdateTransaction extends TransactionBuilder<ContractUpdate
     }
 
     // fixme: update to the new Key interface
-    public ContractUpdateTransaction setAdminKey(Key key) {
+    public ContractUpdateTransaction setAdminKey(PublicKey key) {
         builder.setAdminKey(key.toKeyProto());
         return this;
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/crypto/KeyList.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/crypto/KeyList.java
@@ -6,13 +6,13 @@ package com.hedera.hashgraph.sdk.crypto;
  *
  * Equivalent to a threshold key with a threshold the same as the number of keys it contains.
  */
-public class KeyList implements Key {
+public class KeyList extends PublicKey {
     private com.hederahashgraph.api.proto.java.KeyList.Builder keyListBuilder =
         com.hederahashgraph.api.proto.java.KeyList.newBuilder();
 
     public KeyList() { }
 
-    public KeyList addKey(Key key) {
+    public KeyList addKey(PublicKey key) {
         keyListBuilder.addKeys(key.toKeyProto());
         return this;
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/crypto/PublicKey.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/crypto/PublicKey.java
@@ -10,10 +10,10 @@ import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.math.ec.rfc8032.Ed25519;
 import org.bouncycastle.util.encoders.Hex;
 
-public interface Key {
-    com.hederahashgraph.api.proto.java.Key toKeyProto();
+public abstract class PublicKey {
+    public abstract com.hederahashgraph.api.proto.java.Key toKeyProto();
 
-    static Key fromProtoKey(com.hederahashgraph.api.proto.java.Key key) {
+    public static PublicKey fromProtoKey(com.hederahashgraph.api.proto.java.Key key) {
         switch (key.getKeyCase()) {
         case ED25519:
             return Ed25519PublicKey.fromBytes(
@@ -27,7 +27,7 @@ public interface Key {
         }
     }
 
-    static Key fromString(String keyString) {
+    public static PublicKey fromString(String keyString) {
         SubjectPublicKeyInfo pubKeyInfo;
 
         try {

--- a/src/main/java/com/hedera/hashgraph/sdk/crypto/ThresholdKey.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/crypto/ThresholdKey.java
@@ -4,7 +4,7 @@ import java.util.Collection;
 
 import javax.annotation.Nonnegative;
 
-public class ThresholdKey implements Key {
+public class ThresholdKey extends PublicKey {
     private final com.hederahashgraph.api.proto.java.ThresholdKey.Builder inner =
         com.hederahashgraph.api.proto.java.ThresholdKey.newBuilder();
 
@@ -20,21 +20,21 @@ public class ThresholdKey implements Key {
      *
      * @return {@code this} for fluent API usage.
      */
-    public ThresholdKey add(Key key) {
+    public ThresholdKey add(PublicKey key) {
         inner.getKeysBuilder().addKeys(key.toKeyProto());
         return this;
     }
 
-    public ThresholdKey addAll(Collection<? extends Key> keys) {
-        for (final Key key : keys) {
+    public ThresholdKey addAll(Collection<? extends PublicKey> keys) {
+        for (final PublicKey key : keys) {
             add(key);
         }
 
         return this;
     }
 
-    public ThresholdKey addAll(Key... keys) {
-        for (final Key key : keys) {
+    public ThresholdKey addAll(PublicKey... keys) {
+        for (final PublicKey key : keys) {
             add(key);
         }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/crypto/ed25519/Ed25519PublicKey.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/crypto/ed25519/Ed25519PublicKey.java
@@ -1,7 +1,7 @@
 package com.hedera.hashgraph.sdk.crypto.ed25519;
 
 import com.google.protobuf.ByteString;
-import com.hedera.hashgraph.sdk.crypto.Key;
+import com.hedera.hashgraph.sdk.crypto.PublicKey;
 
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
@@ -18,7 +18,7 @@ import java.io.IOException;
  * Ed25519PrivateKey#getPublicKey()}.
  */
 @SuppressWarnings("Duplicates") // difficult to factor out common code for all algos without exposing it
-public final class Ed25519PublicKey implements Key {
+public final class Ed25519PublicKey extends PublicKey {
     private final Ed25519PublicKeyParameters pubKeyParams;
 
     Ed25519PublicKey(Ed25519PublicKeyParameters pubKeyParams) {

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileCreateTransaction.java
@@ -4,7 +4,7 @@ import com.google.protobuf.ByteString;
 import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.TimestampHelper;
 import com.hedera.hashgraph.sdk.TransactionBuilder;
-import com.hedera.hashgraph.sdk.crypto.Key;
+import com.hedera.hashgraph.sdk.crypto.PublicKey;
 import com.hederahashgraph.api.proto.java.FileCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.Transaction;
@@ -35,7 +35,7 @@ public final class FileCreateTransaction extends TransactionBuilder<FileCreateTr
      *
      * A file without any keys is immutable.
      */
-    public FileCreateTransaction addKey(Key key) {
+    public FileCreateTransaction addKey(PublicKey key) {
         keyList.addKeys(key.toKeyProto());
         return this;
     }
@@ -45,7 +45,7 @@ public final class FileCreateTransaction extends TransactionBuilder<FileCreateTr
         return this;
     }
 
-    public FileCreateTransaction setNewRealmAdminKey(Key key) {
+    public FileCreateTransaction setNewRealmAdminKey(PublicKey key) {
         builder.setNewRealmAdminKey(key.toKeyProto());
         return this;
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileInfo.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileInfo.java
@@ -1,7 +1,7 @@
 package com.hedera.hashgraph.sdk.file;
 
 import com.hedera.hashgraph.sdk.TimestampHelper;
-import com.hedera.hashgraph.sdk.crypto.Key;
+import com.hedera.hashgraph.sdk.crypto.PublicKey;
 import com.hederahashgraph.api.proto.java.FileGetInfoResponse;
 import com.hederahashgraph.api.proto.java.Response;
 
@@ -39,11 +39,11 @@ public final class FileInfo {
         return inner.getDeleted();
     }
 
-    public List<Key> getKeys() {
+    public List<PublicKey> getKeys() {
         return inner.getKeys()
             .getKeysList()
             .stream()
-            .map(Key::fromProtoKey)
+            .map(PublicKey::fromProtoKey)
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileUpdateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileUpdateTransaction.java
@@ -4,7 +4,7 @@ import com.google.protobuf.ByteString;
 import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.TimestampHelper;
 import com.hedera.hashgraph.sdk.TransactionBuilder;
-import com.hedera.hashgraph.sdk.crypto.Key;
+import com.hedera.hashgraph.sdk.crypto.PublicKey;
 import com.hederahashgraph.api.proto.java.FileUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.Transaction;
@@ -37,7 +37,7 @@ public class FileUpdateTransaction extends TransactionBuilder<FileUpdateTransact
         return this;
     }
 
-    public FileUpdateTransaction addKey(Key key) {
+    public FileUpdateTransaction addKey(PublicKey key) {
         keyList.addKeys(key.toKeyProto());
 
         return this;

--- a/src/test/java/com/hedera/hashgraph/sdk/crypto/ed25519/Ed25519PublicKeyTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/crypto/ed25519/Ed25519PublicKeyTest.java
@@ -1,6 +1,6 @@
 package com.hedera.hashgraph.sdk.crypto.ed25519;
 
-import com.hedera.hashgraph.sdk.crypto.Key;
+import com.hedera.hashgraph.sdk.crypto.PublicKey;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,7 +34,7 @@ class Ed25519PublicKeyTest {
         final String key1Str = key1.toString();
         final Ed25519PublicKey key2 = Ed25519PublicKey.fromString(key1Str);
         final String key2Str = key2.toString();
-        final Key key3 = Key.fromString(key1Str);
+        final PublicKey key3 = PublicKey.fromString(key1Str);
         final String key3Str = key3.toString();
 
         assertEquals(key3.getClass(), Ed25519PublicKey.class);


### PR DESCRIPTION
This fixes compatibility with Android (static interface methods require API level 24) and fixes an incongruency with the JS SDK.

Breakage should be mostly due to the rename unless people were implementing the interface for their own class.