### PR TITLE
ConsensusMessage doesn't have a public constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         </repository>
         <repository>
             <id>com.bintray.jcenter</id>
-            <url>http://jcenter.bintray.com/</url>
+            <url>https://jcenter.bintray.com/</url>
             <name>JCenter</name>
             <snapshots>
                 <enabled>false</enabled>

--- a/src/main/java/com/hedera/hashgraph/sdk/consensus/ConsensusMessage.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/consensus/ConsensusMessage.java
@@ -19,7 +19,7 @@ public class ConsensusMessage {
 
     public final long sequenceNumber;
 
-    ConsensusMessage(ConsensusTopicId topicId, ConsensusTopicResponse message) {
+    public ConsensusMessage(ConsensusTopicId topicId, ConsensusTopicResponse message) {
         Experimental.requireFor(ConsensusMessage.class.getName());
 
         this.topicId = topicId;


### PR DESCRIPTION
Added public constructor to `ConsensusMessage` per issue description

Fixes #292 