### PR TITLE
implement encrypted PEM private key import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,8 @@
         <nullaway.version>0.7.2</nullaway.version>
         <spotbugs.version>3.1.12</spotbugs.version>
 
+        <bouncycastle.version>1.64</bouncycastle.version>
+
         <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
         <protoc.version>3.11.2</protoc.version>
     </properties>
@@ -73,7 +75,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.64</version>
+            <version>${bouncycastle.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/src/main/java/com/hedera/hashgraph/sdk/crypto/BadKeyException.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/crypto/BadKeyException.java
@@ -4,7 +4,8 @@ import com.google.gson.JsonSyntaxException;
 import com.hedera.hashgraph.sdk.Internal;
 
 public final class BadKeyException extends IllegalArgumentException {
-    BadKeyException(String message) { super(message); }
+    @Internal
+    public BadKeyException(String message) { super(message); }
 
     BadKeyException(JsonSyntaxException e) {
         super(e);

--- a/src/main/java/com/hedera/hashgraph/sdk/crypto/CryptoUtils.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/crypto/CryptoUtils.java
@@ -1,0 +1,149 @@
+package com.hedera.hashgraph.sdk.crypto;
+
+import com.hedera.hashgraph.sdk.Internal;
+
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.digests.SHA384Digest;
+import org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator;
+import org.bouncycastle.crypto.macs.HMac;
+import org.bouncycastle.crypto.params.KeyParameter;
+
+import java.nio.charset.StandardCharsets;
+import java.security.AlgorithmParameters;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+@Internal
+public final class CryptoUtils {
+    /**
+     * A {@link SecureRandom} instance for internal use.
+     */
+    // SecureRandom.getInstanceStrong() is horrible inside Docker (because it blocks forever
+    // waiting for entropy) so we avoid it
+    public static final SecureRandom secureRandom = new SecureRandom();
+
+    static final int IV_LEN = 16;
+    static final int ITERATIONS = 262144;
+    static final int SALT_LEN = 32;
+    static final int DK_LEN = 32;
+
+    // OpenSSL doesn't like longer derived keys
+    static final int CBC_DK_LEN = 16;
+
+    private CryptoUtils() { }
+
+    static KeyParameter deriveKeySha256(String passphrase, byte[] salt, int iterations, int dkLenBytes) {
+        final PKCS5S2ParametersGenerator gen = new PKCS5S2ParametersGenerator(new SHA256Digest());
+        gen.init(passphrase.getBytes(StandardCharsets.UTF_8), salt, iterations);
+
+        return (KeyParameter) gen.generateDerivedParameters(dkLenBytes * 8);
+    }
+
+    static Cipher initAesCtr128(KeyParameter cipherKey, byte[] iv, boolean forDecrypt) {
+        final Cipher aesCipher;
+
+        try {
+            aesCipher = Cipher.getInstance("AES/CTR/PKCS5Padding");
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+            throw new Error("platform does not support AES-CTR ciphers");
+        }
+
+        return initAesCipher(aesCipher, cipherKey, iv, forDecrypt);
+    }
+
+    static Cipher initAesCbc128Encrypt(KeyParameter cipherKey, byte[] iv) {
+        final Cipher aesCipher;
+
+        try {
+            aesCipher = Cipher.getInstance("AES/CBC/NoPadding");
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+            throw new Error("platform does not support AES-CBC ciphers");
+        }
+
+        return initAesCipher(aesCipher, cipherKey, iv, false);
+    }
+
+    static Cipher initAesCbc128Decrypt(KeyParameter cipherKey, AlgorithmParameters parameters) {
+        final Cipher aesCipher;
+
+        try {
+            aesCipher = Cipher.getInstance("AES/CBC/NoPadding");
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+            throw new Error("platform does not support AES-CBC ciphers");
+        }
+
+        try {
+            aesCipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(cipherKey.getKey(), 0, 16, "AES"), parameters);
+        } catch (InvalidKeyException e) {
+            throw new Error("platform does not support AES-128 ciphers");
+        } catch (InvalidAlgorithmParameterException e) {
+            throw new Error(e);
+        }
+
+        return aesCipher;
+    }
+
+    private static Cipher initAesCipher(Cipher aesCipher, KeyParameter cipherKey, byte[] iv, boolean forDecrypt) {
+        final int mode = forDecrypt ? Cipher.DECRYPT_MODE : Cipher.ENCRYPT_MODE;
+
+        try {
+            aesCipher.init(mode, new SecretKeySpec(cipherKey.getKey(), 0, 16, "AES"),
+                new IvParameterSpec(iv));
+        } catch (InvalidKeyException e) {
+            throw new Error("platform does not support AES-128 ciphers");
+        } catch (InvalidAlgorithmParameterException e) {
+            throw new Error(e);
+        }
+
+        return aesCipher;
+    }
+
+    static byte[] encryptAesCtr128(KeyParameter cipherKey, byte[] iv, byte[] input) {
+        final Cipher aesCipher = initAesCtr128(cipherKey, iv, false);
+        return runCipher(aesCipher, input);
+    }
+
+    static byte[] decryptAesCtr128(KeyParameter cipherKey, byte[] iv, byte[] input) {
+        final Cipher aesCipher = initAesCtr128(cipherKey, iv, true);
+        return runCipher(aesCipher, input);
+    }
+
+    static byte[] runCipher(Cipher cipher, byte[] input) {
+        final byte[] output = new byte[cipher.getOutputSize(input.length)];
+
+        try {
+            cipher.doFinal(input, 0, input.length, output);
+        } catch (ShortBufferException | IllegalBlockSizeException | BadPaddingException e) {
+            throw new Error(e);
+        }
+
+        return output;
+    }
+
+    static byte[] calcHmacSha384(KeyParameter cipherKey, byte[] input) {
+        final HMac hmacSha384 = new HMac(new SHA384Digest());
+        final byte[] output = new byte[hmacSha384.getMacSize()];
+
+        hmacSha384.init(new KeyParameter(cipherKey.getKey(), 16, 16));
+        hmacSha384.update(input, 0, input.length);
+        hmacSha384.doFinal(output, 0);
+
+        return output;
+    }
+
+    static byte[] randomBytes(int len) {
+        final byte[] out = new byte[len];
+        secureRandom.nextBytes(out);
+        return out;
+    }
+}

--- a/src/main/java/com/hedera/hashgraph/sdk/crypto/PemUtils.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/crypto/PemUtils.java
@@ -1,0 +1,160 @@
+package com.hedera.hashgraph.sdk.crypto;
+
+import com.hedera.hashgraph.sdk.Internal;
+
+import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
+import org.bouncycastle.asn1.pkcs.EncryptedPrivateKeyInfo;
+import org.bouncycastle.asn1.pkcs.EncryptionScheme;
+import org.bouncycastle.asn1.pkcs.KeyDerivationFunc;
+import org.bouncycastle.asn1.pkcs.PBES2Parameters;
+import org.bouncycastle.asn1.pkcs.PBKDF2Params;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemReader;
+import org.bouncycastle.util.io.pem.PemWriter;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.security.AlgorithmParameters;
+import java.security.NoSuchAlgorithmException;
+
+import javax.annotation.Nullable;
+import javax.crypto.Cipher;
+
+@Internal
+public final class PemUtils {
+    public static final String TYPE_PRIVATE_KEY = "PRIVATE KEY";
+    public static final String TYPE_ENCRYPTED_PRIVATE_KEY = "ENCRYPTED PRIVATE KEY";
+
+    private PemUtils() { }
+
+    /*
+     * For some reason, this generates PEM encodings that we ourselves can import, but OpenSSL
+     * doesn't like. We decided to punt on generating encrypted PEMs for now but saving
+     * the code for when we get back to it and/or any demand arises.
+     */
+    @SuppressWarnings("unused")
+    public static void writeEncryptedPrivateKey(PrivateKeyInfo pkInfo, Writer out, String passphrase) throws IOException {
+        byte[] salt = CryptoUtils.randomBytes(CryptoUtils.SALT_LEN);
+
+        KeyParameter derivedKey = CryptoUtils.deriveKeySha256(
+            passphrase, salt, CryptoUtils.ITERATIONS, CryptoUtils.CBC_DK_LEN);
+
+        byte[] iv = CryptoUtils.randomBytes(CryptoUtils.IV_LEN);
+
+        Cipher cipher = CryptoUtils.initAesCbc128Encrypt(derivedKey, iv);
+
+        byte[] encryptedKey = CryptoUtils.runCipher(cipher, pkInfo.getEncoded());
+
+        // I wanted to just do this with BC's PKCS8Generator and KcePKCSPBEOutputEncryptorBuilder
+        // but it tries to init AES instance of `Cipher` with a `PBKDF2Key` and the former complains
+
+        // So this is basically a reimplementation of that minus the excess OO
+        PBES2Parameters parameters = new PBES2Parameters(
+            new KeyDerivationFunc(
+                PKCSObjectIdentifiers.id_PBKDF2,
+                new PBKDF2Params(
+                    salt,
+                    CryptoUtils.ITERATIONS,
+                    CryptoUtils.CBC_DK_LEN,
+                    new AlgorithmIdentifier(PKCSObjectIdentifiers.id_hmacWithSHA256))),
+            new EncryptionScheme(NISTObjectIdentifiers.id_aes128_CBC,
+                ASN1Primitive.fromByteArray(cipher.getParameters().getEncoded())));
+
+        EncryptedPrivateKeyInfo encryptedPrivateKeyInfo = new EncryptedPrivateKeyInfo(
+            new AlgorithmIdentifier(PKCSObjectIdentifiers.id_PBES2, parameters),
+            encryptedKey);
+
+        PemWriter writer = new PemWriter(out);
+        writer.writeObject(new PemObject(TYPE_ENCRYPTED_PRIVATE_KEY, encryptedPrivateKeyInfo.getEncoded()));
+        writer.flush();
+    }
+
+    public static PrivateKeyInfo readPrivateKey(Reader input, @Nullable String passphrase) throws IOException {
+        final PemReader pemReader = new PemReader(input);
+
+        PemObject readObject = null;
+
+        for (;;) {
+            PemObject nextObject = pemReader.readPemObject();
+
+            if (nextObject == null) break;
+            readObject = nextObject;
+
+            String objType = readObject.getType();
+
+            if (passphrase != null && !passphrase.isEmpty() && objType.equals(TYPE_ENCRYPTED_PRIVATE_KEY)) {
+                return decryptPrivateKey(readObject.getContent(), passphrase);
+            } else if (objType.equals(TYPE_PRIVATE_KEY)) {
+                return PrivateKeyInfo.getInstance(readObject.getContent());
+            }
+        }
+
+        if (readObject != null && readObject.getType().equals(TYPE_ENCRYPTED_PRIVATE_KEY)) {
+            throw new BadKeyException("PEM file contained an encrypted private key but no passphrase was given");
+        }
+
+        throw new BadKeyException("PEM file did not contain a private key");
+    }
+
+    private static PrivateKeyInfo decryptPrivateKey(byte[] encodedStruct, String passphrase) throws IOException {
+        PKCS8EncryptedPrivateKeyInfo encryptedPrivateKeyInfo = new PKCS8EncryptedPrivateKeyInfo(encodedStruct);
+
+        AlgorithmIdentifier encryptAlg = encryptedPrivateKeyInfo.getEncryptionAlgorithm();
+
+        if (!encryptAlg.getAlgorithm().equals(PKCSObjectIdentifiers.id_PBES2)) {
+            throw new BadKeyException("unsupported PEM key encryption: " + encryptAlg);
+        }
+
+        PBES2Parameters params = PBES2Parameters.getInstance(encryptAlg.getParameters());
+        KeyDerivationFunc kdf = params.getKeyDerivationFunc();
+        EncryptionScheme encScheme = params.getEncryptionScheme();
+
+        if (!kdf.getAlgorithm().equals(PKCSObjectIdentifiers.id_PBKDF2)) {
+            throw new BadKeyException("unsupported KDF: " + kdf.getAlgorithm());
+        }
+
+        if (!encScheme.getAlgorithm().equals(NISTObjectIdentifiers.id_aes128_CBC)) {
+            throw new BadKeyException("unsupported encryption: " + encScheme.getAlgorithm());
+        }
+
+        PBKDF2Params kdfParams = PBKDF2Params.getInstance(kdf.getParameters());
+
+        if (!kdfParams.getPrf().getAlgorithm().equals(PKCSObjectIdentifiers.id_hmacWithSHA256)) {
+            throw new BadKeyException("unsupported PRF: " + kdfParams.getPrf());
+        }
+
+        int keyLength = kdfParams.getKeyLength() != null
+            ? kdfParams.getKeyLength().intValueExact()
+            : CryptoUtils.CBC_DK_LEN;
+
+        KeyParameter derivedKey = CryptoUtils.deriveKeySha256(
+            passphrase,
+            kdfParams.getSalt(),
+            kdfParams.getIterationCount().intValueExact(),
+            keyLength);
+
+        AlgorithmParameters aesParams;
+        try {
+            aesParams = AlgorithmParameters.getInstance("AES");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        aesParams.init(encScheme.getParameters().toASN1Primitive().getEncoded());
+
+        Cipher cipher = CryptoUtils.initAesCbc128Decrypt(derivedKey, aesParams);
+        byte[] decrypted = CryptoUtils.runCipher(cipher, encryptedPrivateKeyInfo.getEncryptedData());
+
+        // we need to parse our input data as the cipher may add padding
+        ASN1InputStream inputStream = new ASN1InputStream(new ByteArrayInputStream(decrypted));
+        return PrivateKeyInfo.getInstance(inputStream.readObject());
+    }
+}

--- a/src/main/java/com/hedera/hashgraph/sdk/crypto/PrivateKey.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/crypto/PrivateKey.java
@@ -1,17 +1,8 @@
 package com.hedera.hashgraph.sdk.crypto;
 
-import com.hedera.hashgraph.proto.SignaturePair;
 import com.hedera.hashgraph.sdk.Internal;
 
-import java.security.SecureRandom;
-
 public abstract class PrivateKey<PubKey extends PublicKey> {
-    /**
-     * A {@link SecureRandom} instance that implementations can use by default.
-     */
-    // SecureRandom.getInstanceStrong() is horrible inside Docker (because it blocks forever
-    // waiting for entropy) so we avoid it
-    protected static final SecureRandom secureRandom = new SecureRandom();
 
     /**
      * The public-key half of this private key.


### PR DESCRIPTION
Tested working with an encrypted private key from OpenSSL

Deprecated `Ed25519PrivateKey.writePem()` for removal as the utility of the method is limited.