### PR TITLE
unify idempotent method naming

### DIFF
--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/GetAddressBook.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/GetAddressBook.java
@@ -39,7 +39,7 @@ public final class GetAddressBook {
         final FileContentsQuery fileQuery = new FileContentsQuery(client)
             .setFileId(FileId.ADDRESS_BOOK);
 
-        final long cost = fileQuery.requestCost();
+        final long cost = fileQuery.getCost();
         System.out.println("file contents cost: " + cost);
 
         fileQuery.setPaymentDefault(100_000);

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/TransferCrypto.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/TransferCrypto.java
@@ -52,7 +52,7 @@ public final class TransferCrypto {
         System.out.println("transaction ID: " + transaction.id);
 
         transaction.execute();
-        TransactionRecord record = transaction.queryRecord();
+        TransactionRecord record = transaction.getRecord();
 
         System.out.println("transferred " + amount + "...");
 

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/UpdateAccountPublicKey.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/UpdateAccountPublicKey.java
@@ -45,7 +45,7 @@ public final class UpdateAccountPublicKey {
             .build();
 
         System.out.println("transaction ID: " + acctTransaction.execute());
-        AccountId accountId = acctTransaction.queryReceipt().getAccountId();
+        AccountId accountId = acctTransaction.getReceipt().getAccountId();
         System.out.println("account = " + accountId);
         // Next, we update the key
 

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/simple/CreateAccount.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/simple/CreateAccount.java
@@ -47,7 +47,7 @@ public final class CreateAccount {
         transaction.execute();
 
         System.out.println("transaction ID: " + transaction.execute());
-        AccountId newAccountId = transaction.queryReceipt().getAccountId();
+        AccountId newAccountId = transaction.getReceipt().getAccountId();
         System.out.println("account = " + newAccountId);
     }
 }

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/simple/TransferCrypto.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/simple/TransferCrypto.java
@@ -38,7 +38,7 @@ public final class TransferCrypto {
 
         transaction.execute();
         // queryReceipt() waits for consensus
-        transaction.queryReceipt();
+        transaction.getReceipt();
 
         System.out.println("transferred 10_000 tinybar...");
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/QueryBuilder.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/QueryBuilder.java
@@ -109,10 +109,24 @@ public abstract class QueryBuilder<Resp, T extends QueryBuilder<Resp, T>> extend
         return (T) this;
     }
 
+    public final long getCost() throws HederaException, HederaNetworkException {
+        return new CostQuery().execute();
+    }
+
+    public final void getCostAsync(Consumer<Long> withCost, Consumer<HederaThrowable> onError) {
+        new CostQuery().executeAsync(withCost, onError);
+    }
+
+    /**
+     * @deprecated renamed to {@link #getCost()}
+     */
     public final long requestCost() throws HederaException, HederaNetworkException {
         return new CostQuery().execute();
     }
 
+    /**
+     * @deprecated renamed to {@link #getCostAsync(Consumer, Consumer)}
+     */
     public final void requestCostAsync(Consumer<Long> withCost, Consumer<HederaThrowable> onError) {
         new CostQuery().executeAsync(withCost, onError);
     }
@@ -122,12 +136,12 @@ public abstract class QueryBuilder<Resp, T extends QueryBuilder<Resp, T>> extend
         final long maxQueryPayment = requireClient().getMaxQueryPayment();
 
         if (!getHeaderBuilder().hasPayment() && isPaymentRequired() && maxQueryPayment > 0) {
-            final long cost = requestCost();
+            final long cost = getCost();
             if (cost > maxQueryPayment) {
                 throw new MaxPaymentExceededException(this, cost, maxQueryPayment);
             }
 
-            setPaymentDefault(requestCost());
+            setPaymentDefault(getCost());
         }
     }
 
@@ -136,7 +150,7 @@ public abstract class QueryBuilder<Resp, T extends QueryBuilder<Resp, T>> extend
         final long maxQueryPayment = requireClient().getMaxQueryPayment();
 
         if (!getHeaderBuilder().hasPayment() && isPaymentRequired() && maxQueryPayment > 0) {
-            requestCostAsync(cost -> {
+            getCostAsync(cost -> {
                 if (cost > maxQueryPayment) {
                     onError.accept(new MaxPaymentExceededException(this, cost, maxQueryPayment));
                     return;

--- a/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -120,51 +120,71 @@ public final class Transaction extends HederaCall<com.hederahashgraph.api.proto.
         return new TransactionId(txnIdProto);
     }
 
+    /**
+     * @deprecated renamed to {@link #getReceipt()}
+     */
+    @Deprecated
     public TransactionReceipt queryReceipt() throws HederaException {
         return new TransactionReceiptQuery(Objects.requireNonNull(client))
             .setTransactionId(id)
             .execute();
     }
 
+    /**
+     * @deprecated renamed to {@link #getReceipt(Duration)}
+     */
+    @Deprecated
     public TransactionReceipt queryReceipt(Duration timeout) throws HederaException {
         return new TransactionReceiptQuery(Objects.requireNonNull(client))
-            .setTransactionId(getId())
+            .setTransactionId(id)
             .execute(timeout);
     }
 
-    public void queryReceiptAsync(Consumer<TransactionReceipt> onReceipt, Consumer<HederaThrowable> onError) {
+    public TransactionReceipt getReceipt() throws HederaException {
+        return new TransactionReceiptQuery(Objects.requireNonNull(client))
+            .setTransactionId(id)
+            .execute();
+    }
+
+    public TransactionReceipt getReceipt(Duration timeout) throws HederaException {
+        return new TransactionReceiptQuery(Objects.requireNonNull(client))
+            .setTransactionId(id)
+            .execute(timeout);
+    }
+
+    public void getReceiptAsync(Consumer<TransactionReceipt> onReceipt, Consumer<HederaThrowable> onError) {
         new TransactionReceiptQuery(Objects.requireNonNull(client))
             .setTransactionId(id)
             .executeAsync(onReceipt, onError);
     }
 
-    public void queryReceiptAsync(Consumer<TransactionReceipt> onReceipt, Consumer<HederaThrowable> onError, Duration timeout) {
+    public void getReceiptAsync(Consumer<TransactionReceipt> onReceipt, Consumer<HederaThrowable> onError, Duration timeout) {
         new TransactionReceiptQuery(Objects.requireNonNull(client))
             .setTransactionId(getId())
             .executeAsync(onReceipt, onError, timeout);
     }
 
-    public TransactionRecord queryRecord() throws HederaException, HederaNetworkException {
+    public TransactionRecord getRecord() throws HederaException, HederaNetworkException {
         return new TransactionRecordQuery(Objects.requireNonNull(client))
             .setTransactionId(id)
             .execute();
     }
 
-    public TransactionRecord queryRecord(Duration timeout) throws HederaException {
+    public TransactionRecord getRecord(Duration timeout) throws HederaException {
         return new TransactionRecordQuery(Objects.requireNonNull(client))
-            .setTransactionId(getId())
+            .setTransactionId(id)
             .execute(timeout);
     }
 
-    public void queryRecordAsync(Consumer<TransactionRecord> onRecord, Consumer<HederaThrowable> onError) {
+    public void getRecordAsync(Consumer<TransactionRecord> onRecord, Consumer<HederaThrowable> onError) {
         new TransactionRecordQuery(Objects.requireNonNull(client))
             .setTransactionId(id)
             .executeAsync(onRecord, onError);
     }
 
-    public void queryRecordAsync(Consumer<TransactionRecord> onRecord, Consumer<HederaThrowable> onError, Duration timeout) {
+    public void getRecordAsync(Consumer<TransactionRecord> onRecord, Consumer<HederaThrowable> onError, Duration timeout) {
         new TransactionRecordQuery(Objects.requireNonNull(client))
-            .setTransactionId(getId())
+            .setTransactionId(id)
             .executeAsync(onRecord, onError, timeout);
     }
 
@@ -252,11 +272,11 @@ public final class Transaction extends HederaCall<com.hederahashgraph.api.proto.
      * @deprecated Makes it difficult to discern whether an error occurred while executing or
      * while fetching a receipt.
      *
-     * Call {@link #execute()} then {@link #queryReceipt()} and handle the errors separately from each.
+     * Call {@link #execute()} then {@link #getReceipt()} and handle the errors separately from each.
      */
     public final TransactionReceipt executeForReceipt() throws HederaException, HederaNetworkException {
         execute();
-        return queryReceipt();
+        return getReceipt();
     }
 
     /**
@@ -272,13 +292,13 @@ public final class Transaction extends HederaCall<com.hederahashgraph.api.proto.
      * @deprecated Makes it difficult to discern whether an error occurred while executing or
      * while fetching a record.
      *
-     * Call {@link #execute()} then {@link #queryRecord()} and handle the errors separately from each.
+     * Call {@link #execute()} then {@link #getRecord()} and handle the errors separately from each.
      */
     @Deprecated
     public TransactionRecord executeForRecord() throws HederaException, HederaNetworkException {
         execute();
         // wait for receipt
-        queryReceipt();
+        getReceipt();
         return new TransactionRecordQuery(Objects.requireNonNull(this.client))
             .setTransactionId(id)
             .execute();
@@ -289,12 +309,12 @@ public final class Transaction extends HederaCall<com.hederahashgraph.api.proto.
      * while fetching a receipt.
      *
      * Call {@link #executeAsync(Consumer, Consumer)} then
-     * {@link #queryReceiptAsync(Consumer, Consumer)} and handle the errors separately
+     * {@link #getReceiptAsync(Consumer, Consumer)} and handle the errors separately
      * from each.
      */
     @Deprecated
     public void executeForReceiptAsync(Consumer<TransactionReceipt> onSuccess, Consumer<HederaThrowable> onError) {
-        executeAsync(id -> queryReceiptAsync(onSuccess, onError), onError);
+        executeAsync(id -> getReceiptAsync(onSuccess, onError), onError);
     }
 
     /**
@@ -304,8 +324,8 @@ public final class Transaction extends HederaCall<com.hederahashgraph.api.proto.
      * @deprecated Makes it difficult to discern whether an error occurred while executing or
      * while fetching a receipt.
      *
-     * Call {@link #executeAsync(BiConsumer, BiConsumer)} then
-     * {@link #queryReceiptAsync(BiConsumer, BiConsumer)} and handle the errors
+     * Call {@link #executeAsync(Consumer, Consumer)} then
+     * {@link #getReceiptAsync(Consumer, Consumer)} and handle the errors
      * separately from each.
      */
     @Deprecated
@@ -318,7 +338,7 @@ public final class Transaction extends HederaCall<com.hederahashgraph.api.proto.
      * while fetching a record.
      *
      * Call {@link #executeAsync(Consumer, Consumer)} then
-     * {@link #queryRecordAsync(Consumer, Consumer)} and handle the errors separately
+     * {@link #getRecordAsync(Consumer, Consumer)} and handle the errors separately
      * from each.
      */
     @Deprecated
@@ -333,8 +353,8 @@ public final class Transaction extends HederaCall<com.hederahashgraph.api.proto.
      * @deprecated Makes it difficult to discern whether an error occurred while executing or
      * while fetching a record.
      *
-     * Call {@link #executeAsync(BiConsumer, BiConsumer)} then
-     * {@link #queryRecordAsync(BiConsumer, BiConsumer)} and handle the errors separately
+     * Call {@link #executeAsync(Consumer, Consumer)} then
+     * {@link #getRecordAsync(Consumer, Consumer)} and handle the errors separately
      * from each.
      */
     @Deprecated

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
@@ -205,7 +205,7 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
      * ID is difficult to retrieve.
      *
      * Call {@link #build()} then {@link Transaction#execute()} then
-     * {@link Transaction#queryReceipt()} and handle the errors separately from each.
+     * {@link Transaction#getReceipt()} and handle the errors separately from each.
      */
     @Deprecated
     public final TransactionReceipt executeForReceipt() throws HederaException, HederaNetworkException {
@@ -218,7 +218,7 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
      * ID is difficult to retrieve.
      *
      * Call {@link #build()} then {@link Transaction#executeAsync(Consumer, Consumer)} then
-     * {@link Transaction#queryReceiptAsync(Consumer, Consumer)} and handle the errors separately
+     * {@link Transaction#getReceiptAsync(Consumer, Consumer)} and handle the errors separately
      * from each.
      */
     @Deprecated
@@ -247,7 +247,7 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
      * ID is difficult to retrieve.
      *
      * Call {@link #build()} then {@link Transaction#execute()} then
-     * {@link Transaction#queryRecord()} and handle the errors separately from each.
+     * {@link Transaction#getRecord()} and handle the errors separately from each.
      */
     @Deprecated
     public final TransactionRecord executeForRecord() throws HederaException, HederaNetworkException {
@@ -260,7 +260,7 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
      * ID is difficult to retrieve.
      *
      * Call {@link #build()} then {@link Transaction#executeAsync(Consumer, Consumer)} then
-     * {@link Transaction#queryRecordAsync(Consumer, Consumer)} and handle the errors separately
+     * {@link Transaction#getRecordAsync(Consumer, Consumer)} and handle the errors separately
      * from each.
      */
     @Deprecated


### PR DESCRIPTION
rename `Transaction.query*()` to `Transaction.get*()` 

rename `QueryBuilder.requestCost*()` to `QueryBuilder.getCost*()`

add appropriate deprecation messages for existing APIs

closes #255 