### PR TITLE
test `Status.valueOf()` for all valid cases of `ResponseCodeEnum`

### DIFF
--- a/src/main/java/com/hedera/hashgraph/sdk/Status.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Status.java
@@ -266,8 +266,14 @@ public enum Status {
             case AUTORENEW_ACCOUNT_NOT_ALLOWED: return AutorenewAccountNotAllowed;
             case TOPIC_EXPIRED: return TopicExpired;
 
+            case UNRECOGNIZED:
+                // protobufs won't give us the actual value that was unexpected, unfortunately
+                throw new IllegalArgumentException(
+                    "network returned unrecognized response code; your SDK may be out of date");
+
             default:
-                throw new IllegalArgumentException("unexpected response code: " + responseCode);
+                throw new IllegalArgumentException(
+                    "(BUG) unhandled response code: " + responseCode);
         }
     }
 }

--- a/src/test/java/com/hedera/hashgraph/sdk/StatusTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/StatusTest.java
@@ -1,0 +1,35 @@
+package com.hedera.hashgraph.sdk;
+
+import com.hedera.hashgraph.proto.ResponseCodeEnum;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class StatusTest {
+    @Test
+    @DisplayName("Status can be constructed from any ResponseCode")
+    void statusToResponseCode() {
+        for (ResponseCodeEnum code : ResponseCodeEnum.values()) {
+            // not an actual value we want to handle
+            // this is what we're given if an unexpected value was decoded
+            if (code == ResponseCodeEnum.UNRECOGNIZED) continue;
+
+            Status status = Status.valueOf(code);
+            Assertions.assertEquals(code.getNumber(), status.code);
+        }
+    }
+
+    @Test
+    @DisplayName("Status throws on Unrecognized")
+    void statusUnrecognized() {
+        Assertions.assertEquals(
+            "network returned unrecognized response code; "
+                + "your SDK may be out of date",
+            Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> Status.valueOf(ResponseCodeEnum.UNRECOGNIZED))
+                .getMessage()
+        );
+    }
+}


### PR DESCRIPTION
This ensures we have all possible response codes covered as long as we keep the protobufs up to date.