### PR TITLE
start integration testing by covering new exception types

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -70,6 +70,7 @@ jobs:
 
     - name: install SDK
       run: mvn install # implicitly runs tests
+      # TODO: turn on `integration-testing` profile when we have testnet account for CI
 
     - name: Build Android Example
       working-directory: android-example

--- a/pom.xml
+++ b/pom.xml
@@ -251,15 +251,6 @@
                             </excludes>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>default-integration-test</id>
-                        <phase>integration-test</phase>
-                        <goals><goal>test</goal></goals>
-                        <!--
-                            can't exclude unit tests and still run integration tests
-                            but unit tests are idempotent so it's not the end of the world
-                         -->
-                    </execution>
                 </executions>
             </plugin>
 
@@ -478,6 +469,30 @@
                                 </arg>
                             </compilerArgs>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>integration-testing</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <!-- Surefire configured for integration testing as a separate profile -->
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M3</version>
+                        <executions>
+                            <execution>
+                                <id>default-integration-test</id>
+                                <phase>integration-test</phase>
+                                <goals><goal>test</goal></goals>
+                                <!--
+                                    can't exclude unit tests and still run integration tests
+                                    but unit tests are idempotent so it's not the end of the world
+                                 -->
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.hedera.hashgraph</groupId>
     <artifactId>sdk</artifactId>
@@ -51,7 +51,8 @@
 
     <scm>
         <connection>scm:git:https://github.com/hashgraph/hedera-sdk-java.git</connection>
-        <developerConnection>scm:git:ssh://github.com:hashgraph/hedera-sdk-java.git</developerConnection>
+        <developerConnection>scm:git:ssh://github.com:hashgraph/hedera-sdk-java.git
+        </developerConnection>
         <url>https://github.com/hashgraph/hedera-sdk-java</url>
     </scm>
 
@@ -130,6 +131,20 @@
             <artifactId>spotbugs-annotations</artifactId>
             <scope>provided</scope>
             <version>${spotbugs.version}</version>
