### PR TITLE
Add getSignedTransactions to Transaction

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -550,6 +550,10 @@ public abstract class Transaction<T extends Transaction<T>>
         return list.build().toByteArray();
     }
 
+    public List<com.hedera.hashgraph.sdk.proto.SignedTransaction.Builder> getSignedTransactions() {
+        return signedTransactions;
+    }
+
     public byte[] getTransactionHash() {
         if (!this.isFrozen()) {
             throw new IllegalStateException("transaction must have been frozen before calculating the hash will be stable, try calling `freeze`");


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR modifies `Transaction.java` to support fetching the `protected` list of signed transactions for external use. It's a quick getter function.

**Related issue(s)**:
Developers should be able to acquire the transaction body bytes from a given `SignedTransaction` to sign said bytes and then use `addSignature` to add the resulting signature.

From an earlier conversation with the Hedera team,
> Well, we’re trying to avoid calling tx.sign(PRIVATE_KEY), because in our production environment, the keys that do the signing are separated from the service running the Hedera SDK—so, we need to get the actual bytes to sign out from the transaction to send to it for signing."

By allowing access to `signedTransactions`, we are able to support manual signing external to the SDK. In our (and perhaps others') codebases, we have our own special procedures to sign transactions, and we don’t use the SDK for that. We just want to use the SDK to build the data that’s signed.

**Fixes**:
With this PR in place, there is no need to do brute-force reflection to fetch the `signedTransactions` field to sign the transaction body, as shown in the code block below.
```java
Field signedTxsField = TransferTransaction.class.getSuperclass().getDeclaredField("signedTransactions");
signedTxsField.setAccessible(true);
List<SignedTransaction.Builder> signedTxs = (List<SignedTransaction.Builder>) signedTxsField.get(tx);
PRIVATE_KEY.sign(signedTxs.get(0).getBodyBytes().toByteArray()));
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
