### PR TITLE
cover some network idiosyncrasies

### DIFF
--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/DeleteAccount.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/DeleteAccount.java
@@ -1,0 +1,76 @@
+package com.hedera.hashgraph.sdk.examples.advanced;
+
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.HederaException;
+import com.hedera.hashgraph.sdk.TransactionId;
+import com.hedera.hashgraph.sdk.TransactionReceipt;
+import com.hedera.hashgraph.sdk.account.AccountCreateTransaction;
+import com.hedera.hashgraph.sdk.account.AccountDeleteTransaction;
+import com.hedera.hashgraph.sdk.account.AccountId;
+import com.hedera.hashgraph.sdk.account.AccountInfo;
+import com.hedera.hashgraph.sdk.account.AccountInfoQuery;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
+
+import java.util.Objects;
+
+import io.github.cdimascio.dotenv.Dotenv;
+
+public final class DeleteAccount {
+
+    // see `.env.sample` in the repository root for how to specify these values
+    // or set environment variables with the same names
+    private static final AccountId OPERATOR_ID = AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_ID")));
+    private static final Ed25519PrivateKey OPERATOR_KEY = Ed25519PrivateKey.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_KEY")));
+
+    private DeleteAccount() { }
+
+    public static void main(String[] args) throws HederaException {
+        // Generate a Ed25519 private, public key pair
+        Ed25519PrivateKey newKey = Ed25519PrivateKey.generate();
+        Ed25519PublicKey newPublicKey = newKey.publicKey;
+
+        System.out.println("private key = " + newKey);
+        System.out.println("public key = " + newPublicKey);
+
+        // `Client.forMainnet()` is provided for connecting to Hedera mainnet
+        Client client = Client.forTestnet();
+
+        // Defaults the operator account ID and key such that all generated transactions will be paid for
+        // by this account and be signed by this key
+        client.setOperator(OPERATOR_ID, OPERATOR_KEY);
+
+        TransactionId txId = new AccountCreateTransaction()
+            // The only _required_ property here is `key`
+            .setKey(newKey.publicKey)
+            .setInitialBalance(Hbar.of(2))
+            .execute(client);
+
+        // This will wait for the receipt to become available
+        TransactionReceipt receipt = txId.getReceipt(client);
+
+        AccountId newAccountId = receipt.getAccountId();
+
+        System.out.println("account = " + newAccountId);
+
+        new AccountDeleteTransaction()
+            // note the transaction ID has to use the ID of the account being deleted
+            .setTransactionId(new TransactionId(newAccountId))
+            .setDeleteAccountId(newAccountId)
+            .setTransferAccountId(OPERATOR_ID)
+            .build(client)
+            .sign(newKey)
+            .execute(client)
+            .getReceipt(client);
+
+        final AccountInfo accountInfo = new AccountInfoQuery()
+            .setAccountId(newAccountId)
+            .setQueryPayment(25)
+            .execute(client);
+
+        // note the above accountInfo will fail with ACCOUNT_DELETED due to a known issue on Hedera
+
+        System.out.println("account info: " + accountInfo);
+    }
+}

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountDeleteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountDeleteTransaction.java
@@ -1,11 +1,11 @@
 package com.hedera.hashgraph.sdk.account;
 
-import com.hedera.hashgraph.sdk.Client;
-import com.hedera.hashgraph.sdk.TransactionBuilder;
 import com.hedera.hashgraph.proto.CryptoDeleteTransactionBody;
+import com.hedera.hashgraph.proto.CryptoServiceGrpc;
 import com.hedera.hashgraph.proto.Transaction;
 import com.hedera.hashgraph.proto.TransactionResponse;
-import com.hedera.hashgraph.proto.CryptoServiceGrpc;
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.TransactionBuilder;
 
 import javax.annotation.Nullable;
 
@@ -32,6 +32,21 @@ public class AccountDeleteTransaction extends TransactionBuilder<AccountDeleteTr
         return this;
     }
 
+    /**
+     * Set the ID of the account to delete.
+     *
+     * Note that this <b>MUST</b> be the same as the account ID in the transaction ID
+     * or else getting the receipt will throw with {@code RECEIPT_NOT_FOUND}.
+     *
+     * You can ensure this is correct by calling
+     * {@code setTransactionId(new TransactionId(deleteAccountId))}, however this does mean
+     * that the account being deleted will also pay the fee for this transaction, which will be
+     * deducted from the balance that will be transferred to the account set by
+     * {@link #setTransferAccountId(AccountId)}.
+     *
+     * @param deleteAccountId the ID of the account to delete.
+     * @return {@code this} for fluent usage.
+     */
     public AccountDeleteTransaction setDeleteAccountId(AccountId deleteAccountId) {
         builder.setDeleteAccountID(deleteAccountId.toProto());
         return this;

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractInfoQuery.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractInfoQuery.java
@@ -1,12 +1,17 @@
 package com.hedera.hashgraph.sdk.contract;
 
-import com.hedera.hashgraph.sdk.Client;
-import com.hedera.hashgraph.sdk.QueryBuilder;
 import com.hedera.hashgraph.proto.ContractGetInfoQuery;
 import com.hedera.hashgraph.proto.Query;
 import com.hedera.hashgraph.proto.QueryHeader;
 import com.hedera.hashgraph.proto.Response;
 import com.hedera.hashgraph.proto.SmartContractServiceGrpc;
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.HederaException;
+import com.hedera.hashgraph.sdk.HederaNetworkException;
+import com.hedera.hashgraph.sdk.HederaThrowable;
+import com.hedera.hashgraph.sdk.QueryBuilder;
+
+import java.util.function.Consumer;
 
 import io.grpc.MethodDescriptor;
 
@@ -49,5 +54,19 @@ public final class ContractInfoQuery extends QueryBuilder<ContractInfo, Contract
     @Override
     protected void doValidate() {
         require(builder.hasContractID(), ".setContractId() required");
+    }
+
+    @Override
+    public long getCost(Client client) throws HederaException, HederaNetworkException {
+        // deleted contracts return a COST_ANSWER of zero which triggers `INSUFFICIENT_TX_FEE`
+        // if you set that as the query payment; 25 tinybar seems to be enough to get
+        // `CONTRACT_DELETED` back instead.
+        return Math.min(super.getCost(client), 25);
+    }
+
+    @Override
+    public void getCostAsync(Client client, Consumer<Long> withCost, Consumer<HederaThrowable> onError) {
+        // see above
+        super.getCostAsync(client, (cost) -> withCost.accept(Math.min(cost, 25)), onError);
     }
 }


### PR DESCRIPTION
* `AccountInfoQuery` and `ContractInfoQuery` return a zero COST_ANSWER for deleted entities but the network won't accept a zero payment
* `AccountDeleteTransaction` requires the account ID in the transaction ID to be the same as the one being deleted