### PR TITLE
implement retry with backoff for `BUSY` on `HederaCall.execute[Async]()`

### DIFF
--- a/src/main/java/com/hedera/hashgraph/sdk/Backoff.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Backoff.java
@@ -1,0 +1,70 @@
+package com.hedera.hashgraph.sdk;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+final class Backoff {
+    private int attempt = 0;
+
+    private final Duration baseDelay;
+    private final Instant expiration;
+
+    Backoff(Duration baseDelay, Instant expiration) {
+        this.baseDelay = baseDelay;
+        this.expiration = expiration;
+    }
+
+    private Optional<Duration> getNextDelay() {
+        attempt += 1;
+
+        final Duration nextDelay = baseDelay.multipliedBy(
+            ThreadLocalRandom.current().nextLong(1L << attempt));
+
+        if (Instant.now().plus(nextDelay).isBefore(expiration)) {
+            return Optional.of(nextDelay);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    <T, E extends Exception> T tryWhile(Predicate<E> shouldRetry, FallibleProducer<T, E> producer) throws E {
+        for (;;) {
+            try {
+                return producer.tryProduce();
+            } catch (Throwable e) {
+                final Optional<Duration> nextDelay = getNextDelay();
+
+                // `producer` can only throw `E` as a checked exception
+                //noinspection unchecked
+                if (shouldRetry.test((E) e) && nextDelay.isPresent()) {
+                    ThreadUtil.sleepDuration(nextDelay.get());
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    <T, E> void asyncTryWhile(Predicate<E> shouldRetry, Consumer<Consumer<E>> onTry, Consumer<E> onError) {
+        onTry.accept(e -> {
+            final Optional<Duration> nextDelay = getNextDelay();
+
+            if (shouldRetry.test(e) && nextDelay.isPresent()) {
+                ThreadUtil.schedule(() ->
+                        asyncTryWhile(shouldRetry, onTry, onError),
+                    nextDelay.get());
+            } else {
+                onError.accept(e);
+            }
+        });
+    }
+
+    @FunctionalInterface
+    interface FallibleProducer<T, E extends Exception> {
+        T tryProduce() throws E;
+    }
+}

--- a/src/main/java/com/hedera/hashgraph/sdk/Backoff.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Backoff.java
@@ -13,9 +13,9 @@ final class Backoff {
     private final Duration baseDelay;
     private final Instant expiration;
 
-    Backoff(Duration baseDelay, Instant expiration) {
+    Backoff(Duration baseDelay, Duration timeout) {
         this.baseDelay = baseDelay;
-        this.expiration = expiration;
+        this.expiration = Instant.now().plus(timeout);
     }
 
     private Optional<Duration> getNextDelay() {

--- a/src/main/java/com/hedera/hashgraph/sdk/ThreadUtil.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/ThreadUtil.java
@@ -1,0 +1,26 @@
+package com.hedera.hashgraph.sdk;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+final class ThreadUtil {
+    private ThreadUtil() { }
+
+    static void sleepDuration(Duration duration) {
+        try {
+            Thread.sleep(duration.toMillis());
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static void schedule(Runnable runnable, Duration delay) {
+        scheduledExecutor.schedule(runnable, delay.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    // we need a background thread to execute timeouts
+    private static final ScheduledExecutorService scheduledExecutor =
+        Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "hedera-async-executor"));
+}

--- a/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -126,10 +126,22 @@ public final class Transaction extends HederaCall<com.hederahashgraph.api.proto.
             .execute();
     }
 
+    public TransactionReceipt queryReceipt(Duration timeout) throws HederaException {
+        return new TransactionReceiptQuery(Objects.requireNonNull(client))
+            .setTransactionId(getId())
+            .execute(timeout);
+    }
+
     public void queryReceiptAsync(Consumer<TransactionReceipt> onReceipt, Consumer<HederaThrowable> onError) {
         new TransactionReceiptQuery(Objects.requireNonNull(client))
             .setTransactionId(id)
             .executeAsync(onReceipt, onError);
+    }
+
+    public void queryReceiptAsync(Consumer<TransactionReceipt> onReceipt, Consumer<HederaThrowable> onError, Duration timeout) {
+        new TransactionReceiptQuery(Objects.requireNonNull(client))
+            .setTransactionId(getId())
+            .executeAsync(onReceipt, onError, timeout);
     }
 
     @Override

--- a/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -21,8 +21,6 @@ import com.hederahashgraph.service.proto.java.SmartContractServiceGrpc;
 import org.bouncycastle.util.encoders.Hex;
 
 import java.time.Duration;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.function.BiConsumer;
@@ -35,24 +33,18 @@ import io.grpc.MethodDescriptor;
 
 public final class Transaction extends HederaCall<com.hederahashgraph.api.proto.java.Transaction, TransactionResponse, TransactionId, Transaction> {
 
+    static final Duration MAX_VALID_DURATION = Duration.ofMinutes(2);
+
     private final io.grpc.MethodDescriptor<com.hederahashgraph.api.proto.java.Transaction, com.hederahashgraph.api.proto.java.TransactionResponse> methodDescriptor;
     final com.hederahashgraph.api.proto.java.Transaction.Builder inner;
     final com.hederahashgraph.api.proto.java.AccountID nodeAccountId;
     final com.hederahashgraph.api.proto.java.TransactionID txnIdProto;
-
-
-    // receipt exists for 3 minutes from the consensus time, which is unknown to the client
-    // after 5 minutes the transaction would be invalid anyway
-    static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(5);
 
     @Nullable
     private final Client client;
 
     // fully qualified to disambiguate
     private final java.time.Duration validDuration;
-
-    private static final Duration RECEIPT_RETRY_DELAY = Duration.ofMillis(500);
-    private static final Duration RECEIPT_INITIAL_DELAY = Duration.ofMillis(1000);
 
     private static final int PREFIX_LEN = 6;
 
@@ -208,13 +200,7 @@ public final class Transaction extends HederaCall<com.hederahashgraph.api.proto.
 
     @Override
     protected Duration getDefaultTimeout() {
-        // receipt exists for 3 minutes from the consensus time, which is unknown to the client
-        // after 5 minutes at the most the transaction would be invalid anyway
-        return validDuration.plus(3, ChronoUnit.MINUTES);
-    }
-
-    private Instant getExpiration() {
-        return getId().getValidStart().plus(validDuration);
+        return validDuration;
     }
 
     /**

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
@@ -6,9 +6,7 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionResponse;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -177,8 +175,8 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
     }
 
     @Override
-    protected Optional<Instant> getRetryUntil() {
-        return Optional.of(Instant.now().plus(MAX_VALID_DURATION));
+    protected Duration getDefaultTimeout() {
+        return Transaction.DEFAULT_TIMEOUT;
     }
 
     public final TransactionReceipt executeForReceipt() throws HederaException, HederaNetworkException {

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
@@ -22,7 +22,7 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
 
     private static final int MAX_MEMO_LENGTH = 100;
 
-    private static final Duration MAX_VALID_DURATION = Duration.ofMinutes(2);
+    private Duration validDuration = Transaction.MAX_VALID_DURATION;
 
     @Nullable
     protected final Client client;
@@ -33,7 +33,7 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
         this.client = client;
 
         setTransactionFee(client != null ? client.getMaxTransactionFee() : Client.DEFAULT_MAX_TXN_FEE);
-        setTransactionValidDuration(Duration.ofMinutes(2));
+        setTransactionValidDuration(Transaction.MAX_VALID_DURATION);
     }
 
     /**
@@ -71,11 +71,12 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
     public final T setTransactionValidDuration(Duration validDuration) {
         Duration actual = validDuration;
 
-        if (MAX_VALID_DURATION.compareTo(validDuration) < 0) {
-            actual = MAX_VALID_DURATION;
+        if (Transaction.MAX_VALID_DURATION.compareTo(validDuration) < 0) {
+            actual = Transaction.MAX_VALID_DURATION;
         }
 
         bodyBuilder.setTransactionValidDuration(DurationHelper.durationFrom(actual));
+        this.validDuration = actual;
 
         return self();
     }
@@ -176,7 +177,7 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
 
     @Override
     protected Duration getDefaultTimeout() {
-        return Transaction.DEFAULT_TIMEOUT;
+        return validDuration;
     }
 
     public final TransactionReceipt executeForReceipt() throws HederaException, HederaNetworkException {

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
@@ -6,7 +6,9 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionResponse;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -172,6 +174,11 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
     @SuppressWarnings("unchecked")
     private T self() {
         return (T) this;
+    }
+
+    @Override
+    protected Optional<Instant> getRetryUntil() {
+        return Optional.of(Instant.now().plus(MAX_VALID_DURATION));
     }
 
     public final TransactionReceipt executeForReceipt() throws HederaException, HederaNetworkException {

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionReceiptQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionReceiptQuery.java
@@ -6,6 +6,8 @@ import com.hederahashgraph.api.proto.java.Response;
 import com.hederahashgraph.api.proto.java.TransactionGetReceiptQuery;
 import com.hederahashgraph.service.proto.java.CryptoServiceGrpc;
 
+import java.time.Duration;
+
 import io.grpc.MethodDescriptor;
 
 public final class TransactionReceiptQuery extends QueryBuilder<TransactionReceipt, TransactionReceiptQuery> {
@@ -62,6 +64,11 @@ public final class TransactionReceiptQuery extends QueryBuilder<TransactionRecei
     @Override
     protected void doValidate() {
         require(builder.hasTransactionID(), ".setTransactionId() required");
+    }
+
+    @Override
+    protected Duration getDefaultTimeout() {
+        return Transaction.DEFAULT_TIMEOUT;
     }
 
     @Override

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionReceiptQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionReceiptQuery.java
@@ -31,6 +31,25 @@ public final class TransactionReceiptQuery extends QueryBuilder<TransactionRecei
     }
 
     @Override
+    protected boolean shouldRetry(HederaThrowable e) {
+        if (!(e instanceof HederaException)) {
+            return false;
+        }
+
+        switch (((HederaException) e).responseCode) {
+            // still in the node's queue
+            case UNKNOWN:
+            // accepted but has not reached consensus
+            case OK:
+            // node queue is full
+            case BUSY:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
     protected MethodDescriptor<Query, Response> getMethod() {
         return CryptoServiceGrpc.getGetTransactionReceiptsMethod();
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionReceiptQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionReceiptQuery.java
@@ -68,7 +68,9 @@ public final class TransactionReceiptQuery extends QueryBuilder<TransactionRecei
 
     @Override
     protected Duration getDefaultTimeout() {
-        return Transaction.DEFAULT_TIMEOUT;
+        // receipt lives for 3 minutes after consensus which we can't know ahead of time
+        // validDuration plus the receipt time should be long enough
+        return Transaction.MAX_VALID_DURATION.plus(Duration.ofMinutes(3));
     }
 
     @Override


### PR DESCRIPTION
closes #231

* `Transaction.execute()` and `Transaction.executeAsync()` (and same methods on `TransactionBuilder` will retry if they get `BUSY` until the `validDuration` of the transaction elapses
* `TransactionReceiptQuery` (and thus `Transactinon.queryReceipt()` and `Transaction.queryReceiptAsync()`) will retry on `BUSY`, `OK` and `UNKNOWN` until 5 minutes elapses (maximum value for `validDuration` plus the 3 minutes that the receipt exists for)
* These timeouts can be overridden by the user by calling overloaded methods which take a `Duration` as their last argument; this only times-out the retry process itself, not any blocking calls internally, so may not be exact.