### PR TITLE
Add new exception types for different sources of status errors

### DIFF
--- a/src/main/java/com/hedera/hashgraph/sdk/HederaPrecheckStatusException.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/HederaPrecheckStatusException.java
@@ -1,0 +1,31 @@
+package com.hedera.hashgraph.sdk;
+
+import com.hedera.hashgraph.proto.ResponseCodeEnum;
+
+/**
+ * A {@link HederaStatusException}, thrown specifically by a transaction precheck (validation
+ * on the node it was submitted to).
+ */
+public class HederaPrecheckStatusException extends HederaStatusException {
+    /**
+     * The ID of the transaction that failed, in case that context is no longer available
+     * (e.g. the exception was bubbled up).
+     */
+    public final TransactionId transactionId;
+
+    HederaPrecheckStatusException(ResponseCodeEnum responseCode, TransactionId transactionId) {
+        super(responseCode);
+        this.transactionId = transactionId;
+    }
+
+    static void throwIfExceptional(ResponseCodeEnum responseCode, TransactionId transactionId) throws HederaPrecheckStatusException {
+        if (isCodeExceptional(responseCode)) {
+            throw new HederaPrecheckStatusException(responseCode, transactionId);
+        }
+    }
+
+    @Override
+    public String getMessage() {
+        return "transaction " + transactionId + " failed precheck with error status " + status;
+    }
+}

--- a/src/main/java/com/hedera/hashgraph/sdk/HederaReceiptStatusException.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/HederaReceiptStatusException.java
@@ -1,0 +1,47 @@
+package com.hedera.hashgraph.sdk;
+
+import com.hedera.hashgraph.proto.ResponseCodeEnum;
+import com.hedera.hashgraph.proto.TransactionGetReceiptQuery;
+import com.hedera.hashgraph.proto.TransactionGetReceiptResponse;
+
+/**
+ * A {@link HederaStatusException}, thrown on error status by {@link TransactionId#getReceipt(Client)}.
+ *
+ * The receipt is included, though only the {@link TransactionReceipt#status} field will be
+ * initialized; all the getters should throw.
+ */
+public class HederaReceiptStatusException extends HederaStatusException {
+    /**
+     * The ID of the transaction that failed, in case that context is no longer available
+     * (e.g. the exception was bubbled up).
+     */
+    public final TransactionId transactionId;
+
+    /**
+     * The receipt of the transaction that failed; the only initialized field is
+     * {@link TransactionReceipt#status}.
+     */
+    public final TransactionReceipt receipt;
+
+    HederaReceiptStatusException(ResponseCodeEnum responseCode, TransactionId transactionId, TransactionReceipt receipt) {
+        super(responseCode);
+        this.transactionId = transactionId;
+        this.receipt = receipt;
+    }
+
+    static void throwIfExceptional(TransactionGetReceiptQuery receiptQuery, TransactionGetReceiptResponse receiptResponse) throws HederaReceiptStatusException {
+        ResponseCodeEnum status = receiptResponse.getReceipt().getStatus();
+
+        if (isCodeExceptional(receiptResponse.getReceipt().getStatus())) {
+            throw new HederaReceiptStatusException(
+                status,
+                new TransactionId(receiptQuery.getTransactionIDOrBuilder()),
+                new TransactionReceipt(receiptResponse.getReceipt()));
+        }
+    }
+
+    @Override
+    public String getMessage() {
+        return "receipt for transaction " + transactionId + " contained error status " + status;
+    }
+}

