### PR TITLE
Do not throw on duplicate signatures

### DIFF
--- a/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -87,8 +87,8 @@ public final class Transaction extends HederaCall<com.hedera.hashgraph.proto.Tra
             ByteString pubKeyPrefix = sigPair.getPubKeyPrefix();
 
             if (publicKey.hasPrefix(pubKeyPrefix)) {
-                throw new IllegalArgumentException(
-                    "transaction already signed with key: " + publicKey.toString());
+                // already signed with this key, just return
+                return this;
             }
         }
 

--- a/src/test/java/com/hedera/hashgraph/sdk/TransactionTest.java
+++ b/src/test/java/com/hedera/hashgraph/sdk/TransactionTest.java
@@ -60,10 +60,8 @@ class TransactionTest {
     @Test
     @DisplayName("validate() forbids duplicate signing keys")
     void validateForbidsDuplicates() {
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> txn.sign(key1).sign(key1),
-            "transaction already signed with key: " + key1
+        assertDoesNotThrow(
+            () -> txn.sign(key1).sign(key1)
         );
     }
 


### PR DESCRIPTION
If a duplicate signature is detected, simply return from the method call
Update tests to allow for duplicate signatures.

Closes #412 