### PR TITLE
set minimum cost for `FileInfoQuery`

### DIFF
--- a/src/main/java/com/hedera/hashgraph/sdk/file/FileInfoQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/file/FileInfoQuery.java
@@ -1,12 +1,17 @@
 package com.hedera.hashgraph.sdk.file;
 
-import com.hedera.hashgraph.sdk.Client;
-import com.hedera.hashgraph.sdk.QueryBuilder;
 import com.hedera.hashgraph.proto.FileGetInfoQuery;
+import com.hedera.hashgraph.proto.FileServiceGrpc;
 import com.hedera.hashgraph.proto.Query;
 import com.hedera.hashgraph.proto.QueryHeader;
 import com.hedera.hashgraph.proto.Response;
-import com.hedera.hashgraph.proto.FileServiceGrpc;
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.HederaException;
+import com.hedera.hashgraph.sdk.HederaNetworkException;
+import com.hedera.hashgraph.sdk.HederaThrowable;
+import com.hedera.hashgraph.sdk.QueryBuilder;
+
+import java.util.function.Consumer;
 
 import io.grpc.MethodDescriptor;
 
@@ -49,5 +54,19 @@ public class FileInfoQuery extends QueryBuilder<FileInfo, FileInfoQuery> {
     @Override
     protected void doValidate() {
         require(builder.hasFileID(), ".setFileId() required");
+    }
+
+    @Override
+    public long getCost(Client client) throws HederaException, HederaNetworkException {
+        // deleted files return a COST_ANSWER of zero which triggers `INSUFFICIENT_TX_FEE`
+        // if you set that as the query payment; 25 tinybar seems to be the minimum to get
+        // `FILE_DELETED` back instead.
+        return Math.min(super.getCost(client), 25);
+    }
+
+    @Override
+    public void getCostAsync(Client client, Consumer<Long> withCost, Consumer<HederaThrowable> onError) {
+        // see above
+        super.getCostAsync(client, (cost) -> withCost.accept(Math.min(cost, 25)), onError);
     }
 }


### PR DESCRIPTION
This is so it returns `FILE_DELETED` instead of `INSUFFICIENT_TX_FEE` for deleted files, where we get back a `COST_ANSWER` of 0.

closes #320 