### PR TITLE
deprecate shard/realm/adminKey setters for Create txns

### DIFF
--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountCreateTransaction.java
@@ -1,16 +1,16 @@
 package com.hedera.hashgraph.sdk.account;
 
+import com.hedera.hashgraph.proto.CryptoCreateTransactionBody;
+import com.hedera.hashgraph.proto.CryptoServiceGrpc;
+import com.hedera.hashgraph.proto.RealmID;
+import com.hedera.hashgraph.proto.ShardID;
+import com.hedera.hashgraph.proto.Transaction;
+import com.hedera.hashgraph.proto.TransactionResponse;
 import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.DurationHelper;
 import com.hedera.hashgraph.sdk.TransactionBuilder;
 import com.hedera.hashgraph.sdk.TransactionId;
 import com.hedera.hashgraph.sdk.crypto.PublicKey;
-import com.hedera.hashgraph.proto.CryptoCreateTransactionBody;
-import com.hedera.hashgraph.proto.RealmID;
-import com.hedera.hashgraph.proto.ShardID;
-import com.hedera.hashgraph.proto.Transaction;
-import com.hedera.hashgraph.proto.TransactionResponse;
-import com.hedera.hashgraph.proto.CryptoServiceGrpc;
 
 import java.time.Duration;
 
@@ -91,6 +91,11 @@ public final class AccountCreateTransaction extends TransactionBuilder<AccountCr
         return this;
     }
 
+    /**
+     * @deprecated shards and realms are not yet implemented on Hedera so this method won't
+     * function as expected. It will be restored when the network functionality is available.
+     */
+    @Deprecated
     public AccountCreateTransaction setShardId(long shardId) {
         builder.setShardID(
             ShardID.newBuilder()
@@ -99,6 +104,11 @@ public final class AccountCreateTransaction extends TransactionBuilder<AccountCr
         return this;
     }
 
+    /**
+     * @deprecated shards and realms are not yet implemented on Hedera so this method won't
+     * function as expected. It will be restored when the network functionality is available.
+     */
+    @Deprecated
     public AccountCreateTransaction setRealmId(long realmId) {
         builder.setRealmID(
             RealmID.newBuilder()
@@ -107,6 +117,11 @@ public final class AccountCreateTransaction extends TransactionBuilder<AccountCr
         return this;
     }
 
+    /**
+     * @deprecated shards and realms are not yet implemented on Hedera so this method won't
+     * function as expected. It will be restored when the network functionality is available.
+     */
+    @Deprecated
     public AccountCreateTransaction setNewRealmAdminKey(PublicKey publicKey) {
         builder.setNewRealmAdminKey(publicKey.toKeyProto());
         return this;

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCreateTransaction.java
@@ -112,6 +112,11 @@ public class ContractCreateTransaction extends TransactionBuilder<ContractCreate
         return this;
     }
 
+    /**
+     * @deprecated shards and realms are not yet implemented on Hedera so this method won't
+     * function as expected. It will be restored when the network functionality is available.
+     */
+    @Deprecated
     public ContractCreateTransaction setShard(long shardId) {
         builder.setShardID(
             ShardID.newBuilder()
@@ -119,6 +124,11 @@ public class ContractCreateTransaction extends TransactionBuilder<ContractCreate
         return this;
     }
 
+    /**
+     * @deprecated shards and realms are not yet implemented on Hedera so this method won't
+     * function as expected. It will be restored when the network functionality is available.
+     */
+    @Deprecated
     public ContractCreateTransaction setRealm(long realmId) {
         builder.setRealmID(
             RealmID.newBuilder()
@@ -126,6 +136,11 @@ public class ContractCreateTransaction extends TransactionBuilder<ContractCreate
         return this;
     }
 
+    /**
+     * @deprecated shards and realms are not yet implemented on Hedera so this method won't
+     * function as expected. It will be restored when the network functionality is available.
+     */
+    @Deprecated
     public ContractCreateTransaction setNewRealmAdminKey(PublicKey newRealmAdminKey) {
         builder.setNewRealmAdminKey(newRealmAdminKey.toKeyProto());
         return this;

--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileCreateTransaction.java
@@ -1,15 +1,15 @@
 package com.hedera.hashgraph.sdk.file;
 
 import com.google.protobuf.ByteString;
+import com.hedera.hashgraph.proto.FileCreateTransactionBody;
+import com.hedera.hashgraph.proto.FileServiceGrpc;
+import com.hedera.hashgraph.proto.KeyList;
+import com.hedera.hashgraph.proto.Transaction;
+import com.hedera.hashgraph.proto.TransactionResponse;
 import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.TimestampHelper;
 import com.hedera.hashgraph.sdk.TransactionBuilder;
 import com.hedera.hashgraph.sdk.crypto.PublicKey;
-import com.hedera.hashgraph.proto.FileCreateTransactionBody;
-import com.hedera.hashgraph.proto.KeyList;
-import com.hedera.hashgraph.proto.Transaction;
-import com.hedera.hashgraph.proto.TransactionResponse;
-import com.hedera.hashgraph.proto.FileServiceGrpc;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -57,6 +57,11 @@ public final class FileCreateTransaction extends TransactionBuilder<FileCreateTr
         return this;
     }
 
+    /**
+     * @deprecated shards and realms are not yet implemented on Hedera so this method won't
+     * do anything. It will be restored when the network functionality is available.
+     */
+    @Deprecated
     public FileCreateTransaction setNewRealmAdminKey(PublicKey key) {
         builder.setNewRealmAdminKey(key.toKeyProto());
         return this;


### PR DESCRIPTION
Since shards and realms are not yet implemented on the network, these methods won't function as expected.

Additionally, we never implemented `setShardId()` or `setRealmId()` for `FileCreate` because we didn't know the expected semantics of the nested `ShardID` and `RealmID` objects (if their fields were supposed to be mutually exclusive or what).