### PR TITLE
Various TopicMessageQuery fixes

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
@@ -1,29 +1,43 @@
 package com.hedera.hashgraph.sdk;
 
-import com.hedera.hashgraph.sdk.proto.TransactionID;
-import com.hedera.hashgraph.sdk.proto.mirror.ConsensusServiceGrpc;
-import com.hedera.hashgraph.sdk.proto.mirror.ConsensusTopicQuery;
-import com.hedera.hashgraph.sdk.proto.mirror.ConsensusTopicResponse;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ClientCalls;
 import io.grpc.stub.StreamObserver;
-import java8.util.function.BiConsumer;
-import java8.util.function.Consumer;
-import org.threeten.bp.Instant;
-
-import javax.annotation.Nullable;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.threeten.bp.Instant;
+
+import com.hedera.hashgraph.sdk.proto.TransactionID;
+import com.hedera.hashgraph.sdk.proto.mirror.ConsensusServiceGrpc;
+import com.hedera.hashgraph.sdk.proto.mirror.ConsensusTopicQuery;
+import com.hedera.hashgraph.sdk.proto.mirror.ConsensusTopicResponse;
 
 public final class TopicMessageQuery {
-    private final ConsensusTopicQuery.Builder builder;
 
-    @Nullable
-    private BiConsumer<Throwable, TopicMessage> errorHandler;
+    private static final Logger LOGGER = LoggerFactory.getLogger(TopicMessageQuery.class);
+    private static final Pattern RST_STREAM = Pattern
+            .compile(".*(rst.stream.*internal.error|internal.error.*rst.stream).*",
+                    Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    private final ConsensusTopicQuery.Builder builder;
+    private Runnable completionHandler = this::onComplete;
+    private BiConsumer<Throwable, TopicMessage> errorHandler = this::onError;
+    private int maxAttempts = 10;
+    private Duration maxBackoff = Duration.ofSeconds(10L);
+    private Predicate<Throwable> retryHandler = this::shouldRetry;
 
     public TopicMessageQuery() {
         builder = ConsensusTopicQuery.newBuilder();
@@ -49,62 +63,113 @@ public final class TopicMessageQuery {
         return this;
     }
 
+    public TopicMessageQuery setCompletionHandler(Runnable completionHandler) {
+        Objects.requireNonNull(completionHandler, "completionHandler must not be null");
+        this.completionHandler = completionHandler;
+        return this;
+    }
+
     public TopicMessageQuery setErrorHandler(BiConsumer<Throwable, TopicMessage> errorHandler) {
+        Objects.requireNonNull(errorHandler, "errorHandler must not be null");
         this.errorHandler = errorHandler;
         return this;
     }
 
+    public TopicMessageQuery setMaxAttempts(int maxAttempts) {
+        if (maxAttempts < 0) {
+            throw new IllegalArgumentException("maxAttempts must be positive");
+        }
+        this.maxAttempts = maxAttempts;
+        return this;
+    }
+
+    public TopicMessageQuery setMaxBackoff(Duration maxBackoff) {
+        if (maxBackoff == null || maxBackoff.toMillis() < 500L) {
+            throw new IllegalArgumentException("maxBackoff must be at least 500 ms");
+        }
+        this.maxBackoff = maxBackoff;
+        return this;
+    }
+
+    public TopicMessageQuery setRetryHandler(Predicate<Throwable> retryHandler) {
+        Objects.requireNonNull(retryHandler, "retryHandler must not be null");
+        this.retryHandler = retryHandler;
+        return this;
+    }
+
+    private void onComplete() {
+        TopicId topicId = TopicId.fromProtobuf(builder.getTopicID());
+        LOGGER.info("Subscription to topic {} complete", topicId);
+    }
+
+    private void onError(Throwable throwable, TopicMessage topicMessage) {
+        TopicId topicId = TopicId.fromProtobuf(builder.getTopicID());
+        LOGGER.error("Error attempting to subscribe to topic {}:", topicId, throwable);
+    }
+
+    /**
+     * This method will retry the following scenarios:
+     *
+     * NOT_FOUND: Can occur when a client creates a topic and attempts to subscribe to it immediately before it is
+     * creation shows up in the mirror node.
+     *
+     * UNAVAILABLE: Can occur when the mirror node's database or other downstream components are temporarily down.
+     *
+     * RESOURCE_EXHAUSTED: Can occur when the mirror node's resources are temporarily exhausted.
+     *
+     * INTERNAL: With details that indicate the stream was reset. Stream resets can sometimes occur when a proxy or
+     * load balancer disconnected the client.
+     *
+     * @param throwable the potentially retryable exception
+     * @return if the request should be retried or not
+     */
+    private boolean shouldRetry(Throwable throwable) {
+        if (throwable instanceof StatusRuntimeException) {
+            StatusRuntimeException statusRuntimeException = (StatusRuntimeException) throwable;
+            Status.Code code = statusRuntimeException.getStatus().getCode();
+            String description = statusRuntimeException.getStatus().getDescription();
+
+            return code == Status.Code.NOT_FOUND ||
+                    code == Status.Code.UNAVAILABLE ||
+                    code == Status.Code.RESOURCE_EXHAUSTED ||
+                    code == Status.Code.INTERNAL && RST_STREAM.matcher(description).matches();
+        }
+
+        return false;
+    }
+
     // TODO: Refactor into a base class when we add more mirror query types
-    public SubscriptionHandle subscribe(
-        Client client,
-        Consumer<TopicMessage> onNext
-    ) {
+    public SubscriptionHandle subscribe(Client client, Consumer<TopicMessage> onNext) {
         SubscriptionHandle subscriptionHandle = new SubscriptionHandle();
-
-        makeStreamingCall(client, subscriptionHandle, errorHandler, builder.build(), onNext, 0, new Instant[]{null});
-
+        makeStreamingCall(client, subscriptionHandle, builder.build(), onNext, 0, new AtomicReference<>());
         return subscriptionHandle;
     }
 
-    private static void makeStreamingCall(
-        Client client,
-        SubscriptionHandle subscriptionHandle,
-        @Nullable BiConsumer<Throwable, TopicMessage> errorHandler,
-        ConsensusTopicQuery query,
-        Consumer<TopicMessage> onNext,
-        int attempt,
-        // startTime must be `final` or `effectively final` to be used within closures.
-        Instant[] startTime
+    private void makeStreamingCall(
+            Client client,
+            SubscriptionHandle subscriptionHandle,
+            ConsensusTopicQuery query,
+            Consumer<TopicMessage> onNext,
+            int attempt,
+            AtomicReference<Instant> startTime
     ) {
-        if (attempt > 10) {
-            if (errorHandler != null) {
-                errorHandler.accept(new Error("Failed to connect to mirror node"), null);
-                return;
-            }
-        }
-
         ClientCall<ConsensusTopicQuery, ConsensusTopicResponse> call =
-            client.mirrorNetwork.getNextMirrorNode().getChannel().newCall(ConsensusServiceGrpc.getSubscribeTopicMethod(), CallOptions.DEFAULT);
+                client.mirrorNetwork.getNextMirrorNode().getChannel()
+                        .newCall(ConsensusServiceGrpc.getSubscribeTopicMethod(), CallOptions.DEFAULT);
 
         subscriptionHandle.setOnUnsubscribe(() -> {
             call.cancel("unsubscribe", null);
         });
 
         HashMap<TransactionID, ArrayList<ConsensusTopicResponse>> pendingMessages = new HashMap<>();
-        ClientCalls.asyncServerStreamingCall(call, query, new StreamObserver<ConsensusTopicResponse>() {
+        ClientCalls.asyncServerStreamingCall(call, query, new StreamObserver<>() {
             @Override
             public void onNext(ConsensusTopicResponse consensusTopicResponse) {
                 if (!consensusTopicResponse.hasChunkInfo()) {
                     // short circuit for no chunks
                     var message = TopicMessage.ofSingle(consensusTopicResponse);
-                    startTime[0] = message.consensusTimestamp;
-                    try {
-                        onNext.accept(message);
-                    } catch (Throwable e) {
-                        if (errorHandler != null) {
-                            errorHandler.accept(e, message);
-                        }
-                    }
+                    startTime.set(message.consensusTimestamp);
+                    onNext.accept(message);
                     return;
                 }
 
@@ -125,48 +190,38 @@ public final class TopicMessageQuery {
                 // if we now have enough chunks, emit
                 if (chunks.size() == consensusTopicResponse.getChunkInfo().getTotal()) {
                     var message = TopicMessage.ofMany(chunks);
-                    startTime[0] = message.consensusTimestamp;
-                    try {
-                        onNext.accept(message);
-                    } catch (Throwable e) {
-                        if (errorHandler != null) {
-                            errorHandler.accept(e, null);
-                        }
-                    }
+                    startTime.set(message.consensusTimestamp);
+                    onNext.accept(message);
                 }
             }
 
             @Override
             public void onError(Throwable t) {
-                if (t instanceof StatusRuntimeException) {
-                    var status = (StatusRuntimeException) t;
-
-                    if (
-                        status.getStatus().getCode().equals(Status.NOT_FOUND.getCode()) ||
-                            status.getStatus().getCode().equals(Status.UNAVAILABLE.getCode())
-                    ) {
-                        // Cannot use `CompletableFuture<U>` here since this future is never polled
-                        try {
-                            Thread.sleep(250 * (long) Math.pow(2, attempt));
-                        } catch (InterruptedException e) {
-                            // Do nothing
-                        }
-
-                        if (startTime[0] != null) {
-                            startTime[0] = startTime[0].plusNanos(1);
-                        }
-
-                        call.cancel("unsubscribed", null);
-                        makeStreamingCall(client, subscriptionHandle, errorHandler, query, onNext, attempt + 1, startTime);
-                    }
-                } else if (errorHandler != null) {
+                if (attempt >= maxAttempts || !retryHandler.test(t)) {
                     errorHandler.accept(t, null);
+                    return;
                 }
+
+                long delay = Math.min(250 * (long) Math.pow(2, attempt), maxBackoff.toMillis());
+                TopicId topicId = TopicId.fromProtobuf(query.getTopicID());
+                LOGGER.warn("Error subscribing to topic {} during attempt #{}. Waiting {} ms before next attempt: {}",
+                        topicId, attempt, delay, t.getMessage());
+                call.cancel("unsubscribed", null);
+
+                // Cannot use `CompletableFuture<U>` here since this future is never polled
+                try {
+                    Thread.sleep(delay);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+
+                startTime.getAndUpdate(s -> s != null ? s.plusNanos(1) : null);
+                makeStreamingCall(client, subscriptionHandle, query, onNext, attempt + 1, startTime);
             }
 
             @Override
             public void onCompleted() {
-                // Do nothing
+                completionHandler.run();
             }
         });
     }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
@@ -63,9 +63,6 @@ public final class TopicMessageQuery {
     }
 
     public TopicMessageQuery setLimit(long limit) {
-        if (limit < 0) {
-            throw new IllegalArgumentException("limit must be positive");
-        }
         builder.setLimit(limit);
         return this;
     }
@@ -105,12 +102,12 @@ public final class TopicMessageQuery {
     }
 
     private void onComplete() {
-        TopicId topicId = TopicId.fromProtobuf(builder.getTopicID());
+        var topicId = TopicId.fromProtobuf(builder.getTopicID());
         LOGGER.info("Subscription to topic {} complete", topicId);
     }
 
     private void onError(Throwable throwable, TopicMessage topicMessage) {
-        TopicId topicId = TopicId.fromProtobuf(builder.getTopicID());
+        var topicId = TopicId.fromProtobuf(builder.getTopicID());
         LOGGER.error("Error attempting to subscribe to topic {}:", topicId, throwable);
     }
 
@@ -132,9 +129,9 @@ public final class TopicMessageQuery {
      */
     private boolean shouldRetry(Throwable throwable) {
         if (throwable instanceof StatusRuntimeException) {
-            StatusRuntimeException statusRuntimeException = (StatusRuntimeException) throwable;
-            Status.Code code = statusRuntimeException.getStatus().getCode();
-            String description = statusRuntimeException.getStatus().getDescription();
+            var statusRuntimeException = (StatusRuntimeException) throwable;
+            var code = statusRuntimeException.getStatus().getCode();
+            var description = statusRuntimeException.getStatus().getDescription();
 
             return code == Status.Code.NOT_FOUND ||
                     code == Status.Code.UNAVAILABLE ||
@@ -168,7 +165,7 @@ public final class TopicMessageQuery {
             call.cancel("unsubscribe", null);
         });
 
-        ConsensusTopicQuery.Builder newBuilder = builder;
+        var newBuilder = builder;
 
         // Update the start time and limit on retry
         if (lastMessage.get() != null) {
@@ -225,8 +222,8 @@ public final class TopicMessageQuery {
                     return;
                 }
 
-                long delay = Math.min(500 * (long) Math.pow(2, attempt), maxBackoff.toMillis());
-                TopicId topicId = TopicId.fromProtobuf(builder.getTopicID());
+                var delay = Math.min(500 * (long) Math.pow(2, attempt), maxBackoff.toMillis());
+                var topicId = TopicId.fromProtobuf(builder.getTopicID());
                 LOGGER.warn("Error subscribing to topic {} during attempt #{}. Waiting {} ms before next attempt: {}",
                         topicId, attempt, delay, t.getMessage());
                 call.cancel("unsubscribed", null);


### PR DESCRIPTION
Fixes #502 

This class has zero unit tests and I don't have the bandwidth to add that test coverage at this time. It would be nice if the SDK team could look into adding some in the future. You can do something [similar](https://github.com/hashgraph/hedera-mirror-node/blob/8dbb54f733af3ff0e7baff2ea37a5614124b5c27/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClientSDKTest.java#L78) to what we do in the mirror node by using a stub for the mirror node gRPC API.

I would also recommend you allow the mirror node's grpc channel to support the [in-process channel builder](https://grpc.github.io/grpc-java/javadoc/io/grpc/inprocess/InProcessChannelBuilder.html) to reduce brittle timeout issues that can occur when using a real grpc channel in constrained CI environments.