### PR TITLE
fix: pull requests should run on forks using this repos secrets

### DIFF
--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - master
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:


### PR DESCRIPTION
**Description**:
Attempt to fix CI when run from a fork. Current it fails since the secrets cannot be accessed from a forks pull request.

