### PR TITLE
TransactionRecord API changes

### DIFF
--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionRecord.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionRecord.java
@@ -40,7 +40,7 @@ public final class TransactionRecord {
      * the transaction, or by a smart contract it calls, or by the creation of threshold
      * records that it triggers.
      */
-    public final List<Transfer> transfers;
+    public final List<com.hedera.hashgraph.sdk.Transfer> transfers;
 
     private final com.hedera.hashgraph.proto.TransactionRecord inner;
 
@@ -60,7 +60,7 @@ public final class TransactionRecord {
             ? inner.getTransferList()
             .getAccountAmountsList()
             .stream()
-            .map(Transfer::new)
+            .map(com.hedera.hashgraph.sdk.Transfer::new)
             .collect(Collectors.toList())
             : Collections.emptyList();
     }
@@ -152,16 +152,22 @@ public final class TransactionRecord {
      * transaction, or by a smart contract it calls, or by the creation of threshold
      * records that it triggers.
      *
-     * @deprecated available as field {@link #transfers}.
+     * @deprecated available as field {@link #transfers}; note the {@code Transfer} class is
+     * different.
      */
     @Deprecated
-    public List<Transfer> getTransfers() {
-        return transfers;
+    public List<TransactionRecord.Transfer> getTransfers() {
+        return inner.hasTransferList()
+            ? inner.getTransferList()
+            .getAccountAmountsList()
+            .stream()
+            .map(Transfer::new)
+            .collect(Collectors.toList())
+            : Collections.emptyList();
     }
 
     /**
-     * @deprecated this class is being hoisted to a top level class in 1.0; it is not changing
-     * otherwise.
+     * @deprecated this class is being hoisted to a top level class in 1.0.
      */
     @Deprecated
     public final static class Transfer {

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionRecord.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionRecord.java
@@ -27,13 +27,20 @@ public final class TransactionRecord {
 
     /** The memo that was submitted as part of the transaction (max 100 bytes) */
     @Nullable
-    public final String memo;
+    public final String transactionMemo;
 
     /**
      * The status (reach consensus, or failed, or is unknown), and the ID of any
      * new account/file/instance created
      */
     public final TransactionReceipt receipt;
+
+    /**
+     * All Hbar transfers as a result of this transaction, such as fees, or transfers performed by
+     * the transaction, or by a smart contract it calls, or by the creation of threshold
+     * records that it triggers.
+     */
+    public final List<Transfer> transfers;
 
     private final com.hedera.hashgraph.proto.TransactionRecord inner;
 
@@ -47,7 +54,15 @@ public final class TransactionRecord {
         consensusTimestamp = inner.hasConsensusTimestamp() ? TimestampHelper.timestampTo(inner.getConsensusTimestamp()) : null;
 
         String memo = inner.getMemo();
-        this.memo = memo.isEmpty() ? null : memo;
+        this.transactionMemo = memo.isEmpty() ? null : memo;
+
+        this.transfers = inner.hasTransferList()
+            ? inner.getTransferList()
+            .getAccountAmountsList()
+            .stream()
+            .map(Transfer::new)
+            .collect(Collectors.toList())
+            : Collections.emptyList();
     }
 
     @Deprecated
@@ -79,7 +94,7 @@ public final class TransactionRecord {
     @Deprecated
     @Nullable
     public String getMemo() {
-        return memo;
+        return transactionMemo;
     }
 
     /**
@@ -136,15 +151,12 @@ public final class TransactionRecord {
      * All Hbar transfers as a result of this transaction, such as fees, or transfers performed by the
      * transaction, or by a smart contract it calls, or by the creation of threshold
      * records that it triggers.
+     *
+     * @deprecated available as field {@link #transfers}.
      */
+    @Deprecated
     public List<Transfer> getTransfers() {
-        return inner.hasTransferList()
-            ? inner.getTransferList()
-                .getAccountAmountsList()
-                .stream()
-                .map(Transfer::new)
-                .collect(Collectors.toList())
-            : Collections.emptyList();
+        return transfers;
     }
 
     public final static class Transfer {

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionRecord.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionRecord.java
@@ -159,6 +159,11 @@ public final class TransactionRecord {
         return transfers;
     }
 
+    /**
+     * @deprecated this class is being hoisted to a top level class in 1.0; it is not changing
+     * otherwise.
+     */
+    @Deprecated
     public final static class Transfer {
         public final AccountId account;
         public final long amount;

--- a/src/main/java/com/hedera/hashgraph/sdk/Transfer.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Transfer.java
@@ -1,0 +1,17 @@
+package com.hedera.hashgraph.sdk;
+
+import com.hedera.hashgraph.proto.AccountAmountOrBuilder;
+import com.hedera.hashgraph.sdk.account.AccountId;
+
+/**
+ * A transfer in a {@link TransactionRecord}.
+ */
+public final class Transfer {
+    public final AccountId accountId;
+    public final Hbar amount;
+
+    Transfer(AccountAmountOrBuilder accountAmount) {
+        accountId = new AccountId(accountAmount.getAccountIDOrBuilder());
+        amount = Hbar.fromTinybar(accountAmount.getAmount());
+    }
+}


### PR DESCRIPTION
* deprecated `getTransfers()` in favor of field `transfers`
* (breaking-beta) renamed `memo` to `transactionMemo`