### PR TITLE
fix: testEnv must always be closed in integration tests.

### DIFF
--- a/sdk/src/integrationTest/java/ClientIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ClientIntegrationTest.java
@@ -73,6 +73,7 @@ public class ClientIntegrationTest {
             new AccountCreateTransaction()
                 .setTransactionId(TransactionId.generate(AccountId.fromString("0.0.123-rmkyk")))
                 .execute(client);
+            client.close();
         });
     }
 

--- a/sdk/src/integrationTest/java/FeeSchedulesTest.java
+++ b/sdk/src/integrationTest/java/FeeSchedulesTest.java
@@ -24,6 +24,8 @@ public class FeeSchedulesTest {
              * Test whether the file 0.0.111 actually contains stuff
              */
             assertNotNull(feeSchedules.getCurrent());
+            
+            testEnv.client.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ScheduleCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ScheduleCreateIntegrationTest.java
@@ -276,6 +276,8 @@ public class ScheduleCreateIntegrationTest {
                 .execute(testEnv.client);
 
             assertNotNull(info.executedAt);
+
+            testEnv.client.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/TransactionIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TransactionIntegrationTest.java
@@ -242,6 +242,8 @@ public class TransactionIntegrationTest {
             var resp = tx.execute(testEnv.client);
 
             resp.getReceipt(testEnv.client);
+
+            testEnv.client.close();
         });
     }
 }


### PR DESCRIPTION
`testEnv` was not always closed after each integration test.  This needs to be done, or else scary-looking (but harmless) errors will clog up the screen while running integration tests.

Signed-off-by: Sean-Tedrow-LB <sean.tedrow@launchbadge.com>