--- a/src/main/java/com/hedera/hashgraph/sdk/HederaRecordStatusException.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/HederaRecordStatusException.java
@@ -1,0 +1,46 @@
+package com.hedera.hashgraph.sdk;
+
+import com.hedera.hashgraph.proto.ResponseCodeEnum;
+import com.hedera.hashgraph.proto.TransactionGetRecordResponse;
+
+/**
+ * A {@link HederaStatusException}, thrown on error status by {@link TransactionId#getRecord(Client)}.
+ *
+ * The record is included which could contain useful context for the error, such as errors
+ * returned by {@link com.hedera.hashgraph.sdk.contract.ContractExecuteTransaction}.
+ */
+public class HederaRecordStatusException extends HederaStatusException {
+    /**
+     * The ID of the transaction that failed, in case that context is no longer available
+     * (e.g. the exception was bubbled up).
+     */
+    public final TransactionId transactionId;
+
+    /**
+     * The record that was fetched; it may still contain useful context (such as contract execution
+     * logs).
+     */
+    public final TransactionRecord record;
+
+    HederaRecordStatusException(ResponseCodeEnum responseCode, TransactionRecord record) {
+        super(responseCode);
+        this.record = record;
+        this.transactionId = record.transactionId;
+    }
+
+    static void throwIfExceptional(TransactionGetRecordResponse recordResponse) throws HederaRecordStatusException {
+        ResponseCodeEnum status = recordResponse.getTransactionRecord().getReceipt().getStatus();
+
+        if (isCodeExceptional(status)) {
+            throw new HederaRecordStatusException(
+                status,
+                new TransactionRecord(recordResponse.getTransactionRecord()));
+        }
+    }
+
+    @Override
+    public String getMessage() {
+        return "record for transaction " + transactionId + " contained error status " + status
+            + "\nthis Exception instance contains the record that was fetched";
+    }
+}

--- a/src/main/java/com/hedera/hashgraph/sdk/HederaStatusException.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/HederaStatusException.java
@@ -2,7 +2,23 @@ package com.hedera.hashgraph.sdk;
 
 import com.hedera.hashgraph.proto.ResponseCodeEnum;
 
+/**
+ * Base class for exceptions thrown from HAPI calls that result in a {@link Status} code that
+ * is not {@link Status#Success}.
+ *
+ * Additional context is provided by the specific subclass that is thrown:
+ *
+ * <ul>
+ *     <li>{@link HederaPrecheckStatusException}</li>
+ *     <li>{@link HederaReceiptStatusException}</li>
+ *     <li>{@link HederaRecordStatusException}</li>
+ * </ul>
+ */
 public class HederaStatusException extends Exception implements HederaThrowable {
+    /**
+     * The status code carried by this exception. It will not be {@link Status#Ok} or
+     * {@link Status#Success}.
+     */
     public final Status status;
 
     HederaStatusException(ResponseCodeEnum responseCode) {

--- a/src/main/java/com/hedera/hashgraph/sdk/Status.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Status.java
@@ -2,6 +2,8 @@ package com.hedera.hashgraph.sdk;
 
 import com.hedera.hashgraph.proto.ResponseCodeEnum;
 
+import java.util.Arrays;
+
 public enum Status {
     Ok(ResponseCodeEnum.OK),
     InvalidTransaction(ResponseCodeEnum.INVALID_TRANSACTION),
@@ -135,6 +137,10 @@ public enum Status {
 
     public String toString() {
         return responseCode.toString();
+    }
+
+    boolean equalsAny(Status... statuses) {
+        return Arrays.asList(statuses).contains(this);
     }
 
     static Status valueOf(ResponseCodeEnum responseCode) {

--- a/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -269,7 +269,7 @@ public final class Transaction extends HederaCall<com.hedera.hashgraph.proto.Tra
 
     @Override
     protected TransactionId mapResponse(TransactionResponse response) throws HederaStatusException {
-        HederaStatusException.throwIfExceptional(response.getNodeTransactionPrecheckCode());
+        HederaPrecheckStatusException.throwIfExceptional(response.getNodeTransactionPrecheckCode());
         return new TransactionId(txnIdProto);
     }
 

--- a/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/TransactionBuilder.java
@@ -221,7 +221,7 @@ public abstract class TransactionBuilder<T extends TransactionBuilder<T>>
 
     @Override
     protected TransactionId mapResponse(TransactionResponse response) throws HederaStatusException {
-        HederaStatusException.throwIfExceptional(response.getNodeTransactionPrecheckCode());
+        HederaPrecheckStatusException.throwIfExceptional(response.getNodeTransactionPrecheckCode());
         return new TransactionId(
             bodyBuilder.getTransactionIDOrBuilder());
     }


### PR DESCRIPTION
These include additional context where available.

This solves the problem that `getRecord()` throws on the `getReceipt()` internal call even though records may contain useful information in the error case; in this case only `Busy` and `Unknown` are bubbled up and other status codes are ignored. If the transaction failed, the specific subclass of `HederaStatusException` will be `HederaRecordStatusException` which contains the record we fetched.

TODO:
- [x] override `getMessage()` in the subclasses to return more context