### PR TITLE
make `Transaction[Receipt, Record]Query` always throw on `UNKNOWN`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>[3.5.2, 3.6.2]</version>
+                                    <version>[3.5.2, 4.0)</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>

--- a/src/main/java/com/hedera/hashgraph/sdk/QueryBuilder.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/QueryBuilder.java
@@ -213,18 +213,18 @@ public abstract class QueryBuilder<Resp, T extends QueryBuilder<Resp, T>> extend
     @Override
     protected final Resp mapResponse(Response raw) throws HederaException {
         final ResponseCodeEnum precheckCode = getResponseHeader(raw).getNodeTransactionPrecheckCode();
-        final Response.ResponseCase responseCase = raw.getResponseCase();
-        boolean unknownIsExceptional = false;
+        HederaException.throwIfExceptional(precheckCode);
 
-        switch (responseCase) {
+        switch (raw.getResponseCase()) {
             case TRANSACTIONGETRECEIPT:
+                HederaException.throwIfExceptional(raw.getTransactionGetReceipt().getReceipt().getStatus());
+                break;
             case TRANSACTIONGETRECORD:
+                HederaException.throwIfExceptional(raw.getTransactionGetRecord().getTransactionRecord().getReceipt().getStatus());
                 break;
             default:
-                unknownIsExceptional = true;
         }
 
-        HederaException.throwIfExceptional(precheckCode, unknownIsExceptional);
         return fromResponse(raw);
     }
 


### PR DESCRIPTION
Fixes behavior of `Transaction.queryReceipt()` to align with expectations.