### PR TITLE
Refactor some objects into POJOs

### DIFF
--- a/src/main/java/com/hedera/hashgraph/sdk/SolidityUtil.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/SolidityUtil.java
@@ -44,9 +44,9 @@ public final class SolidityUtil {
 
     public static String addressFor(ContractId contractId) {
         return addressForEntity(
-            contractId.getShardNum(),
-            contractId.getRealmNum(),
-            contractId.getContractNum());
+            contractId.shard,
+            contractId.realm,
+            contractId.contract);
     }
 
     public static String addressFor(FileId fileId) {

--- a/src/main/java/com/hedera/hashgraph/sdk/SolidityUtil.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/SolidityUtil.java
@@ -51,9 +51,9 @@ public final class SolidityUtil {
 
     public static String addressFor(FileId fileId) {
         return addressForEntity(
-            fileId.getShardNum(),
-            fileId.getRealmNum(),
-            fileId.getFileNum());
+            fileId.shard,
+            fileId.realm,
+            fileId.file);
     }
 
     public static <T> T parseAddress(String address, WithAddress<T> withAddress) {

--- a/src/main/java/com/hedera/hashgraph/sdk/SolidityUtil.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/SolidityUtil.java
@@ -37,9 +37,9 @@ public final class SolidityUtil {
 
     public static String addressFor(AccountId accountId) {
         return addressForEntity(
-            accountId.getShardNum(),
-            accountId.getRealmNum(),
-            accountId.getAccountNum());
+            accountId.shard,
+            accountId.realm,
+            accountId.account);
     }
 
     public static String addressFor(ContractId contractId) {

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountCreateTransaction.java
@@ -40,15 +40,11 @@ public final class AccountCreateTransaction extends TransactionBuilder<AccountCr
         // this
 
         if (!builder.hasShardID()) {
-            setShardId(
-                transactionId.getAccountId()
-                    .getShardNum());
+            setShardId(transactionId.getAccountId().shard);
         }
 
         if (!builder.hasRealmID()) {
-            setRealmId(
-                transactionId.getAccountId()
-                    .getRealmNum());
+            setRealmId(transactionId.getAccountId().realm);
         }
 
         return super.setTransactionId(transactionId);

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountId.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountId.java
@@ -9,18 +9,19 @@ import com.hederahashgraph.api.proto.java.AccountIDOrBuilder;
 import java.util.Objects;
 
 public final class AccountId implements Entity {
-    private final AccountID.Builder inner;
+    public final long shard;
+    public final long realm;
+    public final long account;
 
     /** Constructs an `AccountId` with `0` for `shard` and `realm` (e.g., `0.0.<accountNum>`). */
     public AccountId(long accountNum) {
         this(0, 0, accountNum);
     }
 
-    public AccountId(long shardNum, long realmNum, long accountNum) {
-        inner = AccountID.newBuilder()
-            .setRealmNum(realmNum)
-            .setShardNum(shardNum)
-            .setAccountNum(accountNum);
+    public AccountId(long shard, long realm, long account) {
+        this.shard = shard;
+        this.realm = realm;
+        this.account = account;
     }
 
     /** Constructs an `AccountId` from a string formatted as <shardNum>.<realmNum>.<accountNum> */
@@ -36,21 +37,24 @@ public final class AccountId implements Entity {
         return SolidityUtil.parseAddress(address, AccountId::new);
     }
 
+    @Deprecated
     public long getShardNum() {
-        return inner.getShardNum();
+        return shard;
     }
 
+    @Deprecated
     public long getRealmNum() {
-        return inner.getRealmNum();
+        return realm;
     }
 
+    @Deprecated
     public long getAccountNum() {
-        return inner.getAccountNum();
+        return account;
     }
 
     @Override
     public String toString() {
-        return "" + getShardNum() + "." + getRealmNum() + "." + getAccountNum();
+        return "" + shard + "." + realm + "." + account;
     }
 
     public String toSolidityAddress() {
@@ -58,7 +62,11 @@ public final class AccountId implements Entity {
     }
 
     public AccountID toProto() {
-        return inner.build();
+        return AccountID.newBuilder()
+            .setShardNum(shard)
+            .setRealmNum(realm)
+            .setAccountNum(account)
+            .build();
     }
 
     @Override
@@ -68,12 +76,13 @@ public final class AccountId implements Entity {
         if (other == null || getClass() != other.getClass()) return false;
 
         AccountId otherId = (AccountId) other;
-        return otherId.getAccountNum() == getAccountNum() && otherId.getRealmNum() == getRealmNum()
-                && otherId.getShardNum() == getShardNum();
+        return otherId.account == account
+            && otherId.realm == realm
+            && otherId.shard == shard;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getAccountNum(), getRealmNum(), getShardNum());
+        return Objects.hash(account, realm, shard);
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountInfo.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountInfo.java
@@ -13,75 +13,130 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-public class AccountInfo {
-    private final CryptoGetInfoResponse.AccountInfo inner;
+public final class AccountInfo {
+    public final AccountId accountId;
+    public final String contractAccountId;
 
-    public AccountId getAccountId() {
-        return new AccountId(inner.getAccountIDOrBuilder());
-    }
-
-    public String getContractAccountId() {
-        return inner.getContractAccountID();
-    }
-
-    public boolean isDeleted() {
-        return inner.getDeleted();
-    }
+    public final boolean isDeleted;
 
     @Nullable
-    public AccountId getProxyAccountId() {
-        return inner.hasProxyAccountID() ? new AccountId(inner.getProxyAccountIDOrBuilder()) : null;
-    }
+    public final AccountId proxyAccountId;
+    public final long proxyReceived;
 
-    public long getProxyReceived() {
-        return inner.getProxyReceived();
-    }
+    public final PublicKey key;
 
-    public PublicKey getKey() {
-        return PublicKey.fromProtoKey(inner.getKey());
-    }
+    public final long balance;
 
-    public long getBalance() {
-        return inner.getBalance();
-    }
+    public final long generateSendRecordThreshold;
+    public final long generateReceiveRecordThreshold;
 
-    public long getGenerateSendRecordThreshold() {
-        return inner.getGenerateSendRecordThreshold();
-    }
+    public final boolean isReceiverSignatureRequired;
 
-    public long getGenerateReceiveRecordThreshold() {
-        return inner.getGenerateReceiveRecordThreshold();
-    }
+    public final Instant expirationTime;
 
-    public boolean isReceiverSignatureRequired() {
-        return inner.getReceiverSigRequired();
-    }
+    public final Duration autoRenewPeriod;
 
-    public Instant getExpirationTime() {
-        return TimestampHelper.timestampTo(inner.getExpirationTime());
-    }
+    public final List<Claim> claims;
 
-    public Duration getAutoRenewPeriod() {
-        return DurationHelper.durationTo(inner.getAutoRenewPeriod());
-    }
+    public AccountInfo(CryptoGetInfoResponse.AccountInfoOrBuilder info) {
+        if (!info.hasKey()) {
+            throw new IllegalArgumentException("query response missing key");
+        }
 
-    public List<Claim> getClaims() {
-        return inner.getClaimsList()
+        accountId = new AccountId(info.getAccountIDOrBuilder());
+        contractAccountId = info.getContractAccountID();
+        isDeleted = info.getDeleted();
+        proxyAccountId = info.hasProxyAccountID() ? new AccountId(info.getProxyAccountIDOrBuilder()) : null;
+        proxyReceived = info.getProxyReceived();
+        key = PublicKey.fromProtoKey(info.getKeyOrBuilder());
+        balance = info.getBalance();
+        generateSendRecordThreshold = info.getGenerateSendRecordThreshold();
+        generateReceiveRecordThreshold = info.getGenerateReceiveRecordThreshold();
+        isReceiverSignatureRequired = info.getReceiverSigRequired();
+        expirationTime = TimestampHelper.timestampTo(info.getExpirationTime());
+        autoRenewPeriod = DurationHelper.durationTo(info.getAutoRenewPeriod());
+        claims = info.getClaimsList()
             .stream()
             .map(Claim::new)
             .collect(Collectors.toList());
     }
 
-    AccountInfo(Response response) {
+    /**
+     * @deprecated is now a public field.
+     * @return
+     */
+    @Deprecated
+    public AccountId getAccountId() {
+        return accountId;
+    }
+
+    public String getContractAccountId() {
+        return contractAccountId;
+    }
+
+    @Deprecated
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+
+    @Deprecated
+    @Nullable
+    public AccountId getProxyAccountId() {
+        return proxyAccountId;
+    }
+
+    @Deprecated
+    public long getProxyReceived() {
+        return proxyReceived;
+    }
+
+    @Deprecated
+    public PublicKey getKey() {
+        return key;
+    }
+
+    @Deprecated
+    public long getBalance() {
+        return balance;
+    }
+
+    @Deprecated
+    public long getGenerateSendRecordThreshold() {
+        return generateSendRecordThreshold;
+    }
+
+    @Deprecated
+    public long getGenerateReceiveRecordThreshold() {
+        return generateReceiveRecordThreshold;
+    }
+
+    @Deprecated
+    public boolean isReceiverSignatureRequired() {
+        return isReceiverSignatureRequired;
+    }
+
+    @Deprecated
+    public Instant getExpirationTime() {
+        return expirationTime;
+    }
+
+    @Deprecated
+    public Duration getAutoRenewPeriod() {
+        return autoRenewPeriod;
+    }
+
+    @Deprecated
+    public List<Claim> getClaims() {
+        return claims;
+    }
+
+    static AccountInfo fromResponse(Response response) {
         if (!response.hasCryptoGetInfo()) {
             throw new IllegalArgumentException("query response was not `CryptoGetInfoResponse`");
         }
 
         CryptoGetInfoResponse infoResponse = response.getCryptoGetInfo();
-        inner = infoResponse.getAccountInfo();
 
-        if (!inner.hasKey()) {
-            throw new IllegalArgumentException("query response missing key");
-        }
+        return new AccountInfo(infoResponse.getAccountInfo());
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountInfoQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountInfoQuery.java
@@ -45,6 +45,6 @@ public final class AccountInfoQuery extends QueryBuilder<AccountInfo, AccountInf
 
     @Override
     protected AccountInfo fromResponse(Response raw) {
-        return new AccountInfo(raw);
+        return AccountInfo.fromResponse(raw);
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractId.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractId.java
@@ -10,13 +10,14 @@ import com.hederahashgraph.api.proto.java.ContractIDOrBuilder;
 import java.util.Objects;
 
 public final class ContractId extends PublicKey implements Entity {
-    private final ContractID.Builder inner;
+    public final long shard;
+    public final long realm;
+    public final long contract;
 
-    public ContractId(long shardNum, long realmNum, long contractNum) {
-        inner = ContractID.newBuilder()
-            .setShardNum(shardNum)
-            .setRealmNum(realmNum)
-            .setContractNum(contractNum);
+    public ContractId(long shard, long realm, long contract) {
+        this.shard = shard;
+        this.realm = realm;
+        this.contract = contract;
     }
 
     public ContractId(ContractIDOrBuilder contractID) {
@@ -32,28 +33,31 @@ public final class ContractId extends PublicKey implements Entity {
         return SolidityUtil.parseAddress(address, ContractId::new);
     }
 
+    @Deprecated
     public long getShardNum() {
-        return inner.getShardNum();
+        return shard;
     }
 
+    @Deprecated
     public long getRealmNum() {
-        return inner.getRealmNum();
+        return realm;
     }
 
+    @Deprecated
     public long getContractNum() {
-        return inner.getContractNum();
+        return contract;
     }
 
     @Override
     public com.hederahashgraph.api.proto.java.Key toKeyProto() {
         return com.hederahashgraph.api.proto.java.Key.newBuilder()
-            .setContractID(inner)
+            .setContractID(toProto())
             .build();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getShardNum(), getRealmNum(), getContractNum());
+        return Objects.hash(shard, realm, contract);
     }
 
     @Override
@@ -63,17 +67,22 @@ public final class ContractId extends PublicKey implements Entity {
         if (!(other instanceof ContractId)) return false;
 
         ContractId otherId = (ContractId) other;
-        return getShardNum() == otherId.getShardNum() && getRealmNum() == otherId.getRealmNum()
-                && getContractNum() == otherId.getContractNum();
+        return shard == otherId.shard
+            && realm == otherId.realm
+            && contract == otherId.contract;
     }
 
     public ContractID toProto() {
-        return inner.build();
+        return ContractID.newBuilder()
+            .setShardNum(shard)
+            .setRealmNum(realm)
+            .setContractNum(contract)
+            .build();
     }
 
     @Override
     public String toString() {
-        return "" + getShardNum() + "." + getRealmNum() + "." + getContractNum();
+        return "" + shard + "." + realm + "." + contract;
     }
 
     public String toSolidityAddress() {

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractInfo.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractInfo.java
@@ -13,43 +13,74 @@ import java.time.Instant;
 import javax.annotation.Nullable;
 
 public final class ContractInfo {
-    private final ContractGetInfoResponse.ContractInfo inner;
+    public final ContractId contractId;
+    public final AccountId accountId;
 
-    ContractInfo(Response response) {
+    public final String contractAccountId;
+
+    public final PublicKey adminKey;
+
+    public final Instant expirationTime;
+
+    public final Duration autoRenewPeriod;
+
+    public final long storage;
+
+    public ContractInfo(ContractGetInfoResponse.ContractInfoOrBuilder info) {
+        if (!info.hasContractID()) {
+            throw new IllegalArgumentException("info is empty");
+        }
+
+        contractId = new ContractId(info.getContractIDOrBuilder());
+        accountId = new AccountId(info.getAccountIDOrBuilder());
+        contractAccountId = info.getContractAccountID();
+        adminKey = info.hasAdminKey() ? PublicKey.fromProtoKey(info.getAdminKey()) : null;
+        expirationTime = TimestampHelper.timestampTo(info.getExpirationTime());
+        autoRenewPeriod = DurationHelper.durationTo(info.getAutoRenewPeriod());
+        storage = info.getStorage();
+    }
+
+    @Deprecated
+    public ContractId getContractId() {
+        return contractId;
+    }
+
+    @Deprecated
+    public AccountId getAccountId() {
+        return accountId;
+    }
+
+    @Deprecated
+    public String getContractAccountId() {
+        return contractAccountId;
+    }
+
+    @Deprecated
+    @Nullable
+    public PublicKey getAdminKey() {
+        return adminKey;
+    }
+
+    @Deprecated
+    public Instant getExpirationTime() {
+        return expirationTime;
+    }
+
+    @Deprecated
+    public Duration getAutoRenewPeriod() {
+        return autoRenewPeriod;
+    }
+
+    @Deprecated
+    public long getStorage() {
+        return storage;
+    }
+
+    static ContractInfo fromResponse(Response response) {
         if (!response.hasContractGetInfo()) {
             throw new IllegalArgumentException("response was not `contractGetInfo`");
         }
 
-        inner = response.getContractGetInfo()
-            .getContractInfo();
-    }
-
-    public ContractId getContractId() {
-        return new ContractId(inner.getContractIDOrBuilder());
-    }
-
-    public AccountId getAccountId() {
-        return new AccountId(inner.getAccountIDOrBuilder());
-    }
-
-    public String getContractAccountId() {
-        return inner.getContractAccountID();
-    }
-
-    @Nullable
-    public PublicKey getAdminKey() {
-        return inner.hasAdminKey() ? PublicKey.fromProtoKey(inner.getAdminKey()) : null;
-    }
-
-    public Instant getExpirationTime() {
-        return TimestampHelper.timestampTo(inner.getExpirationTime());
-    }
-
-    public Duration getAutoRenewPeriod() {
-        return DurationHelper.durationTo(inner.getAutoRenewPeriod());
-    }
-
-    public long getStorage() {
-        return inner.getStorage();
+        return new ContractInfo(response.getContractGetInfo().getContractInfo());
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractInfoQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractInfoQuery.java
@@ -39,7 +39,7 @@ public final class ContractInfoQuery extends QueryBuilder<ContractInfo, Contract
 
     @Override
     protected ContractInfo fromResponse(Response raw) {
-        return new ContractInfo(raw);
+        return ContractInfo.fromResponse(raw);
     }
 
     @Override

--- a/src/main/java/com/hedera/hashgraph/sdk/crypto/PublicKey.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/crypto/PublicKey.java
@@ -2,7 +2,8 @@ package com.hedera.hashgraph.sdk.crypto;
 
 import com.hedera.hashgraph.sdk.contract.ContractId;
 import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
-import com.hederahashgraph.api.proto.java.ContractID;
+import com.hederahashgraph.api.proto.java.ContractIDOrBuilder;
+import com.hederahashgraph.api.proto.java.KeyOrBuilder;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.edec.EdECObjectIdentifiers;
@@ -13,14 +14,14 @@ import org.bouncycastle.util.encoders.Hex;
 public abstract class PublicKey {
     public abstract com.hederahashgraph.api.proto.java.Key toKeyProto();
 
-    public static PublicKey fromProtoKey(com.hederahashgraph.api.proto.java.Key key) {
+    public static PublicKey fromProtoKey(KeyOrBuilder key) {
         switch (key.getKeyCase()) {
         case ED25519:
             return Ed25519PublicKey.fromBytes(
                 key.getEd25519()
                     .toByteArray());
         case CONTRACTID:
-            ContractID id = key.getContractID();
+            ContractIDOrBuilder id = key.getContractIDOrBuilder();
             return new ContractId(id.getShardNum(), id.getRealmNum(), id.getContractNum());
         default:
             throw new IllegalStateException("Unchecked Key Case");

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileId.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileId.java
@@ -9,13 +9,14 @@ import com.hederahashgraph.api.proto.java.FileIDOrBuilder;
 import java.util.Objects;
 
 public final class FileId implements Entity {
-    private final FileID.Builder inner;
+    public final long shard;
+    public final long realm;
+    public final long file;
 
     public FileId(long shardNum, long realmNum, long fileNum) {
-        inner = FileID.newBuilder()
-            .setShardNum(shardNum)
-            .setRealmNum(realmNum)
-            .setFileNum(fileNum);
+        this.shard = shardNum;
+        this.realm = realmNum;
+        this.file = fileNum;
     }
 
     public FileId(FileIDOrBuilder fileId) {
@@ -31,21 +32,24 @@ public final class FileId implements Entity {
         return SolidityUtil.parseAddress(address, FileId::new);
     }
 
+    @Deprecated
     public long getShardNum() {
-        return inner.getShardNum();
+        return shard;
     }
 
+    @Deprecated
     public long getRealmNum() {
-        return inner.getRealmNum();
+        return realm;
     }
 
+    @Deprecated
     public long getFileNum() {
-        return inner.getFileNum();
+        return file;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getShardNum(), getRealmNum(), getFileNum());
+        return Objects.hash(shard, realm, file);
     }
 
     @Override
@@ -55,16 +59,20 @@ public final class FileId implements Entity {
         if (!(other instanceof FileId)) return false;
 
         FileId otherId = (FileId) other;
-        return getShardNum() == otherId.getShardNum() && getRealmNum() == otherId.getRealmNum() && getFileNum() == otherId.getFileNum();
+        return shard == otherId.shard && realm == otherId.realm && file == otherId.file;
     }
 
     public FileID toProto() {
-        return inner.build();
+        return FileID.newBuilder()
+            .setShardNum(shard)
+            .setRealmNum(realm)
+            .setFileNum(file)
+            .build();
     }
 
     @Override
     public String toString() {
-        return "" + getShardNum() + "." + getRealmNum() + "." + getFileNum();
+        return "" + shard + "." + realm + "." + file;
     }
 
     public String toSolidityAddress() {

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileInfo.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileInfo.java
@@ -10,40 +10,56 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public final class FileInfo {
-    private final FileGetInfoResponse.FileInfo inner;
+    public final FileId fileId;
+    public final long size;
+    public final Instant expirationTime;
+    public final boolean isDeleted;
+    public final List<PublicKey> keys;
 
-    FileInfo(Response response) {
-        if (!response.hasFileGetInfo()) throw new IllegalArgumentException("response was not `fileGetInfo`");
-
-        inner = response.getFileGetInfo()
-            .getFileInfo();
-
-        if (!inner.hasKeys() || inner.getKeys().getKeysList().isEmpty()) {
+    public FileInfo(FileGetInfoResponse.FileInfoOrBuilder info) {
+        if (!info.hasKeys() || info.getKeys().getKeysList().isEmpty()) {
             throw new IllegalArgumentException("`FileGetInfoResponse` missing keys");
         }
-    }
 
-    public FileId getFileId() {
-        return new FileId(inner.getFileIDOrBuilder());
-    }
-
-    public long getSize() {
-        return inner.getSize();
-    }
-
-    public Instant getExpirationTime() {
-        return TimestampHelper.timestampTo(inner.getExpirationTime());
-    }
-
-    public boolean isDeleted() {
-        return inner.getDeleted();
-    }
-
-    public List<PublicKey> getKeys() {
-        return inner.getKeys()
+        fileId = new FileId(info.getFileIDOrBuilder());
+        size = info.getSize();
+        expirationTime = TimestampHelper.timestampTo(info.getExpirationTime());
+        isDeleted = info.getDeleted();
+        keys = info.getKeys()
             .getKeysList()
             .stream()
             .map(PublicKey::fromProtoKey)
             .collect(Collectors.toList());
+    }
+
+    static FileInfo fromResponse(Response response) {
+        if (!response.hasFileGetInfo()) throw new IllegalArgumentException("response was not `fileGetInfo`");
+
+        return new FileInfo(response.getFileGetInfo().getFileInfoOrBuilder());
+    }
+
+    @Deprecated
+    public FileId getFileId() {
+        return fileId;
+    }
+
+    @Deprecated
+    public long getSize() {
+        return size;
+    }
+
+    @Deprecated
+    public Instant getExpirationTime() {
+        return expirationTime;
+    }
+
+    @Deprecated
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+
+    @Deprecated
+    public List<PublicKey> getKeys() {
+        return keys;
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileInfoQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileInfoQuery.java
@@ -39,7 +39,7 @@ public class FileInfoQuery extends QueryBuilder<FileInfo, FileInfoQuery> {
 
     @Override
     protected FileInfo fromResponse(Response raw) {
-        return new FileInfo(raw);
+        return FileInfo.fromResponse(raw);
     }
 
     @Override

--- a/src/test/java/com/hedera/hashgraph/sdk/IdUtilTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/IdUtilTest.java
@@ -26,9 +26,9 @@ class IdUtilTest {
     @DisplayName("creates contract id from string correctly")
     void testContractIdFromString() {
         ContractId contractFromString = ContractId.fromString("0.0.400");
-        assertEquals( 0, contractFromString.getRealmNum());
-        assertEquals( 0, contractFromString.getShardNum());
-        assertEquals( 400, contractFromString.getContractNum());
+        assertEquals(1, contractFromString.shard);
+        assertEquals(2, contractFromString.realm);
+        assertEquals(400, contractFromString.contract);
     }
 
     @Test

--- a/src/test/java/com/hedera/hashgraph/sdk/IdUtilTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/IdUtilTest.java
@@ -35,9 +35,9 @@ class IdUtilTest {
     @DisplayName("creates file id from string correctly")
     void testFileIdFromString() {
         FileId fileFromString = FileId.fromString("0.0.400");
-        assertEquals( 0, fileFromString.getRealmNum());
-        assertEquals( 0, fileFromString.getShardNum());
-        assertEquals( 400, fileFromString.getFileNum());
+        assertEquals( 0, fileFromString.shard);
+        assertEquals( 0, fileFromString.realm);
+        assertEquals( 400, fileFromString.file);
     }
 
     @Test

--- a/src/test/java/com/hedera/hashgraph/sdk/IdUtilTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/IdUtilTest.java
@@ -25,7 +25,7 @@ class IdUtilTest {
     @Test
     @DisplayName("creates contract id from string correctly")
     void testContractIdFromString() {
-        ContractId contractFromString = ContractId.fromString("0.0.400");
+        ContractId contractFromString = ContractId.fromString("1.2.400");
         assertEquals(1, contractFromString.shard);
         assertEquals(2, contractFromString.realm);
         assertEquals(400, contractFromString.contract);
@@ -34,9 +34,9 @@ class IdUtilTest {
     @Test
     @DisplayName("creates file id from string correctly")
     void testFileIdFromString() {
-        FileId fileFromString = FileId.fromString("0.0.400");
-        assertEquals( 0, fileFromString.shard);
-        assertEquals( 0, fileFromString.realm);
+        FileId fileFromString = FileId.fromString("1.2.400");
+        assertEquals( 1, fileFromString.shard);
+        assertEquals( 2, fileFromString.realm);
         assertEquals( 400, fileFromString.file);
     }
 

--- a/src/test/java/com/hedera/hashgraph/sdk/IdUtilTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/IdUtilTest.java
@@ -16,10 +16,10 @@ class IdUtilTest {
     @Test
     @DisplayName("creates account id from string correctly")
     void testAccountIdFromString() {
-        AccountId accountFromString = AccountId.fromString("0.0.400");
-        assertEquals( 0, accountFromString.getRealmNum());
-        assertEquals( 0, accountFromString.getShardNum());
-        assertEquals( 400, accountFromString.getAccountNum());
+        AccountId accountFromString = AccountId.fromString("1.2.400");
+        assertEquals(1, accountFromString.shard);
+        assertEquals(2, accountFromString.realm);
+        assertEquals(400, accountFromString.account);
     }
 
     @Test

--- a/src/test/java/com/hedera/hashgraph/sdk/TransactionTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/TransactionTest.java
@@ -77,6 +77,6 @@ class TransactionTest {
 
         assertEquals(txn.inner.build(), txn2.inner.build());
         assertEquals(txn.nodeAccountId, txn2.nodeAccountId);
-        assertEquals(txn.transactionId, txn2.transactionId);
+        assertEquals(txn.txnIdProto, txn2.txnIdProto);
     }
 }

--- a/src/test/java/com/hedera/hashgraph/sdk/account/AccountInfoTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/account/AccountInfoTest.java
@@ -14,14 +14,15 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AccountInfoTest {
-    private static final Ed25519PrivateKey privateKey = Ed25519PrivateKey.generate();
+    private static final Ed25519PrivateKey privateKey = Ed25519PrivateKey.fromString(
+        "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10");
 
     @Test
     @DisplayName("won't deserialize from the wrong kind of response")
     void incorrectResponse() {
         assertThrows(
             IllegalArgumentException.class,
-            () -> new AccountInfo(Response.getDefaultInstance())
+            () -> AccountInfo.fromResponse(Response.getDefaultInstance())
         );
     }
 
@@ -34,7 +35,7 @@ class AccountInfoTest {
 
         assertThrows(
             IllegalArgumentException.class,
-            () -> new AccountInfo(response),
+            () -> AccountInfo.fromResponse(response),
             "query response missing key"
         );
     }
@@ -49,12 +50,12 @@ class AccountInfoTest {
                         .setKey(privateKey.getPublicKey().toKeyProto())))
             .build();
 
-        final AccountInfo accountInfo = new AccountInfo(response);
+        final AccountInfo accountInfo = AccountInfo.fromResponse(response);
 
-        assertEquals(accountInfo.getAccountId(), new AccountId(0));
-        assertEquals(accountInfo.getContractAccountId(), "");
-        assertNull(accountInfo.getProxyAccountId());
-        assertEquals(accountInfo.getClaims(), new ArrayList<>());
+        assertEquals(accountInfo.accountId, new AccountId(0));
+        assertEquals(accountInfo.contractAccountId, "");
+        assertNull(accountInfo.proxyAccountId);
+        assertEquals(accountInfo.claims, new ArrayList<>());
     }
 
 }

--- a/src/test/java/com/hedera/hashgraph/sdk/contract/ContractInfoTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/contract/ContractInfoTest.java
@@ -21,7 +21,7 @@ class ContractInfoTest {
     void incorrectResponse() {
         assertThrows(
             IllegalArgumentException.class,
-            () -> new ContractInfo(Response.getDefaultInstance())
+            () -> ContractInfo.fromResponse(Response.getDefaultInstance())
         );
     }
 
@@ -32,9 +32,9 @@ class ContractInfoTest {
             .setContractGetInfo(ContractGetInfoResponse.getDefaultInstance())
             .build();
 
-        final ContractInfo contractInfo = new ContractInfo(response);
+        final ContractInfo contractInfo = ContractInfo.fromResponse(response);
 
-        assertNull(contractInfo.getAdminKey());
+        assertNull(contractInfo.adminKey);
     }
 
     @Test
@@ -48,14 +48,14 @@ class ContractInfoTest {
                             .setStorage(1234)))
             .build();
 
-        final ContractInfo contractInfo = new ContractInfo(response);
+        final ContractInfo contractInfo = ContractInfo.fromResponse(response);
 
-        assertEquals(contractInfo.getAccountId(), new AccountId(0));
-        assertEquals(contractInfo.getContractAccountId(), "");
-        assertEquals(contractInfo.getContractId(), new ContractId(0, 0, 0));
-        assertNull(contractInfo.getAdminKey());
-        assertEquals(contractInfo.getExpirationTime(), Instant.EPOCH);
-        assertEquals(contractInfo.getAutoRenewPeriod(), Duration.ZERO);
-        assertEquals(contractInfo.getStorage(), 1234);
+        assertEquals(contractInfo.accountId, new AccountId(0));
+        assertEquals(contractInfo.contractAccountId, "");
+        assertEquals(contractInfo.contractId, new ContractId(0, 0, 0));
+        assertNull(contractInfo.adminKey);
+        assertEquals(contractInfo.expirationTime, Instant.EPOCH);
+        assertEquals(contractInfo.autoRenewPeriod, Duration.ZERO);
+        assertEquals(contractInfo.storage, 1234);
     }
 }

--- a/src/test/java/com/hedera/hashgraph/sdk/contract/ContractInfoTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/contract/ContractInfoTest.java
@@ -29,7 +29,14 @@ class ContractInfoTest {
     @DisplayName("doesn't require a key")
     void doesntRequireKey() {
         final Response response = Response.newBuilder()
-            .setContractGetInfo(ContractGetInfoResponse.getDefaultInstance())
+            .setContractGetInfo(
+                ContractGetInfoResponse.newBuilder()
+                    .setContractInfo(
+                        ContractGetInfoResponse.ContractInfo
+                            .newBuilder()
+                            .setContractID(new ContractId(0, 0, 1)
+                                .toProto()))
+            )
             .build();
 
         final ContractInfo contractInfo = ContractInfo.fromResponse(response);
@@ -45,6 +52,7 @@ class ContractInfoTest {
                 ContractGetInfoResponse.newBuilder()
                     .setContractInfo(
                         ContractGetInfoResponse.ContractInfo.newBuilder()
+                            .setContractID(new ContractId(0, 0, 0).toProto())
                             .setStorage(1234)))
             .build();
 

--- a/src/test/java/com/hedera/hashgraph/sdk/file/FileInfoTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/file/FileInfoTest.java
@@ -23,7 +23,7 @@ class FileInfoTest {
     void incorrectResponse() {
         assertThrows(
             IllegalArgumentException.class,
-            () -> new FileInfo(Response.getDefaultInstance())
+            () -> FileInfo.fromResponse(Response.getDefaultInstance())
         );
     }
 
@@ -38,7 +38,7 @@ class FileInfoTest {
             "`FileGetInfoResponse` missing keys",
             assertThrows(
                 IllegalArgumentException.class,
-                () -> new FileInfo(response)
+                () -> FileInfo.fromResponse(response)
             ).getMessage());
     }
 
@@ -55,7 +55,7 @@ class FileInfoTest {
                                 KeyList.newBuilder().addKeys(publicKey.toKeyProto()))))
             .build();
 
-        final FileInfo fileInfo = new FileInfo(response);
+        final FileInfo fileInfo = FileInfo.fromResponse(response);
 
         assertEquals(fileInfo.getFileId(), new FileId(0, 0, 0));
         assertFalse(fileInfo.isDeleted());


### PR DESCRIPTION
This refactors some objects to deprecate getters in favor of `public final` fields to improve usability and pave the way for supporting serialization with [Jackson](https://github.com/FasterXML/jackson). This also brings these classes more in line with their equivalents in the Javascript SDK.

* `AccountId`, `ContractId`, and `FileId` had their `getShardNum()` and `getRealmNum()` getters deprecated and `shard`/`realm` fields provided instead. Same with `getAccountNum()`/`getContractNum()`/`getFileNum()`, respectively.
* `Transaction.getTransactionId()` has been deprecated in favor of a new `id` field
* `AccountInfo`, `ContractInfo` and `FileInfo` have had all their getter methods deprecated in favor of public fields in the same fashion as the above.