### PR TITLE
Move `Client` from constructors to build()/execute() of query and transaction builders

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 # Network Node ID and Address
 NODE_ID=0.0.3
-NODE_ADDRESS=testnet.hedera.com:PORT_NUMBER
+NODE_ADDRESS=0.testnet.hedera.com:50211
 
 # Operator ID and Private Key
 OPERATOR_ID=0.0.2

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/CreateAccount.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/CreateAccount.java
@@ -40,17 +40,17 @@ public final class CreateAccount {
         // by this account and be signed by this key
         client.setOperator(OPERATOR_ID, OPERATOR_KEY);
 
-        Transaction tx = new AccountCreateTransaction(client)
+        Transaction tx = new AccountCreateTransaction()
             // The only _required_ property here is `key`
             .setKey(newKey.getPublicKey())
             .setInitialBalance(1000)
             .setMaxTransactionFee(10_000_000)
-            .build();
+            .build(client);
 
-        tx.execute();
+        tx.execute(client);
 
         // This will wait for the receipt to become available
-        TransactionReceipt receipt = tx.queryReceipt();
+        TransactionReceipt receipt = tx.getReceipt(client);
 
         AccountId newAccountId = receipt.getAccountId();
 

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/CreateFile.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/CreateFile.java
@@ -39,7 +39,7 @@ public final class CreateFile {
         // you can easily use the bytes of a file instead.
         byte[] fileContents = "Hedera hashgraph is great!".getBytes();
 
-        Transaction tx = new FileCreateTransaction(client)
+        Transaction tx = new FileCreateTransaction()
             .setExpirationTime(
             Instant.now()
                 .plus(Duration.ofSeconds(2592000)))
@@ -47,12 +47,12 @@ public final class CreateFile {
             .addKey(OPERATOR_KEY.getPublicKey())
             .setMaxTransactionFee(100_000_000)
             .setContents(fileContents)
-            .build();
+            .build(client);
 
         // send the transaction to the network
-        tx.execute();
+        tx.execute(client);
 
-        TransactionReceipt receipt = tx.queryReceipt();
+        TransactionReceipt receipt = tx.getReceipt(client);
         FileId newFileId = receipt.getFileId();
 
         System.out.println("file: " + newFileId);

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/DeleteFile.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/DeleteFile.java
@@ -42,36 +42,36 @@ public final class DeleteFile {
         // you can easily use the bytes of a file instead.
         byte[] fileContents = "Hedera hashgraph is great!".getBytes();
 
-        Transaction tx = new FileCreateTransaction(client).setExpirationTime(
+        Transaction tx = new FileCreateTransaction().setExpirationTime(
             Instant.now()
                 .plus(Duration.ofSeconds(2592000)))
             // Use the same key as the operator to "own" this file
             .addKey(OPERATOR_KEY.getPublicKey())
             .setContents(fileContents)
-            .build();
+            .build(client);
 
-        tx.execute();
+        tx.execute(client);
 
-        TransactionReceipt receipt = tx.queryReceipt();
+        TransactionReceipt receipt = tx.getReceipt(client);
         FileId newFileId = receipt.getFileId();
 
         System.out.println("file: " + newFileId);
 
         // now delete the file
-        Transaction fileDeleteTxn = new FileDeleteTransaction(client)
+        Transaction fileDeleteTxn = new FileDeleteTransaction()
             .setFileId(newFileId)
-            .build();
+            .build(client);
 
-        fileDeleteTxn.execute();
+        fileDeleteTxn.execute(client);
 
         // if this doesn't throw then the transaction was a success
-        fileDeleteTxn.queryReceipt();
+        fileDeleteTxn.getReceipt(client);
 
         System.out.println("File deleted successfully.");
 
-        FileInfo fileInfo = new FileInfoQuery(client)
+        FileInfo fileInfo = new FileInfoQuery()
             .setFileId(newFileId)
-            .execute();
+            .execute(client);
 
         // note the above fileInfo will fail with FILE_DELETED due to a known issue on Hedera
 

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/GetAccountBalance.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/GetAccountBalance.java
@@ -30,9 +30,9 @@ public final class GetAccountBalance {
         // by this account and be signed by this key
         client.setOperator(OPERATOR_ID, OPERATOR_KEY);
 
-        AccountBalanceQuery query = new AccountBalanceQuery(client).setAccountId(OPERATOR_ID);
+        AccountBalanceQuery query = new AccountBalanceQuery().setAccountId(OPERATOR_ID);
 
-        Long balance = query.execute();
+        Long balance = query.execute(client);
 
         System.out.println("balance = " + balance);
     }

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/GetAddressBook.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/GetAddressBook.java
@@ -36,15 +36,15 @@ public final class GetAddressBook {
         // by this account and be signed by this key
         client.setOperator(OPERATOR_ID, OPERATOR_KEY);
 
-        final FileContentsQuery fileQuery = new FileContentsQuery(client)
+        final FileContentsQuery fileQuery = new FileContentsQuery()
             .setFileId(FileId.ADDRESS_BOOK);
 
-        final long cost = fileQuery.getCost();
+        final long cost = fileQuery.getCost(client);
         System.out.println("file contents cost: " + cost);
 
-        fileQuery.setPaymentDefault(100_000);
+        fileQuery.setMaxQueryPayment(100_000_000);
 
-        final ByteString contents = fileQuery.execute().getFileContents().getContents();
+        final ByteString contents = fileQuery.execute(client).getFileContents().getContents();
 
         Files.copy(contents.newInput(),
             FileSystems.getDefault().getPath("address-book.proto.bin"));

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/GetFileContents.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/GetFileContents.java
@@ -2,11 +2,12 @@ package com.hedera.hashgraph.sdk.examples.advanced;
 
 import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.HederaException;
-import com.hedera.hashgraph.sdk.TransactionReceipt;
+import com.hedera.hashgraph.sdk.Transaction;
 import com.hedera.hashgraph.sdk.account.AccountId;
 import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
 import com.hedera.hashgraph.sdk.file.FileContentsQuery;
 import com.hedera.hashgraph.sdk.file.FileCreateTransaction;
+import com.hedera.hashgraph.sdk.file.FileId;
 import com.hederahashgraph.api.proto.java.FileGetContentsResponse;
 
 import java.time.Duration;
@@ -39,19 +40,23 @@ public final class GetFileContents {
         byte[] fileContents = ("Hedera is great!").getBytes();
 
         // Create the new file and set its properties
-        TransactionReceipt newFile = new FileCreateTransaction(client)
+        Transaction newFileTx = new FileCreateTransaction()
             .addKey(OPERATOR_KEY.getPublicKey()) // The public key of the owner of the file
             .setContents(fileContents) // Contents of the file
             .setExpirationTime(Instant.now().plus(Duration.ofSeconds(2592000))) // Set file expiration time in seconds
-            .executeForReceipt(); // Submits transaction to the network and returns receipt which contains file ID
+            .build(client); // Submits transaction to the network and returns receipt which contains file ID
+
+        newFileTx.execute(client);
+
+        FileId newFileId = newFileTx.getReceipt(client).getFileId();
 
         //Print the file ID to console
-        System.out.println("The new file ID is " + newFile.getFileId().toString());
+        System.out.println("The new file ID is " + newFileId.toString());
 
         // Get file contents
-        FileGetContentsResponse contents = new FileContentsQuery(client)
-            .setFileId(newFile.getFileId())
-            .execute();
+        FileGetContentsResponse contents = new FileContentsQuery()
+            .setFileId(newFileId)
+            .execute(client);
 
         // Prints query results to console
         System.out.println("File content query results: " + contents.getFileContents().getContents().toStringUtf8());

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/TransferCrypto.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/TransferCrypto.java
@@ -41,18 +41,18 @@ public final class TransferCrypto {
         System.out.println("" + OPERATOR_ID + " balance = " + senderBalanceBefore);
         System.out.println("" + recipientId + " balance = " + receiptBalanceBefore);
 
-        Transaction transaction = new CryptoTransferTransaction(client)
+        Transaction transaction = new CryptoTransferTransaction()
             // .addSender and .addRecipient can be called as many times as you want as long as the total sum from
             // both sides is equivalent
             .addSender(OPERATOR_ID, amount)
             .addRecipient(recipientId, amount)
             .setMemo("transfer test")
-            .build();
+            .build(client);
 
         System.out.println("transaction ID: " + transaction.id);
 
-        transaction.execute();
-        TransactionRecord record = transaction.getRecord();
+        transaction.execute(client);
+        TransactionRecord record = transaction.getRecord(client);
 
         System.out.println("transferred " + amount + "...");
 

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/UpdateAccountPublicKey.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/UpdateAccountPublicKey.java
@@ -38,14 +38,14 @@ public final class UpdateAccountPublicKey {
         // First, we create a new account so we don't affect our account
 
         Ed25519PrivateKey originalKey = Ed25519PrivateKey.generate();
-        Transaction acctTransaction = new AccountCreateTransaction(client)
+        Transaction acctTransaction = new AccountCreateTransaction()
             .setMaxTransactionFee(1_000_000_000)
             .setKey(originalKey.getPublicKey())
             .setInitialBalance(100_000_000)
-            .build();
+            .build(client);
 
-        System.out.println("transaction ID: " + acctTransaction.execute());
-        AccountId accountId = acctTransaction.getReceipt().getAccountId();
+        System.out.println("transaction ID: " + acctTransaction.execute(client));
+        AccountId accountId = acctTransaction.getReceipt(client).getAccountId();
         System.out.println("account = " + accountId);
         // Next, we update the key
 
@@ -54,21 +54,21 @@ public final class UpdateAccountPublicKey {
         System.out.println(" :: update public key of account " + accountId);
         System.out.println("set key = " + newKey.getPublicKey());
 
-        Transaction transaction = new AccountUpdateTransaction(client)
+        Transaction transaction = new AccountUpdateTransaction()
             .setAccountForUpdate(accountId)
             .setKey(newKey.getPublicKey())
             // Sign with the previous key and the new key
+            .build(client)
             .sign(originalKey)
             .sign(newKey);
 
         System.out.println("transaction ID: " + transaction.id);
 
-        transaction.execute();
+        transaction.execute(client);
         // (important!) wait for the transaction to complete by querying the receipt
-        transaction.queryReceipt();
+        transaction.getReceipt(client);
 
         // Now we fetch the account information to check if the key was changed
-
         System.out.println(" :: getAccount and check our current key");
 
         AccountInfo info = client.getAccount(accountId);

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/simple/CreateAccount.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/simple/CreateAccount.java
@@ -38,16 +38,17 @@ public final class CreateAccount {
         // by this account and be signed by this key
         client.setOperator(OPERATOR_ID, OPERATOR_KEY);
 
-        Transaction transaction = new AccountCreateTransaction(client)
+        Transaction transaction = new AccountCreateTransaction()
             .setMaxTransactionFee(1_000_000_000)
             .setKey(newPublicKey)
             .setInitialBalance(100_000_000)
-            .build();
+            .build(client);
 
-        transaction.execute();
+        transaction.execute(client);
 
-        System.out.println("transaction ID: " + transaction.execute());
-        AccountId newAccountId = transaction.getReceipt().getAccountId();
+        System.out.println("transaction ID: " + transaction.id);
+        // this is where we wait for the transaction to reach consensus
+        AccountId newAccountId = transaction.getReceipt(client).getAccountId();
         System.out.println("account = " + newAccountId);
     }
 }

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/simple/TransferCrypto.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/simple/TransferCrypto.java
@@ -31,14 +31,14 @@ public final class TransferCrypto {
         client.setOperator(OPERATOR_ID, OPERATOR_KEY);
 
         // Transfer X hbar from the operator of the client to the given account ID
-        Transaction transaction = new CryptoTransferTransaction(client)
+        Transaction transaction = new CryptoTransferTransaction()
             .addSender(OPERATOR_ID, 10_000)
             .addRecipient(AccountId.fromString("0.0.3"), 10_000)
-            .build();
+            .build(client);
 
-        transaction.execute();
+        transaction.execute(client);
         // queryReceipt() waits for consensus
-        transaction.getReceipt();
+        transaction.getReceipt(client);
 
         System.out.println("transferred 10_000 tinybar...");
     }

--- a/src/main/java/com/hedera/hashgraph/sdk/FreezeTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/FreezeTransaction.java
@@ -22,8 +22,17 @@ import io.grpc.MethodDescriptor;
 public class FreezeTransaction extends TransactionBuilder<FreezeTransaction> {
     private FreezeTransactionBody.Builder builder = FreezeTransactionBody.newBuilder();
 
+    /**
+     * @deprecated use the no-arg constructor and pass the client to {@link #build(Client)} instead.
+     */
+    @Deprecated
     public FreezeTransaction(@Nullable Client client) {
         super(client);
+        bodyBuilder.setFreeze(builder);
+    }
+
+    public FreezeTransaction() {
+        super();
         bodyBuilder.setFreeze(builder);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/GetBySolidityIdQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/GetBySolidityIdQuery.java
@@ -12,11 +12,15 @@ import io.grpc.MethodDescriptor;
 public final class GetBySolidityIdQuery extends QueryBuilder<GetBySolidityIDResponse, GetBySolidityIdQuery> {
     private final GetBySolidityIDQuery.Builder builder = inner.getGetBySolidityIDBuilder();
 
+    /**
+     * @deprecated {@link Client} should now be provided to {@link #execute(Client)}
+     */
+    @Deprecated
     public GetBySolidityIdQuery(Client client) {
         super(client);
     }
 
-    GetBySolidityIdQuery() {
+    public GetBySolidityIdQuery() {
         super((Client) null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/SystemDeleteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/SystemDeleteTransaction.java
@@ -16,9 +16,15 @@ import io.grpc.MethodDescriptor;
 public final class SystemDeleteTransaction extends TransactionBuilder<SystemDeleteTransaction> {
     private final SystemDeleteTransactionBody.Builder builder = bodyBuilder.getSystemDeleteBuilder();
 
+    /**
+     * @deprecated use the no-arg constructor and pass the client to {@link #build(Client)} instead.
+     */
+    @Deprecated
     public SystemDeleteTransaction(@Nullable Client client) {
         super(client);
     }
+
+    public SystemDeleteTransaction() { super(); }
 
     public SystemDeleteTransaction setID(FileId fileId) {
         builder.setFileID(fileId.toProto());

--- a/src/main/java/com/hedera/hashgraph/sdk/SystemUndeleteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/SystemUndeleteTransaction.java
@@ -15,9 +15,15 @@ public final class SystemUndeleteTransaction extends TransactionBuilder<SystemUn
 
     private final SystemUndeleteTransactionBody.Builder builder = bodyBuilder.getSystemUndeleteBuilder();
 
+    /**
+     * @deprecated use the no-arg constructor and pass the client to {@link #build(Client)} instead.
+     */
+    @Deprecated
     public SystemUndeleteTransaction(@Nullable Client client) {
         super(client);
     }
+
+    public SystemUndeleteTransaction() { super(); }
 
     public SystemUndeleteTransaction setID(FileId fileId) {
         builder.setFileID(fileId.toProto());

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionReceiptQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionReceiptQuery.java
@@ -13,11 +13,15 @@ import io.grpc.MethodDescriptor;
 public final class TransactionReceiptQuery extends QueryBuilder<TransactionReceipt, TransactionReceiptQuery> {
     private final TransactionGetReceiptQuery.Builder builder = inner.getTransactionGetReceiptBuilder();
 
+    /**
+     * @deprecated {@link Client} should now be provided to {@link #execute(Client)}
+     */
+    @Deprecated
     public TransactionReceiptQuery(Client client) {
         super(client);
     }
 
-    TransactionReceiptQuery() {
+    public TransactionReceiptQuery() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionRecordQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionRecordQuery.java
@@ -11,11 +11,15 @@ import io.grpc.MethodDescriptor;
 public class TransactionRecordQuery extends QueryBuilder<TransactionRecord, TransactionRecordQuery> {
     private final TransactionGetRecordQuery.Builder builder = inner.getTransactionGetRecordBuilder();
 
+    /**
+     * @deprecated {@link Client} should now be provided to {@link #execute(Client)}
+     */
+    @Deprecated
     public TransactionRecordQuery(Client client) {
         super(client);
     }
 
-    TransactionRecordQuery() {
+    public TransactionRecordQuery() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountBalanceQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountBalanceQuery.java
@@ -16,10 +16,18 @@ import io.grpc.MethodDescriptor;
 public final class AccountBalanceQuery extends QueryBuilder<Long, AccountBalanceQuery> {
     private final CryptoGetAccountBalanceQuery.Builder builder = inner.getCryptogetAccountBalanceBuilder();
 
+    /**
+     * @deprecated {@link Client} should now be provided to {@link #execute(Client)}
+     */
+    @Deprecated
     public AccountBalanceQuery(@Nullable Client client) {
         super(client);
         // a payment transaction is required but is not processed so it can have zero value
-        setPaymentDefault(0);
+        setPaymentAmount(0);
+    }
+
+    public AccountBalanceQuery() {
+        super();
     }
 
     @Override

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountCreateTransaction.java
@@ -29,9 +29,15 @@ public final class AccountCreateTransaction extends TransactionBuilder<AccountCr
         .setSendRecordThreshold(Long.MAX_VALUE)
         .setReceiveRecordThreshold(Long.MAX_VALUE);
 
+    /**
+     * @deprecated use the no-arg constructor and pass the client to {@link #build(Client)} instead.
+     */
+    @Deprecated
     public AccountCreateTransaction(@Nullable Client client) {
         super(client);
     }
+
+    public AccountCreateTransaction() { super(); }
 
     @Override
     public AccountCreateTransaction setTransactionId(TransactionId transactionId) {

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountDeleteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountDeleteTransaction.java
@@ -15,8 +15,16 @@ import io.grpc.MethodDescriptor;
 public class AccountDeleteTransaction extends TransactionBuilder<AccountDeleteTransaction> {
     private final CryptoDeleteTransactionBody.Builder builder = bodyBuilder.getCryptoDeleteBuilder();
 
+    /**
+     * @deprecated use the no-arg constructor and pass the client to {@link #build(Client)} instead.
+     */
+    @Deprecated
     public AccountDeleteTransaction(@Nullable Client client) {
         super(client);
+    }
+
+    public AccountDeleteTransaction() {
+        super();
     }
 
     public AccountDeleteTransaction setTransferAccountId(AccountId transferAccountId) {

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountInfoQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountInfoQuery.java
@@ -13,6 +13,10 @@ import io.grpc.MethodDescriptor;
 public final class AccountInfoQuery extends QueryBuilder<AccountInfo, AccountInfoQuery> {
     private final com.hederahashgraph.api.proto.java.CryptoGetInfoQuery.Builder builder;
 
+    /**
+     * @deprecated {@link Client} should now be provided to {@link #execute(Client)}
+     */
+    @Deprecated
     public AccountInfoQuery(Client client) {
         super(client);
         builder = inner.getCryptoGetInfoBuilder();

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountRecordsQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountRecordsQuery.java
@@ -15,11 +15,15 @@ import io.grpc.MethodDescriptor;
 public class AccountRecordsQuery extends QueryBuilder<CryptoGetAccountRecordsResponse, AccountRecordsQuery> {
     private final CryptoGetAccountRecordsQuery.Builder builder = inner.getCryptoGetAccountRecordsBuilder();
 
+    /**
+     * @deprecated {@link Client} should now be provided to {@link #execute(Client)}
+     */
+    @Deprecated
     public AccountRecordsQuery(Client client) {
         super(client);
     }
 
-    AccountRecordsQuery() {
+    public AccountRecordsQuery() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountStakersQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountStakersQuery.java
@@ -15,11 +15,15 @@ import io.grpc.MethodDescriptor;
 public class AccountStakersQuery extends QueryBuilder<CryptoGetStakersResponse, AccountStakersQuery> {
     private final CryptoGetStakersQuery.Builder builder = inner.getCryptoGetProxyStakersBuilder();
 
+    /**
+     * @deprecated {@link Client} should now be provided to {@link #execute(Client)}
+     */
+    @Deprecated
     public AccountStakersQuery(Client client) {
         super(client);
     }
 
-    AccountStakersQuery() {
+    public AccountStakersQuery() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountUpdateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountUpdateTransaction.java
@@ -21,9 +21,15 @@ import io.grpc.MethodDescriptor;
 public final class AccountUpdateTransaction extends TransactionBuilder<AccountUpdateTransaction> {
     private final CryptoUpdateTransactionBody.Builder builder = bodyBuilder.getCryptoUpdateAccountBuilder();
 
+    /**
+     * @deprecated use the no-arg constructor and pass the client to {@link #build(Client)} instead.
+     */
+    @Deprecated
     public AccountUpdateTransaction(@Nullable Client client) {
         super(client);
     }
+
+    public AccountUpdateTransaction() { super(); }
 
     public AccountUpdateTransaction setAccountForUpdate(AccountId accountId) {
         builder.setAccountIDToUpdate(accountId.toProto());

--- a/src/main/java/com/hedera/hashgraph/sdk/account/CryptoTransferTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/CryptoTransferTransaction.java
@@ -19,9 +19,15 @@ public final class CryptoTransferTransaction extends TransactionBuilder<CryptoTr
     private final CryptoTransferTransactionBody.Builder builder = bodyBuilder.getCryptoTransferBuilder();
     private final TransferList.Builder transferList = builder.getTransfersBuilder();
 
+    /**
+     * @deprecated use the no-arg constructor and pass the client to {@link #build(Client)} instead.
+     */
+    @Deprecated
     public CryptoTransferTransaction(@Nullable Client client) {
         super(client);
     }
+
+    public CryptoTransferTransaction() { super(); }
 
     public CryptoTransferTransaction addSender(AccountId senderId, @Nonnegative long value) {
         return this.addTransfer(senderId, value * -1L);

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractBytecodeQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractBytecodeQuery.java
@@ -15,11 +15,15 @@ import io.grpc.MethodDescriptor;
 public final class ContractBytecodeQuery extends QueryBuilder<ContractGetBytecodeResponse, ContractBytecodeQuery> {
     private final ContractGetBytecodeQuery.Builder builder = inner.getContractGetBytecodeBuilder();
 
+    /**
+     * @deprecated {@link Client} should now be provided to {@link #execute(Client)}
+     */
+    @Deprecated
     public ContractBytecodeQuery(Client client) {
         super(client);
     }
 
-    ContractBytecodeQuery() {
+    public ContractBytecodeQuery() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCallQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCallQuery.java
@@ -18,11 +18,15 @@ import io.grpc.MethodDescriptor;
 public class ContractCallQuery extends QueryBuilder<FunctionResult, ContractCallQuery> {
     private final ContractCallLocalQuery.Builder builder = inner.getContractCallLocalBuilder();
 
+    /**
+     * @deprecated {@link Client} should now be provided to {@link #execute(Client)}
+     */
+    @Deprecated
     public ContractCallQuery(Client client) {
         super(client);
     }
 
-    ContractCallQuery() {
+    public ContractCallQuery() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCreateTransaction.java
@@ -24,11 +24,20 @@ import io.grpc.MethodDescriptor;
 public class ContractCreateTransaction extends TransactionBuilder<ContractCreateTransaction> {
     private final ContractCreateTransactionBody.Builder builder = bodyBuilder.getContractCreateInstanceBuilder();
 
-    public ContractCreateTransaction(@Nullable Client client) {
-        super(client);
+    {
         // Required fixed autorenew duration (roughly 1/4 year)
         setAutoRenewPeriod(Duration.ofMinutes(131_500));
     }
+
+    /**
+     * @deprecated use the no-arg constructor and pass the client to {@link #build(Client)} instead.
+     */
+    @Deprecated
+    public ContractCreateTransaction(@Nullable Client client) {
+        super(client);
+    }
+
+    public ContractCreateTransaction() { super(); }
 
     @Override
     protected MethodDescriptor<Transaction, TransactionResponse> getMethod() {

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractDeleteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractDeleteTransaction.java
@@ -14,11 +14,15 @@ import io.grpc.MethodDescriptor;
 public final class ContractDeleteTransaction extends TransactionBuilder<ContractDeleteTransaction> {
     private final ContractDeleteTransactionBody.Builder builder = bodyBuilder.getContractDeleteInstanceBuilder();
 
+    /**
+     * @deprecated use the no-arg constructor and pass the client to {@link #build(Client)} instead.
+     */
+    @Deprecated
     public ContractDeleteTransaction(Client client) {
         super(client);
     }
 
-    ContractDeleteTransaction() {
+    public ContractDeleteTransaction() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractExecuteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractExecuteTransaction.java
@@ -18,9 +18,15 @@ import io.grpc.MethodDescriptor;
 public final class ContractExecuteTransaction extends TransactionBuilder<ContractExecuteTransaction> {
     private final ContractCallTransactionBody.Builder builder = bodyBuilder.getContractCallBuilder();
 
+    /**
+     * @deprecated use the no-arg constructor and pass the client to {@link #build(Client)} instead.
+     */
+    @Deprecated
     public ContractExecuteTransaction(@Nullable Client client) {
         super(client);
     }
+
+    public ContractExecuteTransaction() { super(); }
 
     public ContractExecuteTransaction setContractId(ContractId contractId) {
         builder.setContractID(contractId.toProto());

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractInfoQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractInfoQuery.java
@@ -14,11 +14,15 @@ import io.grpc.MethodDescriptor;
 public final class ContractInfoQuery extends QueryBuilder<ContractInfo, ContractInfoQuery> {
     private final ContractGetInfoQuery.Builder builder = inner.getContractGetInfoBuilder();
 
+    /**
+     * @deprecated {@link Client} should now be provided to {@link #execute(Client)}
+     */
+    @Deprecated
     public ContractInfoQuery(Client client) {
         super(client);
     }
 
-    ContractInfoQuery() {
+    public ContractInfoQuery() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractRecordsQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractRecordsQuery.java
@@ -15,11 +15,15 @@ import io.grpc.MethodDescriptor;
 public class ContractRecordsQuery extends QueryBuilder<ContractGetRecordsResponse, ContractRecordsQuery> {
     private final ContractGetRecordsQuery.Builder builder = inner.getContractGetRecordsBuilder();
 
+    /**
+     * @deprecated {@link Client} should now be provided to {@link #execute(Client)}
+     */
+    @Deprecated
     public ContractRecordsQuery(Client client) {
         super(client);
     }
 
-    ContractRecordsQuery() {
+    public ContractRecordsQuery() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractUpdateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractUpdateTransaction.java
@@ -22,8 +22,16 @@ import io.grpc.MethodDescriptor;
 public class ContractUpdateTransaction extends TransactionBuilder<ContractUpdateTransaction> {
     private final ContractUpdateTransactionBody.Builder builder = bodyBuilder.getContractUpdateInstanceBuilder();
 
+    /**
+     * @deprecated use the no-arg constructor and pass the client to {@link #build(Client)} instead.
+     */
+    @Deprecated
     public ContractUpdateTransaction(@Nullable Client client) {
         super(client);
+    }
+
+    public ContractUpdateTransaction() {
+        super();
     }
 
     public ContractUpdateTransaction setContractId(ContractId contract) {

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileAppendTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileAppendTransaction.java
@@ -15,9 +15,15 @@ import io.grpc.MethodDescriptor;
 public final class FileAppendTransaction extends TransactionBuilder<FileAppendTransaction> {
     private final FileAppendTransactionBody.Builder builder = bodyBuilder.getFileAppendBuilder();
 
+    /**
+     * @deprecated use the no-arg constructor and pass the client to {@link #build(Client)} instead.
+     */
+    @Deprecated
     public FileAppendTransaction(@Nullable Client client) {
         super(client);
     }
+
+    public FileAppendTransaction() { super(); }
 
     public FileAppendTransaction setFileId(FileId fileId) {
         builder.setFileID(fileId.toProto());

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileContentsQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileContentsQuery.java
@@ -15,11 +15,15 @@ import io.grpc.MethodDescriptor;
 public class FileContentsQuery extends QueryBuilder<FileGetContentsResponse, FileContentsQuery> {
     private final FileGetContentsQuery.Builder builder = inner.getFileGetContentsBuilder();
 
+    /**
+     * @deprecated {@link Client} should now be provided to {@link #execute(Client)}
+     */
+    @Deprecated
     public FileContentsQuery(Client client) {
         super(client);
     }
 
-    FileContentsQuery() {
+    public FileContentsQuery() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileCreateTransaction.java
@@ -21,9 +21,15 @@ public final class FileCreateTransaction extends TransactionBuilder<FileCreateTr
     private final FileCreateTransactionBody.Builder builder = bodyBuilder.getFileCreateBuilder();
     private final KeyList.Builder keyList = builder.getKeysBuilder();
 
+    /**
+     * @deprecated use the no-arg constructor and pass the client to {@link #build(Client)} instead.
+     */
+    @Deprecated
     public FileCreateTransaction(@Nullable Client client) {
         super(client);
     }
+
+    public FileCreateTransaction() { super(); }
 
     public FileCreateTransaction setExpirationTime(Instant expiration) {
         builder.setExpirationTime(TimestampHelper.timestampFrom(expiration));

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileDeleteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileDeleteTransaction.java
@@ -14,9 +14,15 @@ import io.grpc.MethodDescriptor;
 public final class FileDeleteTransaction extends TransactionBuilder<FileDeleteTransaction> {
     private final FileDeleteTransactionBody.Builder builder = bodyBuilder.getFileDeleteBuilder();
 
+    /**
+     * @deprecated use the no-arg constructor and pass the client to {@link #build(Client)} instead.
+     */
+    @Deprecated
     public FileDeleteTransaction(@Nullable Client client) {
         super(client);
     }
+
+    public FileDeleteTransaction() { super(); }
 
     public FileDeleteTransaction setFileId(FileId fileId) {
         builder.setFileID(fileId.toProto());

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileInfoQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileInfoQuery.java
@@ -14,11 +14,15 @@ import io.grpc.MethodDescriptor;
 public class FileInfoQuery extends QueryBuilder<FileInfo, FileInfoQuery> {
     private final FileGetInfoQuery.Builder builder = inner.getFileGetInfoBuilder();
 
+    /**
+     * @deprecated {@link Client} should now be provided to {@link #execute(Client)}
+     */
+    @Deprecated
     public FileInfoQuery(Client client) {
         super(client);
     }
 
-    FileInfoQuery() {
+    public FileInfoQuery() {
         super(null);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileUpdateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileUpdateTransaction.java
@@ -21,9 +21,15 @@ public class FileUpdateTransaction extends TransactionBuilder<FileUpdateTransact
     private final FileUpdateTransactionBody.Builder builder = bodyBuilder.getFileUpdateBuilder();
     private final KeyList.Builder keyList = builder.getKeysBuilder();
 
+    /**
+     * @deprecated use the no-arg constructor and pass the client to {@link #build(Client)} instead.
+     */
+    @Deprecated
     public FileUpdateTransaction(@Nullable Client client) {
         super(client);
     }
+
+    public FileUpdateTransaction() { super(); }
 
     public FileUpdateTransaction setFileId(FileId file) {
         builder.setFileID(file.toProto());

--- a/src/test/java/com/hedera/hashgraph/sdk/FreezeTransactionTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/FreezeTransactionTest.java
@@ -20,27 +20,27 @@ class FreezeTransactionTest {
         final TransactionId txnId = new TransactionId(new AccountId(2), now);
         final AccountId nodeAcctId = new AccountId(3);
 
-        new FreezeTransaction(null)
+        new FreezeTransaction()
             .setTransactionId(txnId)
             .setNodeAccountId(nodeAcctId)
             // start and end times being 0:00 is technically correct
             .build();
 
-            new FreezeTransaction(null)
+            new FreezeTransaction()
                 .setTransactionId(txnId)
                 .setNodeAccountId(nodeAcctId)
                 .setStartTime(OffsetTime.of(0, 0, 0, 0, ZoneOffset.UTC))
                 .setEndTime(OffsetTime.of(23, 59, 0, 0, ZoneOffset.UTC))
                 .build();
 
-        new FreezeTransaction(null)
+        new FreezeTransaction()
             .setTransactionId(txnId)
             .setNodeAccountId(nodeAcctId)
             .setStartTime(OffsetTime.of(0, 0, 0, 0, ZoneOffset.UTC))
             .setEndTime(OffsetTime.of(0, 0, 0, 0, ZoneOffset.UTC))
             .build();
 
-        new FreezeTransaction(null)
+        new FreezeTransaction()
             .setTransactionId(txnId)
             .setNodeAccountId(nodeAcctId)
             .setStartTime(OffsetTime.of(23, 59, 0, 0, ZoneOffset.UTC))
@@ -53,11 +53,12 @@ class FreezeTransactionTest {
     void serializeTest() {
         final Instant now = Instant.ofEpochSecond(1554158542);
         final Ed25519PrivateKey key = Ed25519PrivateKey.fromString("302e020100300506032b6570042204203b054fade7a2b0869c6bd4a63b7017cbae7855d12acc357bea718e2c3e805962");
-        Transaction txn = new FreezeTransaction(null)
+        Transaction txn = new FreezeTransaction()
             .setTransactionId(new TransactionId(new AccountId(2), now))
             .setNodeAccountId(new AccountId(3))
             .setStartTime(OffsetTime.of(0, 0, 0, 0, ZoneOffset.UTC))
             .setEndTime(OffsetTime.of(23, 59, 0, 0, ZoneOffset.UTC))
+            .setMaxTransactionFee(100_000_000)
             .build()
             .sign(key);
 

--- a/src/test/java/com/hedera/hashgraph/sdk/TransactionReceiptQueryTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/TransactionReceiptQueryTest.java
@@ -20,7 +20,7 @@ class TransactionReceiptQueryTest {
     private static final AccountId NODE_ACCOUNT = new AccountId(3);
     private static final AccountId USER_ACCOUNT = new AccountId(1234);
 
-    static final Transaction paymentTxn = new CryptoTransferTransaction(null)
+    static final Transaction paymentTxn = new CryptoTransferTransaction()
         .setNodeAccountId(NODE_ACCOUNT)
         .setTransactionId(new TransactionId(USER_ACCOUNT, Instant.parse("2019-04-05T12:00:00Z")))
         .addSender(USER_ACCOUNT, 10000)
@@ -73,7 +73,7 @@ class TransactionReceiptQueryTest {
         assertThrows(
             IllegalStateException.class,
             query::validate,
-            "query builder failed validation:\n" +
+            "query builder failed local validation:\n" +
                 ".setTransactionId() required"
         );
     }

--- a/src/test/java/com/hedera/hashgraph/sdk/TransactionRecordQueryTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/TransactionRecordQueryTest.java
@@ -22,7 +22,7 @@ class TransactionRecordQueryTest {
     static final AccountId NODE_ACCOUNT = new AccountId(3);
 
     @SuppressWarnings("/NullAway/")
-    static final Transaction paymentTxn = new CryptoTransferTransaction(null)
+    static final Transaction paymentTxn = new CryptoTransferTransaction()
         .setTransactionId(new TransactionId(USER_ACCT, Instant.parse("2019-04-05T12:00:00Z")))
         .setNodeAccountId(NODE_ACCOUNT)
         .addSender(USER_ACCT, 10000)
@@ -71,7 +71,7 @@ class TransactionRecordQueryTest {
         assertThrows(
             IllegalStateException.class,
             emptyQuery::validate,
-            "query builder failed validation:\n" +
+            "query builder failed local validation:\n" +
                 ".setPayment() required\n" +
                 ".setTransactionId() required"
         );

--- a/src/test/java/com/hedera/hashgraph/sdk/TransactionTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/TransactionTest.java
@@ -25,7 +25,7 @@ class TransactionTest {
     private static final TransactionId txnId = new TransactionId(acctId, txnStartAt);
 
     // a different instance for each test
-    private final Transaction txn = new FileDeleteTransaction(null)
+    private final Transaction txn = new FileDeleteTransaction()
         .setTransactionId(txnId)
         .setNodeAccountId(nodeAcctId)
         .setFileId(new FileId(0, 0, 0))
@@ -37,7 +37,7 @@ class TransactionTest {
         assertThrows(
             IllegalStateException.class,
             txn::validate,
-            "Transaction failed validation:\n"
+            "Transaction failed local validation:\n"
                 + "Transaction requires at least one signature"
         );
     }

--- a/src/test/java/com/hedera/hashgraph/sdk/account/AccountCreateTransactionTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/account/AccountCreateTransactionTest.java
@@ -17,13 +17,14 @@ class AccountCreateTransactionTest {
     @Test
     @DisplayName("empty builder fails validation")
     void emptyBuilder() {
-        assertThrows(
-            IllegalStateException.class,
-            () -> new AccountCreateTransaction(null).validate(),
-            "transaction builder failed validation:\n" +
+        assertEquals(
+            "transaction builder failed local validation:\n" +
                 ".setTransactionId() required\n" +
                 ".setNodeAccountId() required\n" +
-                ".setKey() required"
+                ".setKey() required",
+            assertThrows(
+                IllegalStateException.class,
+                () -> new AccountCreateTransaction().validate()).getMessage()
         );
     }
 
@@ -32,14 +33,15 @@ class AccountCreateTransactionTest {
     void correctBuilder() {
         final Instant now = Instant.ofEpochSecond(1554158542);
         final Ed25519PrivateKey key = Ed25519PrivateKey.fromString("302e020100300506032b6570042204203b054fade7a2b0869c6bd4a63b7017cbae7855d12acc357bea718e2c3e805962");
-        final Transaction txn = new AccountCreateTransaction(null)
+        final Transaction txn = new AccountCreateTransaction()
             .setNodeAccountId(new AccountId(3))
             .setTransactionId(new TransactionId(new AccountId(2), now))
             .setKey(key.getPublicKey())
             .setInitialBalance(450)
             .setProxyAccountId(new AccountId(1020))
             .setReceiverSignatureRequired(true)
-            .setTransactionFee(100_000)
+            .setMaxTransactionFee(100_000)
+            .build()
             .sign(key);
 
         assertEquals(

--- a/src/test/java/com/hedera/hashgraph/sdk/account/AccountDeleteTransactionTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/account/AccountDeleteTransactionTest.java
@@ -4,25 +4,28 @@ import com.hedera.hashgraph.sdk.TransactionId;
 import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
 import com.hederahashgraph.api.proto.java.Transaction;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AccountDeleteTransactionTest {
 
     @Test
     @DisplayName("empty builder fails validation")
     void emptyBuilder() {
-        Assertions.assertThrows(
-            IllegalStateException.class,
-            () -> new AccountCreateTransaction(null).validate(),
-            "transaction builder failed validation:\n" +
+        assertEquals(
+            "transaction builder failed local validation:\n" +
                 ".setTransactionId() required\n" +
                 ".setNodeAccountId() required\n" +
                 ".setTransferAccountId() required\n" +
-                ".setDeleteAccountId() required");
+                ".setDeleteAccountId() required",
+            assertThrows(
+                IllegalStateException.class,
+                () -> new AccountDeleteTransaction().validate()).getMessage());
     }
 
     @Test
@@ -31,15 +34,17 @@ class AccountDeleteTransactionTest {
         final Instant now = Instant.ofEpochSecond(1554158542);
         final Ed25519PrivateKey key = Ed25519PrivateKey.fromString("302e020100300506032b6570042204203b054fade7a2b0869c6bd4a63b7017cbae7855d12acc357bea718e2c3e805962");
         final TransactionId txnId = new TransactionId(new AccountId(2), now);
-        final Transaction txn = new AccountDeleteTransaction(null)
+        final Transaction txn = new AccountDeleteTransaction()
             .setNodeAccountId(new AccountId(3))
             .setTransactionId(txnId)
             .setTransferAccountId(new AccountId(4))
             .setDeleteAccountId(new AccountId(1))
-            .setTransactionFee(100_000)
-            .sign(key).toProto();
+            .setMaxTransactionFee(100_000)
+            .build()
+            .sign(key)
+            .toProto();
 
-        Assertions.assertEquals(
+        assertEquals(
             "sigMap {\n" +
                 "  sigPair {\n" +
                 "    pubKeyPrefix: \"\\344\\361\\300\\353L}\\315\\303\\347\\353\\021p\\263\\b\\212=\\022\\242\\227\\364\\243\\353\\342\\362\\205\\003\\375g5F\\355\\216\"\n" +

--- a/src/test/java/com/hedera/hashgraph/sdk/account/AccountInfoQueryTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/account/AccountInfoQueryTest.java
@@ -19,7 +19,7 @@ class AccountInfoQueryTest {
         Assertions.assertThrows(
             IllegalStateException.class,
             () -> new AccountInfoQuery().validate(),
-            "query builder failed validation:\n" +
+            "query builder failed local validation:\n" +
                 ".setPayment() required\n"
         );
     }
@@ -29,12 +29,13 @@ class AccountInfoQueryTest {
     void correctQuery() {
         final AccountInfoQuery query = new AccountInfoQuery()
             .setPayment(
-                new CryptoTransferTransaction(null)
+                new CryptoTransferTransaction()
                     .setTransactionId(new TransactionId(new AccountId(2), Instant.ofEpochSecond(1559868457)))
                     .setNodeAccountId(new AccountId(3))
                     .addSender(new AccountId(2), 10000)
                     .addRecipient(new AccountId(3), 10000)
-                    .setTransactionFee(100_000)
+                    .setMaxTransactionFee(100_000)
+                    .build()
                     .sign(key))
             .setAccountId(new AccountId(5));
 

--- a/src/test/java/com/hedera/hashgraph/sdk/account/AccountRecordsQueryTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/account/AccountRecordsQueryTest.java
@@ -27,12 +27,13 @@ class AccountRecordsQueryTest {
     void correctBuilder() {
         final AccountRecordsQuery query = new AccountRecordsQuery()
             .setPayment(
-                new CryptoTransferTransaction(null)
+                new CryptoTransferTransaction()
                     .setTransactionId(new TransactionId(new AccountId(2), Instant.ofEpochSecond(1559868457)))
                     .setNodeAccountId(new AccountId(3))
                     .addSender(new AccountId(2), 10000)
                     .addRecipient(new AccountId(3), 10000)
-                    .setTransactionFee(100_000)
+                    .setMaxTransactionFee(100_000)
+                    .build()
                     .sign(key))
             .setAccountId(new AccountId(5));
 

--- a/src/test/java/com/hedera/hashgraph/sdk/account/AccountStakersQueryTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/account/AccountStakersQueryTest.java
@@ -19,7 +19,7 @@ class AccountStakersQueryTest {
     @DisplayName("empty query does not validate")
     void defaultQuery() {
         assertEquals(
-            "query builder failed validation:\n" +
+            "query builder failed local validation:\n" +
                 ".setPayment() required\n" +
                 ".setAccountId() required",
             assertThrows(
@@ -35,12 +35,13 @@ class AccountStakersQueryTest {
     void correctQuery() {
         final AccountStakersQuery query = new AccountStakersQuery()
             .setPayment(
-                new CryptoTransferTransaction(null)
+                new CryptoTransferTransaction()
                     .setTransactionId(new TransactionId(new AccountId(2), Instant.ofEpochSecond(1559868457)))
                     .setNodeAccountId(new AccountId(3))
                     .addSender(new AccountId(2), 10000)
                     .addRecipient(new AccountId(3), 10000)
-                    .setTransactionFee(100_000)
+                    .setMaxTransactionFee(100_000)
+                    .build()
                     .sign(key))
             .setAccountId(new AccountId(5));
 

--- a/src/test/java/com/hedera/hashgraph/sdk/account/AccountUpdateTransactionTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/account/AccountUpdateTransactionTest.java
@@ -19,13 +19,13 @@ class AccountUpdateTransactionTest {
     @DisplayName("empty builder fails validation")
     void emptyBuilder() {
         assertEquals(
-            "transaction builder failed validation:\n"
+            "transaction builder failed local validation:\n"
                 + ".setTransactionId() required\n"
                 + ".setNodeAccountId() required\n"
                 + ".setAccountForUpdate() required",
             assertThrows(
                 IllegalStateException.class,
-                () -> new AccountUpdateTransaction(null).validate()
+                () -> new AccountUpdateTransaction().validate()
             ).getMessage()
         );
     }
@@ -36,7 +36,7 @@ class AccountUpdateTransactionTest {
         final Instant now = Instant.ofEpochSecond(1554158542);
         final Ed25519PrivateKey key = Ed25519PrivateKey.fromString("302e020100300506032b6570042204203b054fade7a2b0869c6bd4a63b7017cbae7855d12acc357bea718e2c3e805962");
         final TransactionId txnId = new TransactionId(new AccountId(2), now);
-        final Transaction txn = new AccountUpdateTransaction(null)
+        final Transaction txn = new AccountUpdateTransaction()
             .setKey(key.getPublicKey())
             .setNodeAccountId(new AccountId(3))
             .setTransactionId(txnId)
@@ -46,7 +46,8 @@ class AccountUpdateTransactionTest {
             .setReceiveRecordThreshold(6)
             .setAutoRenewPeriod(Duration.ofHours(10))
             .setExpirationTime(Instant.ofEpochSecond(1554158543))
-            .setTransactionFee(100_000)
+            .setMaxTransactionFee(100_000)
+            .build()
             .sign(key)
             .toProto();
 

--- a/src/test/java/com/hedera/hashgraph/sdk/account/CryptoTransferTransactionTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/account/CryptoTransferTransactionTest.java
@@ -18,13 +18,13 @@ class CryptoTransferTransactionTest {
     @DisplayName("empty builder fails validation")
     void emptyBuilder() {
         assertEquals(
-            "transaction builder failed validation:\n" +
+            "transaction builder failed local validation:\n" +
                 ".setTransactionId() required\n" +
                 ".setNodeAccountId() required\n" +
                 "at least one transfer required",
             assertThrows(
                 IllegalStateException.class,
-                () -> new CryptoTransferTransaction(null).validate()
+                () -> new CryptoTransferTransaction().validate()
             ).getMessage()
         );
     }
@@ -35,14 +35,16 @@ class CryptoTransferTransactionTest {
         final Instant now = Instant.ofEpochSecond(1554158542);
         final Ed25519PrivateKey key = Ed25519PrivateKey.fromString("302e020100300506032b6570042204203b054fade7a2b0869c6bd4a63b7017cbae7855d12acc357bea718e2c3e805962");
         final TransactionId txnId = new TransactionId(new AccountId(2), now);
-        final Transaction txn = new CryptoTransferTransaction(null)
+        final Transaction txn = new CryptoTransferTransaction()
             .setTransactionId(txnId)
             .setNodeAccountId(new AccountId(2))
             .addSender(new AccountId(4), 800)
             .addRecipient(new AccountId(55), 400)
             .addTransfer(new AccountId(78), 400)
-            .setTransactionFee(100_000)
-            .sign(key).toProto();
+            .setMaxTransactionFee(100_000)
+            .build()
+            .sign(key)
+            .toProto();
 
         assertEquals(
             "sigMap {\n" +

--- a/src/test/java/com/hedera/hashgraph/sdk/contract/ContractBytecodeQueryTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/contract/ContractBytecodeQueryTest.java
@@ -21,7 +21,7 @@ class ContractBytecodeQueryTest {
     @DisplayName("empty query fails validation")
     void emptyBuilder() {
         assertEquals(
-            "query builder failed validation:\n" +
+            "query builder failed local validation:\n" +
                 ".setPayment() required\n" +
                 ".setContractId() required",
             assertThrows(
@@ -36,12 +36,13 @@ class ContractBytecodeQueryTest {
     void correctBuilder() {
         final ContractBytecodeQuery query = new ContractBytecodeQuery()
             .setPayment(
-                new CryptoTransferTransaction(null)
+                new CryptoTransferTransaction()
                     .setTransactionId(new TransactionId(new AccountId(2), Instant.ofEpochSecond(1559868457)))
                     .setNodeAccountId(new AccountId(3))
                     .addSender(new AccountId(2), 10000)
                     .addRecipient(new AccountId(3), 10000)
-                    .setTransactionFee(100_000)
+                    .setMaxTransactionFee(100_000)
+                    .build()
                     .sign(key))
             .setContractId(new ContractId(0, 0, 0));
 

--- a/src/test/java/com/hedera/hashgraph/sdk/contract/ContractCallQueryTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/contract/ContractCallQueryTest.java
@@ -22,7 +22,7 @@ class ContractCallQueryTest {
     @DisplayName("empty query fails validation")
     void emptyBuilder() {
         assertEquals(
-            "query builder failed validation:\n" +
+            "query builder failed local validation:\n" +
                 ".setPayment() required\n" +
                 ".setContractId() required",
             assertThrows(
@@ -37,12 +37,13 @@ class ContractCallQueryTest {
     void correctBuilder() {
         final ContractCallQuery query = new ContractCallQuery()
             .setPayment(
-                new CryptoTransferTransaction(null)
+                new CryptoTransferTransaction()
                     .setTransactionId(new TransactionId(new AccountId(2), Instant.ofEpochSecond(1559868457)))
                     .setNodeAccountId(new AccountId(3))
                     .addSender(new AccountId(2), 10000)
                     .addRecipient(new AccountId(3), 10000)
-                    .setTransactionFee(100_000)
+                    .setMaxTransactionFee(100_000)
+                    .build()
                     .sign(key))
             .setContractId(new ContractId(0, 0, 0))
             .setGas(1541)

--- a/src/test/java/com/hedera/hashgraph/sdk/contract/ContractCreateTransactionTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/contract/ContractCreateTransactionTest.java
@@ -21,13 +21,13 @@ class ContractCreateTransactionTest {
     @DisplayName("Empty builder fails validation")
     void emptyBuilder() {
         assertEquals(
-            "transaction builder failed validation:\n" +
+            "transaction builder failed local validation:\n" +
                 ".setTransactionId() required\n" +
                 ".setNodeAccountId() required\n" +
                 ".setBytecodeFile() required",
             assertThrows(
                 IllegalStateException.class,
-                () -> new ContractCreateTransaction(null).validate()
+                () -> new ContractCreateTransaction().validate()
             ).getMessage()
         );
     }
@@ -38,7 +38,7 @@ class ContractCreateTransactionTest {
         final Instant now = Instant.ofEpochSecond(1554158542);
         final Ed25519PrivateKey key = Ed25519PrivateKey.fromString("302e020100300506032b6570042204203b054fade7a2b0869c6bd4a63b7017cbae7855d12acc357bea718e2c3e805962");
         final TransactionId txnId = new TransactionId(new AccountId(2), now);
-        final Transaction txn = new ContractCreateTransaction(null)
+        final Transaction txn = new ContractCreateTransaction()
             .setNodeAccountId(new AccountId(3))
             .setTransactionId(txnId)
             .setBytecodeFile(new FileId(1, 2, 3))
@@ -51,8 +51,9 @@ class ContractCreateTransactionTest {
             .setShard(20)
             .setRealm(40)
             .setNewRealmAdminKey(key.getPublicKey())
-            .setTransactionFee(100_000)
-            .sign(key)
+            .setMaxTransactionFee(100_000)
+                    .build()
+                    .sign(key)
             .toProto();
 
         assertEquals(

--- a/src/test/java/com/hedera/hashgraph/sdk/contract/ContractExecuteTransactionTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/contract/ContractExecuteTransactionTest.java
@@ -19,13 +19,13 @@ class ContractExecuteTransactionTest {
     @DisplayName("empty builder fails validation")
     void emptyBuilder() {
         assertEquals(
-            "transaction builder failed validation:\n"
+            "transaction builder failed local validation:\n"
                 + ".setTransactionId() required\n"
                 + ".setNodeAccountId() required\n"
                 + ".setContractId() required",
             assertThrows(
                 IllegalStateException.class,
-                () -> new ContractExecuteTransaction(null).validate()
+                () -> new ContractExecuteTransaction().validate()
             ).getMessage()
         );
     }
@@ -36,15 +36,16 @@ class ContractExecuteTransactionTest {
         final Instant now = Instant.ofEpochSecond(1554158542);
         final Ed25519PrivateKey key = Ed25519PrivateKey.fromString("302e020100300506032b6570042204203b054fade7a2b0869c6bd4a63b7017cbae7855d12acc357bea718e2c3e805962");
         final TransactionId txnId = new TransactionId(new AccountId(2), now);
-        final Transaction txn = new ContractExecuteTransaction(null)
+        final Transaction txn = new ContractExecuteTransaction()
             .setNodeAccountId(new AccountId(3))
             .setTransactionId(txnId)
             .setContractId(new ContractId(1, 2, 3))
             .setGas(10)
             .setAmount(1000)
             .setFunctionParameters(new byte[]{24, 43, 11})
-            .setTransactionFee(100_000)
-            .sign(key)
+            .setMaxTransactionFee(100_000)
+                    .build()
+                    .sign(key)
             .toProto();
 
         assertEquals(

--- a/src/test/java/com/hedera/hashgraph/sdk/contract/ContractInfoQueryTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/contract/ContractInfoQueryTest.java
@@ -21,7 +21,7 @@ class ContractInfoQueryTest {
     @DisplayName("empty builder fails validation")
     void emptyBuilder() {
         assertEquals(
-            "query builder failed validation:\n" +
+            "query builder failed local validation:\n" +
                 ".setPayment() required\n" +
                 ".setContractId() required",
             assertThrows(
@@ -36,12 +36,13 @@ class ContractInfoQueryTest {
     void correctBuilder() {
         final ContractInfoQuery query = new ContractInfoQuery()
             .setPayment(
-                new CryptoTransferTransaction(null)
+                new CryptoTransferTransaction()
                     .setTransactionId(new TransactionId(new AccountId(2), Instant.ofEpochSecond(1559868457)))
                     .setNodeAccountId(new AccountId(3))
                     .addSender(new AccountId(2), 10000)
                     .addRecipient(new AccountId(3), 10000)
-                    .setTransactionFee(100_000)
+                    .setMaxTransactionFee(100_000)
+                    .build()
                     .sign(key))
             .setContractId(new ContractId(0, 0, 0));
 

--- a/src/test/java/com/hedera/hashgraph/sdk/contract/ContractRecordsQueryTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/contract/ContractRecordsQueryTest.java
@@ -21,7 +21,7 @@ class ContractRecordsQueryTest {
     @DisplayName("empty builder fails validation")
     void emptyBuilder() {
         assertEquals(
-            "query builder failed validation:\n" +
+            "query builder failed local validation:\n" +
                 ".setPayment() required\n" +
                 ".setContractId() required",
             assertThrows(
@@ -36,12 +36,13 @@ class ContractRecordsQueryTest {
     void correctBuilder() {
         final ContractRecordsQuery query = new ContractRecordsQuery()
             .setPayment(
-                new CryptoTransferTransaction(null)
+                new CryptoTransferTransaction()
                     .setTransactionId(new TransactionId(new AccountId(2), Instant.ofEpochSecond(1559868457)))
                     .setNodeAccountId(new AccountId(3))
                     .addSender(new AccountId(2), 10000)
                     .addRecipient(new AccountId(3), 10000)
-                    .setTransactionFee(100_000)
+                    .setMaxTransactionFee(100_000)
+                    .build()
                     .sign(key))
             .setContractId(new ContractId(0, 0, 0));
 

--- a/src/test/java/com/hedera/hashgraph/sdk/contract/ContractUpdateTransactionTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/contract/ContractUpdateTransactionTest.java
@@ -19,13 +19,13 @@ class ContractUpdateTransactionTest {
     @DisplayName("empty builder fails validation")
     void emptyBuilder() {
         assertEquals(
-            "transaction builder failed validation:\n"
+            "transaction builder failed local validation:\n"
                 + ".setTransactionId() required\n"
                 + ".setNodeAccountId() required\n"
                 + ".setContractId() required",
             assertThrows(
                 IllegalStateException.class,
-                () -> new ContractUpdateTransaction(null).validate()
+                () -> new ContractUpdateTransaction().validate()
             ).getMessage());
     }
 
@@ -35,12 +35,13 @@ class ContractUpdateTransactionTest {
         final Instant now = Instant.ofEpochSecond(1554158542);
         final Ed25519PrivateKey key = Ed25519PrivateKey.fromString("302e020100300506032b6570042204203b054fade7a2b0869c6bd4a63b7017cbae7855d12acc357bea718e2c3e805962");
         final TransactionId txnId = new TransactionId(new AccountId(2), now);
-        final Transaction txn = new ContractUpdateTransaction(null)
+        final Transaction txn = new ContractUpdateTransaction()
             .setNodeAccountId(new AccountId(3))
             .setTransactionId(txnId)
             .setContractId(new ContractId(1, 2, 3))
-            .setTransactionFee(100_000)
-            .sign(key)
+            .setMaxTransactionFee(100_000)
+                    .build()
+                    .sign(key)
             .toProto();
 
         assertEquals(

--- a/src/test/java/com/hedera/hashgraph/sdk/file/FileAppendTransactionTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/file/FileAppendTransactionTest.java
@@ -19,14 +19,14 @@ class FileAppendTransactionTest {
     @DisplayName("empty builder fails validation")
     void emptyBuilder() {
         assertEquals(
-            "transaction builder failed validation:\n"
+            "transaction builder failed local validation:\n"
                 + ".setTransactionId() required\n"
                 + ".setNodeAccountId() required\n"
                 + ".setFileId() required\n"
                 + ".setContents() required",
             assertThrows(
                 IllegalStateException.class,
-                () -> new FileAppendTransaction(null).validate()
+                () -> new FileAppendTransaction().validate()
             ).getMessage());
     }
 
@@ -36,13 +36,14 @@ class FileAppendTransactionTest {
         final Instant now = Instant.ofEpochSecond(1554158542);
         final Ed25519PrivateKey key = Ed25519PrivateKey.fromString("302e020100300506032b6570042204203b054fade7a2b0869c6bd4a63b7017cbae7855d12acc357bea718e2c3e805962");
         final TransactionId txnId = new TransactionId(new AccountId(2), now);
-        final Transaction txn = new FileAppendTransaction(null)
+        final Transaction txn = new FileAppendTransaction()
             .setNodeAccountId(new AccountId(3))
             .setTransactionId(txnId)
             .setFileId(new FileId(1, 2, 3))
             .setContents(new byte[]{1, 2, 3, 4})
-            .setTransactionFee(100_000)
-            .sign(key)
+            .setMaxTransactionFee(100_000)
+                    .build()
+                    .sign(key)
             .toProto();
 
         assertEquals(

--- a/src/test/java/com/hedera/hashgraph/sdk/file/FileContentsQueryTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/file/FileContentsQueryTest.java
@@ -21,7 +21,7 @@ class FileContentsQueryTest {
     @DisplayName("empty builder fails validation")
     void emptyBuilder() {
         assertEquals(
-            "query builder failed validation:\n" +
+            "query builder failed local validation:\n" +
                 ".setPayment() required\n" +
                 ".setFileId() required",
             assertThrows(
@@ -36,12 +36,12 @@ class FileContentsQueryTest {
     void correctBuilder() {
         final FileContentsQuery query = new FileContentsQuery()
             .setPayment(
-                new CryptoTransferTransaction(null)
+                new CryptoTransferTransaction()
                     .setTransactionId(new TransactionId(new AccountId(2), Instant.ofEpochSecond(1559868457)))
                     .setNodeAccountId(new AccountId(3))
                     .addSender(new AccountId(2), 10000)
                     .addRecipient(new AccountId(3), 10000)
-                    .setTransactionFee(100_000)
+                    .setMaxTransactionFee(100_000)
                     .sign(key))
             .setFileId(new FileId(1, 2, 3));
 

--- a/src/test/java/com/hedera/hashgraph/sdk/file/FileCreateTransactionTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/file/FileCreateTransactionTest.java
@@ -19,12 +19,12 @@ class FileCreateTransactionTest {
     @DisplayName("empty builder fails validation")
     void emptyBuilder() {
         assertEquals(
-            "transaction builder failed validation:\n"
+            "transaction builder failed local validation:\n"
                 + ".setTransactionId() required\n"
                 + ".setNodeAccountId() required",
             assertThrows(
                 IllegalStateException.class,
-                () -> new FileCreateTransaction(null).validate()
+                () -> new FileCreateTransaction().validate()
             ).getMessage());
     }
 
@@ -34,14 +34,15 @@ class FileCreateTransactionTest {
         final Instant now = Instant.ofEpochSecond(1554158542);
         final Ed25519PrivateKey key = Ed25519PrivateKey.fromString("302e020100300506032b6570042204203b054fade7a2b0869c6bd4a63b7017cbae7855d12acc357bea718e2c3e805962");
         final TransactionId txnId = new TransactionId(new AccountId(2), now);
-        final Transaction txn = new FileCreateTransaction(null)
+        final Transaction txn = new FileCreateTransaction()
             .setNodeAccountId(new AccountId(3))
             .setTransactionId(txnId)
             .setContents(new byte[]{1, 2, 3, 4})
             .setExpirationTime(Instant.ofEpochSecond(1554158728))
             .addKey(key.getPublicKey())
             .setNewRealmAdminKey(key.getPublicKey())
-            .setTransactionFee(100_000)
+            .setMaxTransactionFee(100_000)
+            .build()
             .sign(key)
             .toProto();
 
@@ -63,10 +64,11 @@ class FileCreateTransactionTest {
         final Instant now = Instant.ofEpochSecond(1554158542);
         final Ed25519PrivateKey key = Ed25519PrivateKey.fromString("302e020100300506032b6570042204203b054fade7a2b0869c6bd4a63b7017cbae7855d12acc357bea718e2c3e805962");
         final TransactionId txnId = new TransactionId(new AccountId(2), now);
-        final Transaction txn = new FileCreateTransaction(null)
+        final Transaction txn = new FileCreateTransaction()
             .setNodeAccountId(new AccountId(3))
             .setTransactionId(txnId)
-            .setTransactionFee(100_000)
+            .setMaxTransactionFee(100_000)
+            .build()
             .sign(key)
             .toProto();
 

--- a/src/test/java/com/hedera/hashgraph/sdk/file/FileDeleteTransactionTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/file/FileDeleteTransactionTest.java
@@ -19,13 +19,13 @@ class FileDeleteTransactionTest {
     @DisplayName("empty builder fails validation")
     void emptyBuilder() {
         assertEquals(
-            "transaction builder failed validation:\n"
+            "transaction builder failed local validation:\n"
                 + ".setTransactionId() required\n"
                 + ".setNodeAccountId() required\n"
                 + ".setFileId() required",
             assertThrows(
                 IllegalStateException.class,
-                () -> new FileDeleteTransaction(null).validate()
+                () -> new FileDeleteTransaction().validate()
             ).getMessage());
     }
 
@@ -35,12 +35,13 @@ class FileDeleteTransactionTest {
         final Instant now = Instant.ofEpochSecond(1554158542);
         final Ed25519PrivateKey key = Ed25519PrivateKey.fromString("302e020100300506032b6570042204203b054fade7a2b0869c6bd4a63b7017cbae7855d12acc357bea718e2c3e805962");
         final TransactionId txnId = new TransactionId(new AccountId(2), now);
-        final Transaction txn = new FileDeleteTransaction(null)
+        final Transaction txn = new FileDeleteTransaction()
             .setNodeAccountId(new AccountId(3))
             .setTransactionId(txnId)
             .setFileId(new FileId(1, 2, 3))
-            .setTransactionFee(100_000)
-            .sign(key)
+            .setMaxTransactionFee(100_000)
+                    .build()
+                    .sign(key)
             .toProto();
 
         assertEquals(

--- a/src/test/java/com/hedera/hashgraph/sdk/file/FileInfoQueryTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/file/FileInfoQueryTest.java
@@ -21,7 +21,7 @@ class FileInfoQueryTest {
     @DisplayName("empty builder fails validation")
     void emptyBuilder() {
         assertEquals(
-            "query builder failed validation:\n" +
+            "query builder failed local validation:\n" +
                 ".setPayment() required\n" +
                 ".setFileId() required",
             assertThrows(
@@ -36,12 +36,13 @@ class FileInfoQueryTest {
     void correctBuilder() {
         final FileInfoQuery query = new FileInfoQuery()
             .setPayment(
-                new CryptoTransferTransaction(null)
+                new CryptoTransferTransaction()
                     .setTransactionId(new TransactionId(new AccountId(2), Instant.ofEpochSecond(1559868457)))
                     .setNodeAccountId(new AccountId(3))
                     .addSender(new AccountId(2), 10000)
                     .addRecipient(new AccountId(3), 10000)
-                    .setTransactionFee(100_000)
+                    .setMaxTransactionFee(100_000)
+                    .build()
                     .sign(key))
             .setFileId(new FileId(1, 2, 3));
 

--- a/src/test/java/com/hedera/hashgraph/sdk/file/FileUpdateTransactionTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/file/FileUpdateTransactionTest.java
@@ -19,13 +19,13 @@ class FileUpdateTransactionTest {
     @DisplayName("empty builder fails validation")
     void emptyBuilder() {
         assertEquals(
-            "transaction builder failed validation:\n"
+            "transaction builder failed local validation:\n"
                 + ".setTransactionId() required\n"
                 + ".setNodeAccountId() required\n"
                 + ".setFileId() required",
             assertThrows(
                 IllegalStateException.class,
-                () -> new FileUpdateTransaction(null).validate()
+                () -> new FileUpdateTransaction().validate()
             ).getMessage());
     }
 
@@ -35,7 +35,7 @@ class FileUpdateTransactionTest {
         final Instant now = Instant.ofEpochSecond(1554158542);
         final Ed25519PrivateKey key = Ed25519PrivateKey.fromString("302e020100300506032b6570042204203b054fade7a2b0869c6bd4a63b7017cbae7855d12acc357bea718e2c3e805962");
         final TransactionId txnId = new TransactionId(new AccountId(2), now);
-        final Transaction txn = new FileUpdateTransaction(null)
+        final Transaction txn = new FileUpdateTransaction()
             .setNodeAccountId(new AccountId(3))
             .setTransactionId(txnId)
             .setFileId(new FileId(1, 2, 3))


### PR DESCRIPTION
This brings the APIs into parity with the JS SDK, which made these changes back in https://github.com/hashgraph/hedera-sdk-js/pull/95