### PR TITLE
fix javadoc package exclusion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
                 </executions>
                 <configuration>
                     <additionalJOption>-Xdoclint:none</additionalJOption>
-                    <excludePackageNames>com.hedera.hashgraph.proto.*</excludePackageNames>
+                    <excludePackageNames>com.hedera.hashgraph.proto</excludePackageNames>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
@mehcode I think `proto.*` just excludes subpackages but `proto` will exclude that package and all subpackages: https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#excludePackageNames

closes #287 