### PR TITLE
reordered operations in Node::increaseDelay()

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Node.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Node.java
@@ -20,8 +20,8 @@ class Node extends ManagedNode implements Comparable<Node>{
     }
 
     void increaseDelay() {
-        this.delay = Math.min(this.delay * 2, 8000);
         this.delayUntil = System.currentTimeMillis() + this.delay;
+        this.delay = Math.min(this.delay * 2, 8000);
     }
 
     void decreaseDelay() {


### PR DESCRIPTION
This is mostly a test to make sure that I know how to use git and github.  I promise my next contribution will actually be substantial.  =P

increaseDelay() was written in such a way that the minimum delay of 250 would never occur, because the delay integer would be doubled **before** the delay was actually carried out, so the minimum delay in practice was 500 instead of 250.