### PR TITLE
Hcs fixes and examples

### DIFF
--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/AdvancedExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/AdvancedExample.java
@@ -1,0 +1,42 @@
+package com.hedera.hashgraph.sdk.examples.advanced;
+
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.account.AccountId;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
+import io.github.cdimascio.dotenv.Dotenv;
+
+import java.util.Objects;
+
+/**
+ * Base class for advanced examples.
+ * Responsible for setting up the HAPI Client based on environment variable settings.
+ */
+class AdvancedExample {
+    private Client hapiClient;
+
+    public AdvancedExample() {
+        setupHapiClient();
+    }
+
+    public Client getHapiClient() {
+        return hapiClient;
+    }
+
+    private void setupHapiClient() {
+        // The Hedera Hashgrpah node's IP address, port, and account ID.
+        AccountId nodeID = AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("NODE_ID")));
+        String nodeAddress = Objects.requireNonNull(Dotenv.load().get("NODE_ADDRESS"));
+
+        // Transaction payer's account ID and ED25519 private key.
+        AccountId payerId = AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_ID")));
+        Ed25519PrivateKey payerPrivateKey =
+            Ed25519PrivateKey.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_KEY")));
+
+        // Interface used to publish messages on the HCS topic.
+        hapiClient = new Client(nodeID, nodeAddress);
+
+        // Defaults the operator account ID and key such that all generated transactions will be paid for by this
+        // account and be signed by this key
+        hapiClient.setOperator(payerId, payerPrivateKey);
+    }
+}

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/ConsensusPubSubWithSubmitKey.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/ConsensusPubSubWithSubmitKey.java
@@ -1,0 +1,130 @@
+package com.hedera.hashgraph.sdk.examples.advanced;
+
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.HederaException;
+import com.hedera.hashgraph.sdk.TransactionId;
+import com.hedera.hashgraph.sdk.account.AccountId;
+import com.hedera.hashgraph.sdk.consensus.ConsensusClient;
+import com.hedera.hashgraph.sdk.consensus.ConsensusMessageSubmitTransaction;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicCreateTransaction;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicId;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
+import io.github.cdimascio.dotenv.Dotenv;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Random;
+
+/**
+ * An example of an HCS topic that utilizes a submitKey to limit who can submit messages on the topic.
+ *
+ * Creates a new HCS topic with a single ED25519 submitKey.
+ * Subscribes to the topic (no key required).
+ * Publishes a number of messages to the topic signed by the submitKey.
+ */
+public final class ConsensusPubSubWithSubmitKey {
+    // see `.env.sample` in the repository root for how to specify these value or set environment variables with the
+    // same names.
+
+    // The Hedera Hashgrpah node's IP address, port, and account ID.
+    private static final AccountId NODE_ID = AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("NODE_ID")));
+    private static final String NODE_ADDRESS = Objects.requireNonNull(Dotenv.load().get("NODE_ADDRESS"));
+
+    // Transaction payer's account ID and ED25519 private key.
+    private static final AccountId OPERATOR_ID
+        = AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_ID")));
+    private static final Ed25519PrivateKey OPERATOR_KEY
+        = Ed25519PrivateKey.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_KEY")));
+
+    // Mirror node GRPC API's IP address and port.
+    private static final String MIRROR_NODE_ADDRESS = Objects.requireNonNull(Dotenv.load().get("MIRROR_NODE_ADDRESS"));
+
+    private Client hapiClient;
+    private ConsensusClient mirrorNodeClient;
+
+    private ConsensusTopicId topicId;
+    private Ed25519PrivateKey submitKey;
+    private int messagesToPublish;
+    private int millisBetweenMessages;
+
+    private ConsensusPubSubWithSubmitKey(int messagesToPublish, int millisBetweenMessages) {
+        this.messagesToPublish = messagesToPublish;
+        this.millisBetweenMessages = millisBetweenMessages;
+    }
+
+    public static void main(String[] args) throws HederaException, InterruptedException {
+        new ConsensusPubSubWithSubmitKey(5, 2000).execute();
+    }
+
+    public void execute() throws HederaException, InterruptedException {
+        setupConnections();
+
+        createTopicWithSubmitKey();
+
+        subscribeToTopic();
+
+        publishMessagesToTopic();
+    }
+
+    private void setupConnections() {
+        // Interface used to publish messages on the HCS topic.
+        hapiClient = new Client(NODE_ID, NODE_ADDRESS);
+
+        // Defaults the operator account ID and key such that all generated transactions will be paid for by this
+        // account and be signed by this key
+        hapiClient.setOperator(OPERATOR_ID, OPERATOR_KEY);
+
+        // Interface used to subscribe to messages on the HCS topic.
+        mirrorNodeClient = new ConsensusClient(MIRROR_NODE_ADDRESS)
+            .setErrorHandler(e -> System.out.println("Error in ConsensusClient: " + e));
+    }
+
+    private void createTopicWithSubmitKey() throws HederaException {
+        // Generate a Ed25519 private, public key pair
+        submitKey = Ed25519PrivateKey.generate();
+        Ed25519PublicKey submitPublicKey = submitKey.getPublicKey();
+
+        final TransactionId transactionId = new ConsensusTopicCreateTransaction()
+            .setMaxTransactionFee(20_000_000L)
+            .setSubmitKey(submitPublicKey)
+            .execute(hapiClient);
+
+        topicId = transactionId.getReceipt(hapiClient).getConsensusTopicId();
+        System.out.println("Created new topic " + topicId + " with ED25519 submitKey of " + submitKey);
+    }
+
+    private void subscribeToTopic() {
+        mirrorNodeClient.subscribe(topicId, Instant.ofEpochSecond(0), message -> {
+            System.out.println("Received message: " + message.getMessageString()
+                + ": consensus timestamp " + message.consensusTimestamp
+                + ": topic sequence number " + message.sequenceNumber);
+        });
+    }
+
+    private void publishMessagesToTopic() throws InterruptedException, HederaException {
+        Random r = new Random();
+        for (int i = 0; i < messagesToPublish; i++) {
+            String message = "random message " + r.nextLong();
+
+            System.out.println("Publishing message: " + message);
+
+            new ConsensusMessageSubmitTransaction()
+                .setTopicId(topicId)
+                .setMessage(message)
+                .build(hapiClient)
+
+                // The transaction is automatically signed by the payer.
+                // Due to the topic having a submitKey requirement, additionally sign the transaction with that key.
+                .sign(submitKey)
+
+                .execute(hapiClient)
+                .getReceipt(hapiClient);
+
+            Thread.sleep(millisBetweenMessages);
+        }
+
+        Thread.sleep(10000);
+    }
+}

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/TopicWithAdminKey.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/advanced/TopicWithAdminKey.java
@@ -1,0 +1,132 @@
+package com.hedera.hashgraph.sdk.examples.advanced;
+
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.HederaException;
+import com.hedera.hashgraph.sdk.Transaction;
+import com.hedera.hashgraph.sdk.TransactionId;
+import com.hedera.hashgraph.sdk.account.AccountId;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicCreateTransaction;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicId;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicUpdateTransaction;
+import com.hedera.hashgraph.sdk.crypto.ThresholdKey;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
+import io.github.cdimascio.dotenv.Dotenv;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * An example of HCS topic management using a threshold key as the adminKey and going through a key rotation to a new
+ * set of keys.
+ *
+ * Creates a new HCS topic with a 2-of-3 threshold key for the adminKey.
+ * Updates the HCS topic to a 3-of-4 threshold key for the adminKey.
+ */
+public final class TopicWithAdminKey {
+    // see `.env.sample` in the repository root for how to specify these value or set environment variables with the
+    // same names.
+
+    // The Hedera Hashgrpah node's IP address, port, and account ID.
+    private static final AccountId NODE_ID = AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("NODE_ID")));
+    private static final String NODE_ADDRESS = Objects.requireNonNull(Dotenv.load().get("NODE_ADDRESS"));
+
+    // Transaction payer's account ID and ED25519 private key.
+    private static final AccountId OPERATOR_ID
+        = AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_ID")));
+    private static final Ed25519PrivateKey OPERATOR_KEY
+        = Ed25519PrivateKey.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_KEY")));
+
+    private Client hapiClient;
+
+    private ConsensusTopicId topicId;
+    private Ed25519PrivateKey[] initialAdminKeys;
+
+    private TopicWithAdminKey() {
+    }
+
+    public static void main(String[] args) throws HederaException, InterruptedException {
+        new TopicWithAdminKey().execute();
+    }
+
+    public void execute() throws HederaException, InterruptedException {
+        setupConnections();
+
+        createTopicWithAdminKey();
+
+       updateTopicAdminKeyAndMemo();
+    }
+
+    private void setupConnections() {
+        // Interface used to publish messages on the HCS topic.
+        hapiClient = new Client(NODE_ID, NODE_ADDRESS);
+
+        // Defaults the operator account ID and key such that all generated transactions will be paid for by this
+        // account and be signed by this key
+        hapiClient.setOperator(OPERATOR_ID, OPERATOR_KEY);
+    }
+
+    private void createTopicWithAdminKey() throws HederaException {
+        // Generate the initial keys that are part of the adminKey's thresholdKey.
+        // 3 ED25519 keys part of a 2-of-3 threshold key.
+        initialAdminKeys = new Ed25519PrivateKey[3];
+        Arrays.setAll(initialAdminKeys, i -> Ed25519PrivateKey.generate());
+
+        ThresholdKey thresholdKey = new ThresholdKey(2)
+            .addAll(Arrays.stream(initialAdminKeys)
+                .peek(k -> System.out.println("Adding key to 2-of-3 threshold adminKey: " + k))
+                .map(Ed25519PrivateKey::getPublicKey)
+                .collect(Collectors.toList()));
+
+        Transaction transaction = new ConsensusTopicCreateTransaction()
+            .setMaxTransactionFee(50_000_000L)
+            .setAdminKey(thresholdKey)
+            .build(hapiClient);
+
+        // Sign the transaction with 2 of 3 keys that are part of the adminKey threshold key.
+        Arrays.stream(initialAdminKeys, 0, 2).forEach(k -> {
+            System.out.println("Signing CreateTopic with key " + k);
+            transaction.sign(k);
+        });
+
+        TransactionId transactionId = transaction.execute(hapiClient);
+
+        topicId = transactionId.getReceipt(hapiClient).getConsensusTopicId();
+        System.out.println("Created new topic " + topicId + " with 2-of-3 threshold key as adminKey.");
+    }
+
+    private void updateTopicAdminKeyAndMemo() throws HederaException {
+        // Generate the new keys that are part of the adminKey's thresholdKey.
+        // 4 ED25519 keys part of a 3-of-4 threshold key.
+        Ed25519PrivateKey[] newAdminKeys = new Ed25519PrivateKey[4];
+        Arrays.setAll(newAdminKeys, i -> Ed25519PrivateKey.generate());
+
+        ThresholdKey thresholdKey = new ThresholdKey(3)
+            .addAll(Arrays.stream(newAdminKeys)
+                .peek(k -> System.out.println("New key created for 3-of-4 threshold adminKey: " + k))
+                .map(Ed25519PrivateKey::getPublicKey)
+                .collect(Collectors.toList()));
+
+        Transaction transaction = new ConsensusTopicUpdateTransaction()
+            .setMaxTransactionFee(50_000_000L)
+            .setTopicId(topicId)
+            .setAdminKey(thresholdKey)
+            .build(hapiClient);
+
+        // Sign with the initial adminKey. 2 of the 3 keys already part of the topic's adminKey.
+        Arrays.stream(initialAdminKeys, 0, 2).forEach(k -> {
+            System.out.println("Signing UpdateTopic with initial admin key " + k);
+            transaction.sign(k);
+        });
+
+        // Sign with the new adminKey. 3 of 4 keys already part of the topic's adminKey.
+        Arrays.stream(newAdminKeys, 0, 3).forEach(k -> {
+            System.out.println("Signing UpdateTopic with new admin key " + k);
+            transaction.sign(k);
+        });
+
+        TransactionId transactionId = transaction.execute(hapiClient);
+
+        System.out.println("Updated topic " + topicId + " with 3-of-4 threshold key as adminKey.");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         </repository>
         <repository>
             <id>com.bintray.jcenter</id>
-            <url>http://jcenter.bintray.com/</url>
+            <url>https://jcenter.bintray.com/</url>
             <name>JCenter</name>
             <snapshots>
                 <enabled>false</enabled>

--- a/src/main/java/com/hedera/hashgraph/sdk/HederaConstants.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/HederaConstants.java
@@ -1,0 +1,10 @@
+package com.hedera.hashgraph.sdk;
+
+import java.time.Duration;
+
+public final class HederaConstants {
+    private HederaConstants() {}
+
+    // Required fixed default autorenew duration for entities. (roughly 1/4 year)
+    public static final Duration DEFAULT_AUTORENEW_DURATION = Duration.ofMinutes(131_500);
+}

--- a/src/main/java/com/hedera/hashgraph/sdk/HederaConstants.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/HederaConstants.java
@@ -3,7 +3,7 @@ package com.hedera.hashgraph.sdk;
 import java.time.Duration;
 
 public final class HederaConstants {
-    private HederaConstants() {}
+    private HederaConstants() { }
 
     // Required fixed default autorenew duration for entities. (roughly 1/4 year)
     public static final Duration DEFAULT_AUTORENEW_DURATION = Duration.ofMinutes(131_500);

--- a/src/main/java/com/hedera/hashgraph/sdk/QueryBuilder.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/QueryBuilder.java
@@ -298,6 +298,8 @@ public abstract class QueryBuilder<Resp, T extends QueryBuilder<Resp, T>> extend
                 return raw.getTransactionGetRecord().getHeader();
             case RESPONSE_NOT_SET:
                 throw new IllegalStateException("Response not set");
+            case CONSENSUSGETTOPICINFO:
+                return raw.getConsensusGetTopicInfo().getHeader();
             default:
                 // NOTE: TRANSACTIONGETFASTRECORD shouldn't be handled as we don't expose that query
                 throw new RuntimeException("Unhandled response case");

--- a/src/main/java/com/hedera/hashgraph/sdk/account/AccountCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/account/AccountCreateTransaction.java
@@ -2,6 +2,7 @@ package com.hedera.hashgraph.sdk.account;
 
 import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.DurationHelper;
+import com.hedera.hashgraph.sdk.HederaConstants;
 import com.hedera.hashgraph.sdk.TransactionBuilder;
 import com.hedera.hashgraph.sdk.TransactionId;
 import com.hedera.hashgraph.sdk.crypto.PublicKey;
@@ -21,8 +22,8 @@ import io.grpc.MethodDescriptor;
 // Corresponds to `CryptoCreateTransaction`
 public final class AccountCreateTransaction extends TransactionBuilder<AccountCreateTransaction> {
     private final CryptoCreateTransactionBody.Builder builder = bodyBuilder.getCryptoCreateAccountBuilder()
-        // Required fixed autorenew duration (roughly 1/4 year)
-        .setAutoRenewPeriod(DurationHelper.durationFrom(Duration.ofMinutes(131_500)))
+        // Required fixed autorenew duration.
+        .setAutoRenewPeriod(DurationHelper.durationFrom(HederaConstants.DEFAULT_AUTORENEW_DURATION))
         // Default to maximum values for record thresholds. Without this records would be
         // auto-created whenever a send or receive transaction takes place for this new account. This should
         // be an explicit ask.

--- a/src/main/java/com/hedera/hashgraph/sdk/consensus/ConsensusClient.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/consensus/ConsensusClient.java
@@ -74,8 +74,7 @@ public class ConsensusClient implements AutoCloseable {
         return startStreamingCall(topicId, consensusStartTime, listener);
     }
 
-    private Subscription startStreamingCall(ConsensusTopicId topicId, @Nullable Instant startTime,
-                                            Consumer<ConsensusMessage> listener) {
+    private Subscription startStreamingCall(ConsensusTopicId topicId, @Nullable Instant startTime, Consumer<ConsensusMessage> listener) {
         final ClientCall<ConsensusTopicQuery, ConsensusTopicResponse> call =
             channel.newCall(ConsensusServiceGrpc.getSubscribeTopicMethod(), CallOptions.DEFAULT);
 

--- a/src/main/java/com/hedera/hashgraph/sdk/consensus/ConsensusMessageSubmitTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/consensus/ConsensusMessageSubmitTransaction.java
@@ -16,8 +16,8 @@ public class ConsensusMessageSubmitTransaction extends TransactionBuilder<Consen
         super();
     }
 
-    public ConsensusMessageSubmitTransaction setTopicId(ConsensusTopicId topic) {
-        builder.setTopicID(topic.toProto());
+    public ConsensusMessageSubmitTransaction setTopicId(ConsensusTopicId topicId) {
+        builder.setTopicID(topicId.toProto());
         return this;
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/consensus/ConsensusTopicCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/consensus/ConsensusTopicCreateTransaction.java
@@ -5,6 +5,7 @@ import com.hedera.hashgraph.proto.ConsensusServiceGrpc;
 import com.hedera.hashgraph.proto.Transaction;
 import com.hedera.hashgraph.proto.TransactionResponse;
 import com.hedera.hashgraph.sdk.DurationHelper;
+import com.hedera.hashgraph.sdk.HederaConstants;
 import com.hedera.hashgraph.sdk.TransactionBuilder;
 import com.hedera.hashgraph.sdk.account.AccountId;
 import com.hedera.hashgraph.sdk.crypto.PublicKey;
@@ -18,6 +19,9 @@ public class ConsensusTopicCreateTransaction extends TransactionBuilder<Consensu
 
     public ConsensusTopicCreateTransaction() {
         super();
+
+        // Set the required autorenew duration.
+        builder.setAutoRenewPeriod(DurationHelper.durationFrom(HederaConstants.DEFAULT_AUTORENEW_DURATION));
     }
 
     public ConsensusTopicCreateTransaction setTopicMemo(String topicMemo) {

--- a/src/main/java/com/hedera/hashgraph/sdk/consensus/ConsensusTopicDeleteTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/consensus/ConsensusTopicDeleteTransaction.java
@@ -1,7 +1,7 @@
 package com.hedera.hashgraph.sdk.consensus;
 
+import com.hedera.hashgraph.proto.ConsensusDeleteTopicTransactionBody;
 import com.hedera.hashgraph.proto.ConsensusServiceGrpc;
-import com.hedera.hashgraph.proto.ConsensusUpdateTopicTransactionBody;
 import com.hedera.hashgraph.proto.Transaction;
 import com.hedera.hashgraph.proto.TransactionResponse;
 import com.hedera.hashgraph.sdk.TransactionBuilder;
@@ -9,7 +9,7 @@ import com.hedera.hashgraph.sdk.TransactionBuilder;
 import io.grpc.MethodDescriptor;
 
 public class ConsensusTopicDeleteTransaction extends TransactionBuilder<ConsensusTopicDeleteTransaction> {
-    private final ConsensusUpdateTopicTransactionBody.Builder builder = bodyBuilder.getConsensusUpdateTopicBuilder();
+    private final ConsensusDeleteTopicTransactionBody.Builder builder = bodyBuilder.getConsensusDeleteTopicBuilder();
 
     public ConsensusTopicDeleteTransaction() {
         super();

--- a/src/main/java/com/hedera/hashgraph/sdk/consensus/ConsensusTopicInfo.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/consensus/ConsensusTopicInfo.java
@@ -5,6 +5,7 @@ import com.hedera.hashgraph.sdk.DurationHelper;
 import com.hedera.hashgraph.sdk.TimestampHelper;
 import com.hedera.hashgraph.sdk.account.AccountId;
 import com.hedera.hashgraph.sdk.crypto.PublicKey;
+import org.bouncycastle.util.encoders.Hex;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -64,5 +65,18 @@ public class ConsensusTopicInfo {
         }
 
         return new ConsensusTopicInfo(response.getConsensusGetTopicInfo());
+    }
+
+    @Override
+    public String toString() {
+        return "topic ID: " + id +
+            " sequence number: " + sequenceNumber +
+            " running hash: " + Hex.toHexString(runningHash) +
+            " expiration time: " + expirationTime +
+            " admin key: " + adminKey +
+            " submit key: " + submitKey +
+            " auto-renew period: " + autoRenewPeriod +
+            " auto-renew account: " + autoRenewAccount +
+            " memo: " + memo;
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/consensus/ConsensusTopicInfo.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/consensus/ConsensusTopicInfo.java
@@ -69,14 +69,14 @@ public class ConsensusTopicInfo {
 
     @Override
     public String toString() {
-        return "topic ID: " + id +
-            " sequence number: " + sequenceNumber +
-            " running hash: " + Hex.toHexString(runningHash) +
-            " expiration time: " + expirationTime +
-            " admin key: " + adminKey +
-            " submit key: " + submitKey +
-            " auto-renew period: " + autoRenewPeriod +
-            " auto-renew account: " + autoRenewAccount +
-            " memo: " + memo;
+        return "topic ID: " + id
+            + " sequence number: " + sequenceNumber
+            + " running hash: " + Hex.toHexString(runningHash)
+            + " expiration time: " + expirationTime
+            + " admin key: " + adminKey
+            + " submit key: " + submitKey
+            + " auto-renew period: " + autoRenewPeriod
+            + " auto-renew account: " + autoRenewAccount
+            + " memo: " + memo;
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/consensus/ConsensusTopicUpdateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/consensus/ConsensusTopicUpdateTransaction.java
@@ -1,8 +1,11 @@
 package com.hedera.hashgraph.sdk.consensus;
 
 import com.google.protobuf.StringValue;
+import com.hedera.hashgraph.proto.AccountID;
 import com.hedera.hashgraph.proto.ConsensusServiceGrpc;
 import com.hedera.hashgraph.proto.ConsensusUpdateTopicTransactionBody;
+import com.hedera.hashgraph.proto.Key;
+import com.hedera.hashgraph.proto.KeyList;
 import com.hedera.hashgraph.proto.Transaction;
 import com.hedera.hashgraph.proto.TransactionResponse;
 import com.hedera.hashgraph.sdk.DurationHelper;
@@ -33,13 +36,40 @@ public class ConsensusTopicUpdateTransaction extends TransactionBuilder<Consensu
         return this;
     }
 
+    /**
+     * Explicitly clear any memo on the topic.
+     * @return
+     */
+    public ConsensusTopicUpdateTransaction clearTopicMemo() {
+        builder.setMemo(StringValue.of(""));
+        return this;
+    }
+
     public ConsensusTopicUpdateTransaction setAdminKey(PublicKey key) {
         builder.setAdminKey(key.toKeyProto());
         return this;
     }
 
+    /**
+     * Explicitly clear any adminKey on the topic.
+     * @return
+     */
+    public ConsensusTopicUpdateTransaction clearAdminKey() {
+        builder.setAdminKey(Key.newBuilder().setKeyList(KeyList.getDefaultInstance()));
+        return this;
+    }
+
     public ConsensusTopicUpdateTransaction setSubmitKey(PublicKey key) {
         builder.setSubmitKey(key.toKeyProto());
+        return this;
+    }
+
+    /**
+     * Explicitly clear any submitKey on the topic.
+     * @return
+     */
+    public ConsensusTopicUpdateTransaction clearSubmitKey() {
+        builder.setSubmitKey(Key.newBuilder().setKeyList(KeyList.getDefaultInstance()));
         return this;
     }
 
@@ -55,6 +85,15 @@ public class ConsensusTopicUpdateTransaction extends TransactionBuilder<Consensu
 
     public ConsensusTopicUpdateTransaction setAutoRenewAccountId(AccountId autoRenewAccountId) {
         builder.setAutoRenewAccount(autoRenewAccountId.toProto());
+        return this;
+    }
+
+    /**
+     * Explicitly clear any auto renew account ID on the topic.
+     * @return
+     */
+    public ConsensusTopicUpdateTransaction clearAutoRenewAccountId() {
+        builder.setAutoRenewAccount(AccountID.getDefaultInstance());
         return this;
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCreateTransaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/contract/ContractCreateTransaction.java
@@ -4,6 +4,7 @@ import com.google.protobuf.ByteString;
 import com.hedera.hashgraph.sdk.CallParams;
 import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.DurationHelper;
+import com.hedera.hashgraph.sdk.HederaConstants;
 import com.hedera.hashgraph.sdk.TransactionBuilder;
 import com.hedera.hashgraph.sdk.account.AccountId;
 import com.hedera.hashgraph.sdk.crypto.PublicKey;
@@ -25,8 +26,8 @@ public class ContractCreateTransaction extends TransactionBuilder<ContractCreate
     private final ContractCreateTransactionBody.Builder builder = bodyBuilder.getContractCreateInstanceBuilder();
 
     {
-        // Required fixed autorenew duration (roughly 1/4 year)
-        setAutoRenewPeriod(Duration.ofMinutes(131_500));
+        // Required fixed autorenew duration.
+        setAutoRenewPeriod(HederaConstants.DEFAULT_AUTORENEW_DURATION);
     }
 
     /**

--- a/src/main/java/com/hedera/hashgraph/sdk/crypto/PublicKey.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/crypto/PublicKey.java
@@ -23,6 +23,18 @@ public abstract class PublicKey {
         case CONTRACTID:
             ContractIDOrBuilder id = key.getContractIDOrBuilder();
             return new ContractId(id.getShardNum(), id.getRealmNum(), id.getContractNum());
+        case THRESHOLDKEY:
+            ThresholdKey thresholdKey = new ThresholdKey(key.getThresholdKey().getThreshold());
+            key.getThresholdKey().getKeys().getKeysList().forEach(k -> {
+               thresholdKey.add(PublicKey.fromProtoKey(k));
+            });
+            return thresholdKey;
+        case KEYLIST:
+            KeyList keyList = new KeyList();
+            key.getKeyList().getKeysList().forEach(k -> {
+                keyList.addKey(PublicKey.fromProtoKey(k));
+            });
+            return keyList;
         default:
             throw new IllegalStateException("Unchecked Key Case");
         }

--- a/src/test/java/com/hedera/hashgraph/sdk/crypto/PublicKeyTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/crypto/PublicKeyTest.java
@@ -1,0 +1,84 @@
+package com.hedera.hashgraph.sdk.crypto;
+
+import com.google.protobuf.ByteString;
+import com.hedera.hashgraph.proto.Key;
+import com.hedera.hashgraph.proto.KeyList;
+import com.hedera.hashgraph.proto.KeyOrBuilder;
+import com.hedera.hashgraph.proto.ThresholdKey;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PublicKeyTest {
+    @Test
+    @DisplayName("can convert from protobuf ED25519 key to PublicKey")
+    void fromProtoKeyEd25519() {
+        final byte[] keyBytes = Hex.decode("0011223344556677889900112233445566778899001122334455667788990011");
+        final Key protoKey = Key.newBuilder().setEd25519(ByteString.copyFrom(keyBytes)).build();
+
+        final PublicKey cut = PublicKey.fromProtoKey(protoKey);
+
+        assertEquals(cut.getClass(), Ed25519PublicKey.class);
+        assertArrayEquals(keyBytes, ((Ed25519PublicKey)cut).toBytes());
+    }
+
+    @Test
+    @DisplayName("can convert from protobuf key list to PublicKey")
+    void fromProtoKeyKeyList() {
+        // given
+        final byte[][] keyBytes = new byte[][] {
+            Hex.decode("0011223344556677889900112233445566778899001122334455667788990011"),
+            Hex.decode("aa11223344556677889900112233445566778899001122334455667788990011")
+        };
+        final KeyList.Builder protoKeyList = KeyList.newBuilder();
+        Arrays.stream(keyBytes).forEach(kb -> {
+            protoKeyList.addKeys(Key.newBuilder().setEd25519(ByteString.copyFrom(kb)));
+        });
+        final KeyOrBuilder protoKey = Key.newBuilder().setKeyList(protoKeyList).build();
+
+        // when
+        final PublicKey cut = PublicKey.fromProtoKey(protoKey);
+
+        // then
+        assertEquals(cut.getClass(), com.hedera.hashgraph.sdk.crypto.KeyList.class);
+        final com.hedera.hashgraph.sdk.crypto.KeyList keyList = (com.hedera.hashgraph.sdk.crypto.KeyList)cut;
+        final KeyList actual = keyList.toKeyProto().getKeyList();
+        assertEquals(2, actual.getKeysCount());
+        assertArrayEquals(keyBytes[0], actual.getKeys(0).getEd25519().toByteArray());
+        assertArrayEquals(keyBytes[1], actual.getKeys(1).getEd25519().toByteArray());
+    }
+
+    @Test
+    @DisplayName("can convert from protobuf threshold key to PublicKey")
+    void fromProtoKeyThresholdKey() {
+        // given
+        final byte[][] keyBytes = new byte[][] {
+            Hex.decode("0011223344556677889900112233445566778899001122334455667788990011"),
+            Hex.decode("aa11223344556677889900112233445566778899001122334455667788990011")
+        };
+        final KeyList.Builder protoKeyList = KeyList.newBuilder();
+        Arrays.stream(keyBytes).forEach(kb -> {
+            protoKeyList.addKeys(Key.newBuilder().setEd25519(ByteString.copyFrom(kb)));
+        });
+        final ThresholdKey.Builder protoThresholdKey = ThresholdKey.newBuilder().setThreshold(1).setKeys(protoKeyList);
+        final KeyOrBuilder protoKey = Key.newBuilder().setThresholdKey(protoThresholdKey).build();
+
+        // when
+        final PublicKey cut = PublicKey.fromProtoKey(protoKey);
+
+        // then
+        assertEquals(cut.getClass(), com.hedera.hashgraph.sdk.crypto.ThresholdKey.class);
+        final com.hedera.hashgraph.sdk.crypto.ThresholdKey thresholdKey =
+            (com.hedera.hashgraph.sdk.crypto.ThresholdKey)cut;
+        final ThresholdKey actual = thresholdKey.toKeyProto().getThresholdKey();
+        assertEquals(1, actual.getThreshold());
+        assertEquals(2, actual.getKeys().getKeysCount());
+        assertArrayEquals(keyBytes[0], actual.getKeys().getKeys(0).getEd25519().toByteArray());
+        assertArrayEquals(keyBytes[1], actual.getKeys().getKeys(1).getEd25519().toByteArray());
+    }
+}

--- a/src/test/java/com/hedera/hashgraph/sdk/crypto/ed25519/Ed25519PublicKeyTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/crypto/ed25519/Ed25519PublicKeyTest.java
@@ -1,20 +1,11 @@
 package com.hedera.hashgraph.sdk.crypto.ed25519;
 
-import com.google.protobuf.ByteString;
-import com.hedera.hashgraph.proto.Key;
-import com.hedera.hashgraph.proto.KeyList;
-import com.hedera.hashgraph.proto.KeyListOrBuilder;
-import com.hedera.hashgraph.proto.KeyOrBuilder;
-import com.hedera.hashgraph.proto.ThresholdKey;
 import com.hedera.hashgraph.sdk.crypto.PublicKey;
 
-import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -73,72 +64,5 @@ class Ed25519PublicKeyTest {
 
         assertNotNull(key);
         assertEquals(testKeyStr, key.toString());
-    }
-
-    @Test
-    @DisplayName("can convert from protobuf ED25519 key to PublicKey")
-    void fromProtoKeyEd25519() {
-        final byte[] keyBytes = Hex.decode("0011223344556677889900112233445566778899001122334455667788990011");
-        final Key protoKey = Key.newBuilder().setEd25519(ByteString.copyFrom(keyBytes)).build();
-
-        final PublicKey cut = PublicKey.fromProtoKey(protoKey);
-
-        assertEquals(cut.getClass(), Ed25519PublicKey.class);
-        assertArrayEquals(keyBytes, ((Ed25519PublicKey)cut).toBytes());
-    }
-
-    @Test
-    @DisplayName("can convert from protobuf key list to PublicKey")
-    void fromProtoKeyKeyList() {
-        // given
-        final byte[][] keyBytes = new byte[][] {
-            Hex.decode("0011223344556677889900112233445566778899001122334455667788990011"),
-            Hex.decode("aa11223344556677889900112233445566778899001122334455667788990011")
-        };
-        final KeyList.Builder protoKeyList = KeyList.newBuilder();
-        Arrays.stream(keyBytes).forEach(kb -> {
-            protoKeyList.addKeys(Key.newBuilder().setEd25519(ByteString.copyFrom(kb)));
-        });
-        final KeyOrBuilder protoKey = Key.newBuilder().setKeyList(protoKeyList).build();
-
-        // when
-        final PublicKey cut = PublicKey.fromProtoKey(protoKey);
-
-        // then
-        assertEquals(cut.getClass(), com.hedera.hashgraph.sdk.crypto.KeyList.class);
-        final com.hedera.hashgraph.sdk.crypto.KeyList keyList = (com.hedera.hashgraph.sdk.crypto.KeyList)cut;
-        final KeyList actual = keyList.toKeyProto().getKeyList();
-        assertEquals(2, actual.getKeysCount());
-        assertArrayEquals(keyBytes[0], actual.getKeys(0).getEd25519().toByteArray());
-        assertArrayEquals(keyBytes[1], actual.getKeys(1).getEd25519().toByteArray());
-    }
-
-    @Test
-    @DisplayName("can convert from protobuf threshold key to PublicKey")
-    void fromProtoKeyThresholdKey() {
-        // given
-        final byte[][] keyBytes = new byte[][] {
-            Hex.decode("0011223344556677889900112233445566778899001122334455667788990011"),
-            Hex.decode("aa11223344556677889900112233445566778899001122334455667788990011")
-        };
-        final KeyList.Builder protoKeyList = KeyList.newBuilder();
-        Arrays.stream(keyBytes).forEach(kb -> {
-            protoKeyList.addKeys(Key.newBuilder().setEd25519(ByteString.copyFrom(kb)));
-        });
-        final ThresholdKey.Builder protoThresholdKey = ThresholdKey.newBuilder().setThreshold(1).setKeys(protoKeyList);
-        final KeyOrBuilder protoKey = Key.newBuilder().setThresholdKey(protoThresholdKey).build();
-
-        // when
-        final PublicKey cut = PublicKey.fromProtoKey(protoKey);
-
-        // then
-        assertEquals(cut.getClass(), com.hedera.hashgraph.sdk.crypto.ThresholdKey.class);
-        final com.hedera.hashgraph.sdk.crypto.ThresholdKey thresholdKey =
-            (com.hedera.hashgraph.sdk.crypto.ThresholdKey)cut;
-        final ThresholdKey actual = thresholdKey.toKeyProto().getThresholdKey();
-        assertEquals(1, actual.getThreshold());
-        assertEquals(2, actual.getKeys().getKeysCount());
-        assertArrayEquals(keyBytes[0], actual.getKeys().getKeys(0).getEd25519().toByteArray());
-        assertArrayEquals(keyBytes[1], actual.getKeys().getKeys(1).getEd25519().toByteArray());
     }
 }

--- a/src/test/java/com/hedera/hashgraph/sdk/crypto/ed25519/Ed25519PublicKeyTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/crypto/ed25519/Ed25519PublicKeyTest.java
@@ -1,11 +1,20 @@
 package com.hedera.hashgraph.sdk.crypto.ed25519;
 
+import com.google.protobuf.ByteString;
+import com.hedera.hashgraph.proto.Key;
+import com.hedera.hashgraph.proto.KeyList;
+import com.hedera.hashgraph.proto.KeyListOrBuilder;
+import com.hedera.hashgraph.proto.KeyOrBuilder;
+import com.hedera.hashgraph.proto.ThresholdKey;
 import com.hedera.hashgraph.sdk.crypto.PublicKey;
 
+import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -64,5 +73,72 @@ class Ed25519PublicKeyTest {
 
         assertNotNull(key);
         assertEquals(testKeyStr, key.toString());
+    }
+
+    @Test
+    @DisplayName("can convert from protobuf ED25519 key to PublicKey")
+    void fromProtoKeyEd25519() {
+        final byte[] keyBytes = Hex.decode("0011223344556677889900112233445566778899001122334455667788990011");
+        final Key protoKey = Key.newBuilder().setEd25519(ByteString.copyFrom(keyBytes)).build();
+
+        final PublicKey cut = PublicKey.fromProtoKey(protoKey);
+
+        assertEquals(cut.getClass(), Ed25519PublicKey.class);
+        assertArrayEquals(keyBytes, ((Ed25519PublicKey)cut).toBytes());
+    }
+
+    @Test
+    @DisplayName("can convert from protobuf key list to PublicKey")
+    void fromProtoKeyKeyList() {
+        // given
+        final byte[][] keyBytes = new byte[][] {
+            Hex.decode("0011223344556677889900112233445566778899001122334455667788990011"),
+            Hex.decode("aa11223344556677889900112233445566778899001122334455667788990011")
+        };
+        final KeyList.Builder protoKeyList = KeyList.newBuilder();
+        Arrays.stream(keyBytes).forEach(kb -> {
+            protoKeyList.addKeys(Key.newBuilder().setEd25519(ByteString.copyFrom(kb)));
+        });
+        final KeyOrBuilder protoKey = Key.newBuilder().setKeyList(protoKeyList).build();
+
+        // when
+        final PublicKey cut = PublicKey.fromProtoKey(protoKey);
+
+        // then
+        assertEquals(cut.getClass(), com.hedera.hashgraph.sdk.crypto.KeyList.class);
+        final com.hedera.hashgraph.sdk.crypto.KeyList keyList = (com.hedera.hashgraph.sdk.crypto.KeyList)cut;
+        final KeyList actual = keyList.toKeyProto().getKeyList();
+        assertEquals(2, actual.getKeysCount());
+        assertArrayEquals(keyBytes[0], actual.getKeys(0).getEd25519().toByteArray());
+        assertArrayEquals(keyBytes[1], actual.getKeys(1).getEd25519().toByteArray());
+    }
+
+    @Test
+    @DisplayName("can convert from protobuf threshold key to PublicKey")
+    void fromProtoKeyThresholdKey() {
+        // given
+        final byte[][] keyBytes = new byte[][] {
+            Hex.decode("0011223344556677889900112233445566778899001122334455667788990011"),
+            Hex.decode("aa11223344556677889900112233445566778899001122334455667788990011")
+        };
+        final KeyList.Builder protoKeyList = KeyList.newBuilder();
+        Arrays.stream(keyBytes).forEach(kb -> {
+            protoKeyList.addKeys(Key.newBuilder().setEd25519(ByteString.copyFrom(kb)));
+        });
+        final ThresholdKey.Builder protoThresholdKey = ThresholdKey.newBuilder().setThreshold(1).setKeys(protoKeyList);
+        final KeyOrBuilder protoKey = Key.newBuilder().setThresholdKey(protoThresholdKey).build();
+
+        // when
+        final PublicKey cut = PublicKey.fromProtoKey(protoKey);
+
+        // then
+        assertEquals(cut.getClass(), com.hedera.hashgraph.sdk.crypto.ThresholdKey.class);
+        final com.hedera.hashgraph.sdk.crypto.ThresholdKey thresholdKey =
+            (com.hedera.hashgraph.sdk.crypto.ThresholdKey)cut;
+        final ThresholdKey actual = thresholdKey.toKeyProto().getThresholdKey();
+        assertEquals(1, actual.getThreshold());
+        assertEquals(2, actual.getKeys().getKeysCount());
+        assertArrayEquals(keyBytes[0], actual.getKeys().getKeys(0).getEd25519().toByteArray());
+        assertArrayEquals(keyBytes[1], actual.getKeys().getKeys(1).getEd25519().toByteArray());
     }
 }


### PR DESCRIPTION
- Fix ConsensusTopicDeleteTransaction.
- Set default entity lifetime for topic in ConsensusTopicCreateTransaction (and update account/contract create to use same constant).
- Update parameter name "topic" to "topicId" in several places for consistency.
- Add "clearXyz()" methods to ConsensusTopicUpdateTransaction for clearing various attributes on the topic entity.
- Add example - HCS pub-sub with submitKey.
- Add example - HCS topic adminKey as a 2-of-3 thresholdKey, then updated to a 3-of-4 adminKey via UpdateTopic.
- Fixes GetTopicInfo (switch statement not constructing TopicInfo on response)
- Fixes PublicKey not translating from KeyList and ThresholdKey protobufs

Fixes #327 (minus requirement to update a bunch of javadoc - I'll create another issue)
Fixes #323
Fixes #333