### PR TITLE
Move optional timeout to before the callback parameters

### DIFF
--- a/src/main/java/com/hedera/hashgraph/sdk/HederaCall.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/HederaCall.java
@@ -91,10 +91,10 @@ public abstract class HederaCall<Req, RawResp, Resp, T extends HederaCall<Req, R
     }
 
     public final void executeAsync(Client client, Consumer<Resp> onSuccess, Consumer<HederaThrowable> onError) {
-        executeAsync(client, onSuccess, onError, getDefaultTimeout());
+        executeAsync(client, getDefaultTimeout(), onSuccess, onError);
     }
 
-    public void executeAsync(Client client, Consumer<Resp> onSuccess, Consumer<HederaThrowable> onError, Duration retryTimeout) {
+    public void executeAsync(Client client, Duration retryTimeout, Consumer<Resp> onSuccess, Consumer<HederaThrowable> onError) {
         if (isExecuted) {
             throw new IllegalStateException("call already executed");
         }
@@ -112,14 +112,14 @@ public abstract class HederaCall<Req, RawResp, Resp, T extends HederaCall<Req, R
      */
     @Deprecated
     public final void executeAsync(Consumer<Resp> onSuccess, Consumer<HederaThrowable> onError) {
-        executeAsync(onSuccess, onError, getDefaultTimeout());
+        executeAsync(getDefaultTimeout(), onSuccess, onError);
     }
 
     /**
-     * @deprecated use {@link #executeAsync(Client, Consumer, Consumer, Duration)} instead.
+     * @deprecated use {@link #executeAsync(Client, Duration, Consumer, Consumer)} instead.
      */
     @Deprecated
-    public final void executeAsync(Consumer<Resp> onSuccess, Consumer<HederaThrowable> onError, Duration retryTimeout) {
+    public final void executeAsync(Duration retryTimeout, Consumer<Resp> onSuccess, Consumer<HederaThrowable> onError) {
         if (isExecuted) {
             throw new IllegalStateException("call already executed");
         }
@@ -140,16 +140,16 @@ public abstract class HederaCall<Req, RawResp, Resp, T extends HederaCall<Req, R
      */
     @Deprecated
     public final void executeAsync(BiConsumer<T, Resp> onSuccess, BiConsumer<T, HederaThrowable> onError) {
-        executeAsync(onSuccess, onError, getDefaultTimeout());
+        executeAsync(getDefaultTimeout(), onSuccess, onError);
     }
 
     /**
-     * Equivalent to {@link #executeAsync(Consumer, Consumer, Duration)} but providing {@code this}
+     * Equivalent to {@link #executeAsync(Duration, Consumer, Consumer)} but providing {@code this}
      * to the callback for additional context.
      */
-    public final void executeAsync(BiConsumer<T, Resp> onSuccess, BiConsumer<T, HederaThrowable> onError, Duration timeout) {
+    public final void executeAsync(Duration timeout, BiConsumer<T, Resp> onSuccess, BiConsumer<T, HederaThrowable> onError) {
         //noinspection unchecked
-        executeAsync(resp -> onSuccess.accept((T) this, resp), err -> onError.accept((T) this, err), timeout);
+        executeAsync(timeout, resp -> onSuccess.accept((T) this, resp), err -> onError.accept((T) this, err));
     }
 
     /**

--- a/src/main/java/com/hedera/hashgraph/sdk/QueryBuilder.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/QueryBuilder.java
@@ -219,7 +219,7 @@ public abstract class QueryBuilder<Resp, T extends QueryBuilder<Resp, T>> extend
     }
 
     @Override
-    public final void executeAsync(Client client, Consumer<Resp> onSuccess, Consumer<HederaThrowable> onError, Duration timeout) {
+    public final void executeAsync(Client client, Duration timeout, Consumer<Resp> onSuccess, Consumer<HederaThrowable> onError) {
         final long maxQueryPayment = requireClient().getMaxQueryPayment();
 
         if (!getHeaderBuilder().hasPayment() && isPaymentRequired() && maxQueryPayment > 0) {
@@ -230,10 +230,10 @@ public abstract class QueryBuilder<Resp, T extends QueryBuilder<Resp, T>> extend
                 }
                 paymentAmount = cost;
 
-                super.executeAsync(client, onSuccess, onError, timeout);
+                super.executeAsync(client, timeout, onSuccess, onError);
             }, onError);
         } else {
-            super.executeAsync(client, onSuccess, onError, timeout);
+            super.executeAsync(client, timeout, onSuccess, onError);
         }
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -158,10 +158,10 @@ public final class Transaction extends HederaCall<com.hederahashgraph.api.proto.
             .executeAsync(client, onReceipt, onError);
     }
 
-    public void getReceiptAsync(Client client, Consumer<TransactionReceipt> onReceipt, Consumer<HederaThrowable> onError, Duration timeout) {
+    public void getReceiptAsync(Client client, Duration timeout, Consumer<TransactionReceipt> onReceipt, Consumer<HederaThrowable> onError) {
         new TransactionReceiptQuery()
             .setTransactionId(id)
-            .executeAsync(client, onReceipt, onError, timeout);
+            .executeAsync(client, timeout, onReceipt, onError);
     }
 
     public TransactionRecord getRecord(Client client) throws HederaException, HederaNetworkException {
@@ -182,10 +182,10 @@ public final class Transaction extends HederaCall<com.hederahashgraph.api.proto.
             .executeAsync(client, onRecord, onError);
     }
 
-    public void getRecordAsync(Client client, Consumer<TransactionRecord> onRecord, Consumer<HederaThrowable> onError, Duration timeout) {
+    public void getRecordAsync(Client client, Duration timeout, Consumer<TransactionRecord> onRecord, Consumer<HederaThrowable> onError) {
         new TransactionRecordQuery()
             .setTransactionId(id)
-            .executeAsync(client, onRecord, onError, timeout);
+            .executeAsync(client, timeout, onRecord, onError);
     }
 
     @Override


### PR DESCRIPTION
When reviewing, it was surprising that timeout came after the async callback parameters.

---

After we decide on the change, can you help me identify what functions need a deprecated equivalent.