+        </dependency>
+
+        <!-- integration test dependencies -->
+        <dependency>
+            <groupId>io.github.cdimascio</groupId>
+            <artifactId>java-dotenv</artifactId>
+            <version>5.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>${grpc.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -223,6 +238,29 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <phase>test</phase>
+                        <goals><goal>test</goal></goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>
+                                    **/integration_tests/*.*
+                                </exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>default-integration-test</id>
+                        <phase>integration-test</phase>
+                        <goals><goal>test</goal></goals>
+                        <!--
+                            can't exclude unit tests and still run integration tests
+                            but unit tests are idempotent so it's not the end of the world
+                         -->
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>
@@ -309,10 +347,12 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>${protobuf.plugin.version}</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}
+                    <protocArtifact>
+                        com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}
                     </protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
+                    <pluginArtifact>
+                        io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
                     </pluginArtifact>
                     <additionalProtoPathElements>
                         <element>
@@ -332,9 +372,9 @@
         </plugins>
     </build>
     <profiles>
-     <!-- shade profile which adds the possibility to shade the .jar file.
-        Call "mvn clean install -Pshade" to invoke this additional
-        plugin in the maven build -->
+        <!-- shade profile which adds the possibility to shade the .jar file.
+           Call "mvn clean install -Pshade" to invoke this additional
+           plugin in the maven build -->
         <profile>
             <id>shade</id>
             <build>

--- a/src/main/java/com/hedera/hashgraph/sdk/HederaPrecheckStatusException.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/HederaPrecheckStatusException.java
@@ -26,6 +26,6 @@ public class HederaPrecheckStatusException extends HederaStatusException {
 
     @Override
     public String getMessage() {
-        return "transaction " + transactionId + " failed precheck with error status " + status;
+        return "transaction " + transactionId + " failed precheck with status " + status;
     }
 }

--- a/src/main/java/com/hedera/hashgraph/sdk/QueryBuilder.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/QueryBuilder.java
@@ -269,8 +269,11 @@ public abstract class QueryBuilder<Resp, T extends QueryBuilder<Resp, T>> extend
 
     @Override
     protected final Resp mapResponse(Response raw) throws HederaStatusException {
-        final ResponseCodeEnum precheckCode = getResponseHeader(raw).getNodeTransactionPrecheckCode();
-        HederaPrecheckStatusException.throwIfExceptional(precheckCode, Objects.requireNonNull(paymentTransactionId));
+        if (paymentTransactionId != null) {
+            // precheck code for transaction only matters if we have a payment attached
+            final ResponseCodeEnum precheckCode = getResponseHeader(raw).getNodeTransactionPrecheckCode();
+            HederaPrecheckStatusException.throwIfExceptional(precheckCode, paymentTransactionId);
+        }
 
         switch (raw.getResponseCase()) {
             case TRANSACTIONGETRECEIPT:

--- a/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -269,7 +269,7 @@ public final class Transaction extends HederaCall<com.hedera.hashgraph.proto.Tra
 
     @Override
     protected TransactionId mapResponse(TransactionResponse response) throws HederaStatusException {
-        HederaPrecheckStatusException.throwIfExceptional(response.getNodeTransactionPrecheckCode());
+        HederaPrecheckStatusException.throwIfExceptional(response.getNodeTransactionPrecheckCode(), id);
         return new TransactionId(txnIdProto);
     }
 

--- a/src/test/java/com/hedera/hashgraph/sdk/integration_tests/ExceptionsTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/integration_tests/ExceptionsTest.java
@@ -2,6 +2,7 @@ package com.hedera.hashgraph.sdk.integration_tests;
 
 import com.hedera.hashgraph.sdk.Hbar;
 import com.hedera.hashgraph.sdk.HederaPrecheckStatusException;
+import com.hedera.hashgraph.sdk.HederaReceiptStatusException;
 import com.hedera.hashgraph.sdk.Transaction;
 import com.hedera.hashgraph.sdk.account.AccountId;
 import com.hedera.hashgraph.sdk.account.CryptoTransferTransaction;
@@ -15,7 +16,7 @@ public class ExceptionsTest {
     private final TestEnv testEnv = new TestEnv();
 
     @Test
-    @DisplayName("precheck exception is thrown for bad signature")
+    @DisplayName("HederaPrecheckStatusException is thrown for bad account amounts")
     void precheckException() {
         Transaction badTxn = new CryptoTransferTransaction()
             .addSender(new AccountId(2), new Hbar(5))
@@ -28,6 +29,27 @@ public class ExceptionsTest {
 
         Assertions.assertEquals("transaction "
                 + badTxn.id + " failed precheck with status ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS",
+            exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("HederaReceiptStatusException is thrown for bad signature")
+    void receiptException() {
+        Transaction badTxn = new CryptoTransferTransaction()
+            .addSender(new AccountId(2), new Hbar(10))
+            .addRecipient(testEnv.operatorId, new Hbar(10))
+            .build(testEnv.client);
+
+        HederaReceiptStatusException exception = Assertions.assertThrows(
+            HederaReceiptStatusException.class,
+            () -> {
+                badTxn
+                    .execute(testEnv.client)
+                    .getReceipt(testEnv.client);
+            });
+
+        Assertions.assertEquals("receipt for transaction "
+                + badTxn.id + " contained error status INVALID_SIGNATURE",
             exception.getMessage());
     }
 }

--- a/src/test/java/com/hedera/hashgraph/sdk/integration_tests/ExceptionsTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/integration_tests/ExceptionsTest.java
@@ -1,0 +1,33 @@
+package com.hedera.hashgraph.sdk.integration_tests;
+
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.HederaPrecheckStatusException;
+import com.hedera.hashgraph.sdk.Transaction;
+import com.hedera.hashgraph.sdk.account.AccountId;
+import com.hedera.hashgraph.sdk.account.CryptoTransferTransaction;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ExceptionsTest {
+
+    private final TestEnv testEnv = new TestEnv();
+
+    @Test
+    @DisplayName("precheck exception is thrown for bad signature")
+    void precheckException() {
+        Transaction badTxn = new CryptoTransferTransaction()
+            .addSender(new AccountId(2), new Hbar(5))
+            .addSender(new AccountId(2), new Hbar(5))
+            .addRecipient(testEnv.operatorId, new Hbar(10))
+            .build(testEnv.client);
+
+        HederaPrecheckStatusException exception = Assertions.assertThrows(
+            HederaPrecheckStatusException.class, () -> badTxn.execute(testEnv.client));
+
+        Assertions.assertEquals("transaction "
+                + badTxn.id + " failed precheck with status ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS",
+            exception.getMessage());
+    }
+}

--- a/src/test/java/com/hedera/hashgraph/sdk/integration_tests/TestEnv.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/integration_tests/TestEnv.java
@@ -15,10 +15,15 @@ public class TestEnv {
     public final Client client;
 
     public TestEnv() {
-        final Dotenv dotenv = Dotenv.load();
+        final Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
 
-        operatorId = AccountId.fromString(Objects.requireNonNull(dotenv.get("OPERATOR_ID")));
-        operatorKey = Ed25519PrivateKey.fromString(Objects.requireNonNull(dotenv.get("OPERATOR_KEY")));
+        operatorId = AccountId.fromString(Objects.requireNonNull(
+            dotenv.get("OPERATOR_ID"),
+            "OPERATOR_ID must be set in environment or .env"));
+
+        operatorKey = Ed25519PrivateKey.fromString(Objects.requireNonNull(
+            dotenv.get("OPERATOR_KEY"),
+            "OPERATOR_KEY must be set in environment or .env"));
 
         client = Client.forTestnet().setOperator(operatorId, operatorKey);
     }

--- a/src/test/java/com/hedera/hashgraph/sdk/integration_tests/TestEnv.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/integration_tests/TestEnv.java
@@ -1,0 +1,25 @@
+package com.hedera.hashgraph.sdk.integration_tests;
+
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.account.AccountId;
+import com.hedera.hashgraph.sdk.crypto.ed25519.Ed25519PrivateKey;
+
+import java.util.Objects;
+
+import io.github.cdimascio.dotenv.Dotenv;
+
+public class TestEnv {
+
+    public final AccountId operatorId;
+    public final Ed25519PrivateKey operatorKey;
+    public final Client client;
+
+    public TestEnv() {
+        final Dotenv dotenv = Dotenv.load();
+
+        operatorId = AccountId.fromString(Objects.requireNonNull(dotenv.get("OPERATOR_ID")));
+        operatorKey = Ed25519PrivateKey.fromString(Objects.requireNonNull(dotenv.get("OPERATOR_KEY")));
+
+        client = Client.forTestnet().setOperator(operatorId, operatorKey);
+    }
+}


### PR DESCRIPTION
- [x] tested `HederaPrecheckStatusException` and found a bug (we were calling the wrong version of `.throwIfExceptional()`)
- [x] tested `HederaReceiptStatusException` (apparently `INVALID_SIGNATURE` errors aren't returned during precheck so that's a good one, can just copy the precheck test and fix the amounts)
- [ ] tested `HederaRecordStatusException` (maybe with a contract execute to test logging? we'll want to create and destroy a contract though which requires setup/teardown)

Actually running these tests on CI is blocked on getting a testnet account and private key for CI.