### PR TITLE
2 HCS-related examples using submit and admin keys.

### DIFF
--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/ConsensusPubSubWithSubmitKey.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/ConsensusPubSubWithSubmitKey.java
@@ -1,0 +1,153 @@
+package com.hedera.hashgraph.sdk.examples;
+
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.HederaStatusException;
+import com.hedera.hashgraph.sdk.TransactionId;
+import com.hedera.hashgraph.sdk.account.AccountId;
+import com.hedera.hashgraph.sdk.consensus.ConsensusClient;
+import com.hedera.hashgraph.sdk.consensus.ConsensusMessageSubmitTransaction;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicCreateTransaction;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicId;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PublicKey;
+import io.github.cdimascio.dotenv.Dotenv;
+import org.spongycastle.util.encoders.Hex;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.Random;
+
+/**
+ * An example of an HCS topic that utilizes a submitKey to limit who can submit messages on the topic.
+ *
+ * Creates a new HCS topic with a single ED25519 submitKey.
+ * Subscribes to the topic (no key required).
+ * Publishes a number of messages to the topic signed by the submitKey.
+ */
+public class ConsensusPubSubWithSubmitKey {
+    private Client hapiClient;
+    private ConsensusClient mirrorNodeClient;
+
+    private int messagesToPublish;
+    private int millisBetweenMessages;
+
+    private ConsensusTopicId topicId;
+    private Ed25519PrivateKey submitKey;
+
+    public ConsensusPubSubWithSubmitKey(int messagesToPublish, int millisBetweenMessages) {
+        this.messagesToPublish = messagesToPublish;
+        this.millisBetweenMessages = millisBetweenMessages;
+        setupHapiClient();
+        setupMirrorNodeClient();
+    }
+
+    public static void main(String[] args) throws InterruptedException, HederaStatusException {
+        new ConsensusPubSubWithSubmitKey(5, 2000).execute();
+    }
+
+    public void execute() throws InterruptedException, HederaStatusException {
+        createTopicWithSubmitKey();
+
+        subscribeToTopic();
+
+        publishMessagesToTopic();
+    }
+
+    private void setupHapiClient() {
+        // see `.env.sample` in the repository root for how to specify these values or set environment variables with
+        // the same names
+
+        // The Hedera Hashgraph node's IP address, port, and account ID.
+        AccountId nodeAccountId = AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("NODE_ID")));
+        String nodeAddress = Objects.requireNonNull(Dotenv.load().get("NODE_ADDRESS"));
+
+        // Transaction payer's account ID and ED25519 private key.
+        AccountId payerId = AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_ID")));
+        Ed25519PrivateKey payerPrivateKey =
+            Ed25519PrivateKey.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_KEY")));
+
+        // Interface used to publish messages on the HCS topic.
+        hapiClient = new Client(new HashMap<AccountId, String>() {
+            {
+                put(nodeAccountId, nodeAddress);
+            }
+        });
+
+        // Defaults the operator account ID and key such that all generated transactions will be paid for by this
+        // account and be signed by this key
+        hapiClient.setOperator(payerId, payerPrivateKey);
+    }
+
+    private void setupMirrorNodeClient() {
+        // Interface used to subscribe to messages on the HCS topic.
+        mirrorNodeClient = new ConsensusClient(Objects.requireNonNull(Dotenv.load().get("MIRROR_NODE_ADDRESS")))
+            .setErrorHandler(e -> System.out.println("Error in ConsensusClient: " + e));
+    }
+
+    /**
+     * Generate a brand new ED25519 key pair.
+     *
+     * Create a new topic with that key as the topic's submitKey; required to sign all future
+     * ConsensusMessageSubmitTransactions for that topic.
+     *
+     * @throws HederaStatusException
+     */
+    private void createTopicWithSubmitKey() throws HederaStatusException {
+        // Generate a Ed25519 private, public key pair
+        submitKey = Ed25519PrivateKey.generate();
+        Ed25519PublicKey submitPublicKey = submitKey.publicKey;
+
+        final TransactionId transactionId = new ConsensusTopicCreateTransaction()
+            .setMaxTransactionFee(20_000_000L)
+            .setTopicMemo("HCS topic with submit key")
+            .setSubmitKey(submitPublicKey)
+            .execute(hapiClient);
+
+        topicId = transactionId.getReceipt(hapiClient).getConsensusTopicId();
+        System.out.println("Created new topic " + topicId + " with ED25519 submitKey of " + submitKey);
+    }
+
+    /**
+     * Subscribe to messages on the topic, printing out the received message and metadata as it is published by the
+     * Hedera mirror node.
+     */
+    private void subscribeToTopic() {
+        mirrorNodeClient.subscribe(topicId, Instant.ofEpochSecond(0), message -> {
+            System.out.println("Received message: " + message.getMessageString()
+                + " consensus timestamp: " + message.consensusTimestamp
+                + " topic sequence number: " + message.sequenceNumber
+                + " topic running hash: " + Hex.toHexString(message.runningHash));
+        });
+    }
+
+    /**
+     * Publish a list of messages to a topic, signing each transaction with the topic's submitKey.
+     * @throws InterruptedException
+     * @throws HederaStatusException
+     */
+    private void publishMessagesToTopic() throws InterruptedException, HederaStatusException {
+        Random r = new Random();
+        for (int i = 0; i < messagesToPublish; i++) {
+            String message = "random message " + r.nextLong();
+
+            System.out.println("Publishing message: " + message);
+
+            new ConsensusMessageSubmitTransaction()
+                .setTopicId(topicId)
+                .setMessage(message)
+                .build(hapiClient)
+
+                // The transaction is automatically signed by the payer.
+                // Due to the topic having a submitKey requirement, additionally sign the transaction with that key.
+                .sign(submitKey)
+
+                .execute(hapiClient)
+                .getReceipt(hapiClient);
+
+            Thread.sleep(millisBetweenMessages);
+        }
+
+        Thread.sleep(10000);
+    }
+}

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/TopicWithAdminKey.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/TopicWithAdminKey.java
@@ -1,0 +1,146 @@
+package com.hedera.hashgraph.sdk.examples;
+
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.HederaStatusException;
+import com.hedera.hashgraph.sdk.Transaction;
+import com.hedera.hashgraph.sdk.TransactionId;
+import com.hedera.hashgraph.sdk.account.AccountId;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicCreateTransaction;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicId;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicInfo;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicInfoQuery;
+import com.hedera.hashgraph.sdk.consensus.ConsensusTopicUpdateTransaction;
+import com.hedera.hashgraph.sdk.crypto.ThresholdKey;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
+import io.github.cdimascio.dotenv.Dotenv;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * An example of HCS topic management using a threshold key as the adminKey and going through a key rotation to a new
+ * set of keys.
+ *
+ * Creates a new HCS topic with a 2-of-3 threshold key for the adminKey.
+ * Updates the HCS topic to a 3-of-4 threshold key for the adminKey.
+ */
+class TopicWithAdminKey {
+    private Client hapiClient;
+
+    private ConsensusTopicId topicId;
+    private Ed25519PrivateKey[] initialAdminKeys;
+
+    private TopicWithAdminKey() {
+        setupHapiClient();
+    }
+
+    public static void main(String[] args) throws HederaStatusException {
+        new TopicWithAdminKey().execute();
+    }
+
+    public void execute() throws HederaStatusException {
+        createTopicWithAdminKey();
+
+        updateTopicAdminKeyAndMemo();
+    }
+
+    private void setupHapiClient() {
+        // see `.env.sample` in the repository root for how to specify these values or set environment variables with
+        // the same names
+
+        // The Hedera Hashgraph node's IP address, port, and account ID.
+        AccountId nodeAccountId = AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("NODE_ID")));
+        String nodeAddress = Objects.requireNonNull(Dotenv.load().get("NODE_ADDRESS"));
+
+        // Transaction payer's account ID and ED25519 private key.
+        AccountId payerId = AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_ID")));
+        Ed25519PrivateKey payerPrivateKey =
+            Ed25519PrivateKey.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_KEY")));
+
+        // Interface used to publish messages on the HCS topic.
+        hapiClient = new Client(new HashMap<AccountId, String>() {
+            {
+                put(nodeAccountId, nodeAddress);
+            }
+        });
+
+        // Defaults the operator account ID and key such that all generated transactions will be paid for by this
+        // account and be signed by this key
+        hapiClient.setOperator(payerId, payerPrivateKey);
+    }
+
+    private void createTopicWithAdminKey() throws HederaStatusException {
+        // Generate the initial keys that are part of the adminKey's thresholdKey.
+        // 3 ED25519 keys part of a 2-of-3 threshold key.
+        initialAdminKeys = new Ed25519PrivateKey[3];
+        Arrays.setAll(initialAdminKeys, i -> Ed25519PrivateKey.generate());
+
+        ThresholdKey thresholdKey = new ThresholdKey(2)
+            .addAll(Arrays.stream(initialAdminKeys)
+                .peek(k -> System.out.println("Adding key to 2-of-3 threshold adminKey: " + k))
+                .map(k -> k.publicKey)
+                .collect(Collectors.toList()));
+
+        Transaction transaction = new ConsensusTopicCreateTransaction()
+            .setMaxTransactionFee(50_000_000L)
+            .setTopicMemo("demo topic")
+            .setAdminKey(thresholdKey)
+            .build(hapiClient);
+
+        // Sign the transaction with 2 of 3 keys that are part of the adminKey threshold key.
+        Arrays.stream(initialAdminKeys, 0, 2).forEach(k -> {
+            System.out.println("Signing ConsensusTopicCreateTransaction with key " + k);
+            transaction.sign(k);
+        });
+
+        TransactionId transactionId = transaction.execute(hapiClient);
+
+        topicId = transactionId.getReceipt(hapiClient).getConsensusTopicId();
+
+        System.out.println("Created new topic " + topicId + " with 2-of-3 threshold key as adminKey.");
+    }
+
+    private void updateTopicAdminKeyAndMemo() throws HederaStatusException {
+        // Generate the new keys that are part of the adminKey's thresholdKey.
+        // 4 ED25519 keys part of a 3-of-4 threshold key.
+        Ed25519PrivateKey[] newAdminKeys = new Ed25519PrivateKey[4];
+        Arrays.setAll(newAdminKeys, i -> Ed25519PrivateKey.generate());
+
+        ThresholdKey thresholdKey = new ThresholdKey(3)
+            .addAll(Arrays.stream(newAdminKeys)
+                .peek(k -> System.out.println("New key created for 3-of-4 threshold adminKey: " + k))
+                .map(k -> k.publicKey)
+                .collect(Collectors.toList()));
+
+        Transaction transaction = new ConsensusTopicUpdateTransaction()
+            .setMaxTransactionFee(50_000_000L)
+            .setTopicId(topicId)
+            .setTopicMemo("updated demo topic")
+            .setAdminKey(thresholdKey)
+            .build(hapiClient);
+
+        // Sign with the initial adminKey. 2 of the 3 keys already part of the topic's adminKey.
+        Arrays.stream(initialAdminKeys, 0, 2).forEach(k -> {
+            System.out.println("Signing ConsensusTopicUpdateTransaction with initial admin key " + k);
+            transaction.sign(k);
+        });
+
+        // Sign with the new adminKey. 3 of 4 keys already part of the topic's adminKey.
+        Arrays.stream(newAdminKeys, 0, 3).forEach(k -> {
+            System.out.println("Signing ConsensusTopicUpdateTransaction with new admin key " + k);
+            transaction.sign(k);
+        });
+
+        TransactionId transactionId = transaction.execute(hapiClient);
+
+        // Retrieve results post-consensus.
+        transactionId.getReceipt(hapiClient);
+
+        System.out.println("Updated topic " + topicId + " with 3-of-4 threshold key as adminKey");
+
+        ConsensusTopicInfo topicInfo = new ConsensusTopicInfoQuery().setTopicId(topicId).execute(hapiClient);
+        System.out.println(topicInfo);
+    }
+}


### PR DESCRIPTION
I added 2 HCS-related examples:
- 1 publishing and subscribing to messages with a simple submitKey required for submit/publish
- 1 creating a new topic with a 2-of-3 threshold key, then updating that topic to a 3-of-4 threshold key

Removed the base class per @abonander comments on the previous PR and I can make it all 1 function like some of the other examples if that's desired.

There's no rush to get this on the hcs branch, and can just be merged to master when hcs is merged to master if that's easier.