### PR TITLE
Update HCS examples to use MirrorClient and default to testnet

### DIFF
--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/ConsensusPubSub.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/ConsensusPubSub.java
@@ -20,11 +20,6 @@ import io.github.cdimascio.dotenv.Dotenv;
 
 public final class ConsensusPubSub {
 
-    // see `.env.sample` in the repository root for how to specify these values
-    // or set environment variables with the same names
-    private static final AccountId NODE_ID = AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("NODE_ID")));
-    private static final String NODE_ADDRESS = Objects.requireNonNull(Dotenv.load().get("NODE_ADDRESS"));
-
     private static final AccountId OPERATOR_ID = AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_ID")));
     private static final Ed25519PrivateKey OPERATOR_KEY = Ed25519PrivateKey.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_KEY")));
 
@@ -36,22 +31,18 @@ public final class ConsensusPubSub {
     public static void main(String[] args) throws InterruptedException, HederaStatusException {
         final MirrorClient mirrorClient = new MirrorClient(MIRROR_NODE_ADDRESS);
 
-        // To improve responsiveness, you should specify multiple nodes
-        Client client = new Client(new HashMap<AccountId, String>() {
-            {
-                put(NODE_ID, NODE_ADDRESS);
-            }
-        });
+        // `Client.forMainnet()` is provided for connecting to Hedera mainnet
+        Client client = Client.forTestnet();
 
         // Defaults the operator account ID and key such that all generated transactions will be paid for
         // by this account and be signed by this key
         client.setOperator(OPERATOR_ID, OPERATOR_KEY);
 
         final TransactionId transactionId = new ConsensusTopicCreateTransaction()
-            .setMaxTransactionFee(1_000_000_000)
             .execute(client);
 
         final ConsensusTopicId topicId = transactionId.getReceipt(client).getConsensusTopicId();
+        System.out.println("New topic created: " + topicId);
 
         new MirrorConsensusTopicQuery()
             .setTopicId(topicId)

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/TopicWithAdminKey.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/TopicWithAdminKey.java
@@ -15,7 +15,6 @@ import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
 import io.github.cdimascio.dotenv.Dotenv;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -47,24 +46,13 @@ class TopicWithAdminKey {
     }
 
     private void setupHapiClient() {
-        // see `.env.sample` in the repository root for how to specify these values or set environment variables with
-        // the same names
-
-        // The Hedera Hashgraph node's IP address, port, and account ID.
-        AccountId nodeAccountId = AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("NODE_ID")));
-        String nodeAddress = Objects.requireNonNull(Dotenv.load().get("NODE_ADDRESS"));
-
         // Transaction payer's account ID and ED25519 private key.
         AccountId payerId = AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_ID")));
         Ed25519PrivateKey payerPrivateKey =
             Ed25519PrivateKey.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_KEY")));
 
         // Interface used to publish messages on the HCS topic.
-        hapiClient = new Client(new HashMap<AccountId, String>() {
-            {
-                put(nodeAccountId, nodeAddress);
-            }
-        });
+        hapiClient = Client.forTestnet();
 
         // Defaults the operator account ID and key such that all generated transactions will be paid for by this
         // account and be signed by this key
@@ -84,7 +72,6 @@ class TopicWithAdminKey {
                 .collect(Collectors.toList()));
 
         Transaction transaction = new ConsensusTopicCreateTransaction()
-            .setMaxTransactionFee(50_000_000L)
             .setTopicMemo("demo topic")
             .setAdminKey(thresholdKey)
             .build(hapiClient);
@@ -115,7 +102,6 @@ class TopicWithAdminKey {
                 .collect(Collectors.toList()));
 
         Transaction transaction = new ConsensusTopicUpdateTransaction()
-            .setMaxTransactionFee(50_000_000L)
             .setTopicId(topicId)
             .setTopicMemo("updated demo topic")
             .setAdminKey(thresholdKey)


### PR DESCRIPTION
- Update HCS examples to use MirrorClient as opposed to ConsensusClient
- Have HAPI client pointing at Client.forTestnet() now that HCS is in testnet
- Don't hardcode fees

Fixes #340 