### PR TITLE
rename `Transaction.setMemo()` to `setTransactionMemo()`

### DIFF
--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/MultiAppTransfer.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/MultiAppTransfer.java
@@ -63,7 +63,7 @@ public final class MultiAppTransfer {
             .addSender(OPERATOR_ID, transferAmount)
             .addRecipient(exchangeAccountId, transferAmount)
             // the exchange-provided memo required to validate the transaction
-            .setMemo("https://some-exchange.com/user1/account1")
+            .setTransactionMemo("https://some-exchange.com/user1/account1")
             // To manually sign, you must explicitly build the Transaction
             .build(client)
             .sign(userKey);

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/TransferCrypto.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/TransferCrypto.java
@@ -1,6 +1,9 @@
 package com.hedera.hashgraph.sdk.examples.advanced;
 
-import com.hedera.hashgraph.sdk.*;
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.HederaException;
+import com.hedera.hashgraph.sdk.TransactionId;
+import com.hedera.hashgraph.sdk.TransactionRecord;
 import com.hedera.hashgraph.sdk.account.AccountId;
 import com.hedera.hashgraph.sdk.account.CryptoTransferTransaction;
 import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
@@ -43,7 +46,7 @@ public final class TransferCrypto {
             // both sides is equivalent
             .addSender(OPERATOR_ID, amount)
             .addRecipient(recipientId, amount)
-            .setMemo("transfer test")
+            .setTransactionMemo("transfer test")
             .execute(client);
 
         System.out.println("transaction ID: " + transactionId);

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
@@ -1,9 +1,9 @@
 package com.hedera.hashgraph.sdk;
 
-import com.hedera.hashgraph.sdk.account.AccountId;
-import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
 import com.hedera.hashgraph.proto.TransactionBody;
 import com.hedera.hashgraph.proto.TransactionResponse;
+import com.hedera.hashgraph.sdk.account.AccountId;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
 
 import java.time.Duration;
 import java.util.Objects;
@@ -117,13 +117,24 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
      * Sets any notes or description that should be put into the transaction record (if one is
      * requested). Note that a max of length of 100 is enforced.
      */
-    public final T setMemo(String memo) {
+    public final T setTransactionMemo(String memo) {
         if (memo.length() > MAX_MEMO_LENGTH) {
             throw new IllegalArgumentException("memo must not be longer than 100 characters");
         }
 
         bodyBuilder.setMemo(memo);
         return self();
+    }
+
+    /**
+     * Sets any notes or description that should be put into the transaction record (if one is
+     * requested). Note that a max of length of 100 is enforced.
+     *
+     * @deprecated renamed to {@link #setTransactionMemo(String)}
+     */
+    @Deprecated
+    public final T setMemo(String memo) {
+        return setTransactionMemo(memo);
     }
 
     protected abstract void doValidate();

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCreateTransaction.java
@@ -133,7 +133,7 @@ public class ContractCreateTransaction extends TransactionBuilder<ContractCreate
 
     /**
      * Set a memo for the contract itself, as opposed to for this transaction
-     * (via {@link #setMemo(String)}).
+     * (via {@link #setTransactionMemo(String)}).
      */
     public ContractCreateTransaction setContractMemo(String memo) {
         builder.setMemo(memo);

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractUpdateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractUpdateTransaction.java
@@ -75,7 +75,7 @@ public class ContractUpdateTransaction extends TransactionBuilder<ContractUpdate
 
     /**
      * Set a memo for the contract itself, as opposed to for this transaction
-     * (via {@link #setMemo(String)}).
+     * (via {@link #setTransactionMemo(String)}).
      */
     public ContractUpdateTransaction setContractMemo(String memo) {
         builder.setMemo(memo);


### PR DESCRIPTION
This makes it harder to confuse with `ContractCreateTransaction.setContractMemo()` and `ConsensusTopicCreateTransaction.setTopicMemo()`.