### PR TITLE
Add a TopicMessageQueryTest

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -34,10 +34,11 @@ dependencies {
     // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
     implementation 'org.slf4j:slf4j-api:1.7.30'
 
-    implementation "io.grpc:grpc-api:1.38.0"
+    implementation "io.grpc:grpc-core:1.38.0"
     implementation "io.grpc:grpc-protobuf-lite:1.38.0"
     implementation "io.grpc:grpc-stub:1.38.0"
 
+    testCompile "org.assertj:assertj-core:3.20.2"
     testImplementation "org.junit.jupiter:junit-jupiter-engine:5.6.1"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.6.1"
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ManagedNode.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ManagedNode.java
@@ -2,12 +2,16 @@ package com.hedera.hashgraph.sdk;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.inprocess.InProcessChannelBuilder;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 abstract class ManagedNode {
+
+    private static final String IN_PROCESS = "in-process:";
+
     String address;
     final ExecutorService executor;
     long lastUsed = 0;
@@ -32,7 +36,14 @@ abstract class ManagedNode {
             return channel;
         }
 
-        var channelBuilder = ManagedChannelBuilder.forTarget(address);
+        ManagedChannelBuilder channelBuilder;
+
+        if (address.startsWith(IN_PROCESS)) {
+          String name = address.substring(IN_PROCESS.length());
+          channelBuilder = InProcessChannelBuilder.forName(name);
+        } else {
+          channelBuilder = ManagedChannelBuilder.forTarget(address);
+        }
 
         if (address.endsWith(":50212") || address.endsWith(":443")) {
             channelBuilder.useTransportSecurity();

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Status.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Status.java
@@ -517,7 +517,7 @@ public enum Status {
     ENTITY_NOT_ALLOWED_TO_DELETE(ResponseCodeEnum.ENTITY_NOT_ALLOWED_TO_DELETE),
 
     /**
-     * Violating one of these rules: 1) treasury account can update all entities below 0.0.1000, 2) account 0.0.50 can update all entities from 0.0.51 - 0.0.80, 3) Network Function Master Account A/c 0.0.50 - Update all Network Function accounts & perform all the Network Functions listed below, 4) Network Function Accounts: i) A/c 0.0.55 - Update Address Book files (0.0.101/102), ii) A/c 0.0.56 - Update Fee schedule (0.0.111), iii) A/c 0.0.57 - Update Exchange Rate (0.0.112).
+     * Violating one of these rules: 1) treasury account can update all entities below 0.0.1000, 2) account 0.0.50 can update all entities from 0.0.51 - 0.0.80, 3) Network Function Master Account A/c 0.0.50 - Update all Network Function accounts and perform all the Network Functions listed below, 4) Network Function Accounts: i) A/c 0.0.55 - Update Address Book files (0.0.101/102), ii) A/c 0.0.56 - Update Fee schedule (0.0.111), iii) A/c 0.0.57 - Update Exchange Rate (0.0.112).
      */
     AUTHORIZATION_FAILED(ResponseCodeEnum.AUTHORIZATION_FAILED),
 
@@ -631,7 +631,7 @@ public enum Status {
     ACCOUNT_FROZEN_FOR_TOKEN(ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN),
 
     /**
-     * An involved account already has more than <tt>tokens.maxPerAccount</tt> associations with non-deleted tokens.
+     * An involved account already has more than tokens.maxPerAccount associations with non-deleted tokens.
      */
     TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED(ResponseCodeEnum.TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED),
 
@@ -771,7 +771,7 @@ public enum Status {
     TOKEN_IS_IMMUTABLE(ResponseCodeEnum.TOKEN_IS_IMMUTABLE),
 
     /**
-     * An <tt>associateToken</tt> operation specified a token already associated to the account
+     * An associateToken operation specified a token already associated to the account
      */
     TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT(ResponseCodeEnum.TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT),
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
@@ -31,8 +31,7 @@ public final class TopicMessageQuery {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TopicMessageQuery.class);
     private static final Pattern RST_STREAM = Pattern
-            .compile(".*(rst.stream.*internal.error|internal.error.*rst.stream).*",
-                    Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+            .compile(".*\\brst[^0-9a-zA-Z]stream\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     private final ConsensusTopicQuery.Builder builder;
     private Runnable completionHandler = this::onComplete;
@@ -138,7 +137,7 @@ public final class TopicMessageQuery {
             return (code == Status.Code.NOT_FOUND) ||
                     (code == Status.Code.UNAVAILABLE) ||
                     (code == Status.Code.RESOURCE_EXHAUSTED) ||
-                    ((code == Status.Code.INTERNAL) && RST_STREAM.matcher(description).matches());
+                    (code == Status.Code.INTERNAL && description != null && RST_STREAM.matcher(description).matches());
         }
 
         return false;

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageQueryTest.java
@@ -1,0 +1,413 @@
+package com.hedera.hashgraph.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java8.util.function.Consumer;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.primitives.Longs;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.google.protobuf.ByteString;
+import com.hedera.hashgraph.sdk.proto.AccountID;
+import com.hedera.hashgraph.sdk.proto.ConsensusMessageChunkInfo;
+import com.hedera.hashgraph.sdk.proto.Timestamp;
+import com.hedera.hashgraph.sdk.proto.TopicID;
+import com.hedera.hashgraph.sdk.proto.TransactionID;
+import com.hedera.hashgraph.sdk.proto.mirror.ConsensusServiceGrpc;
+import com.hedera.hashgraph.sdk.proto.mirror.ConsensusTopicQuery;
+import com.hedera.hashgraph.sdk.proto.mirror.ConsensusTopicResponse;
+import io.github.jsonSnapshot.SnapshotMatcher;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import org.apache.commons.lang3.ArrayUtils;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.threeten.bp.Duration;
+import org.threeten.bp.Instant;
+
+class TopicMessageQueryTest {
+
+    private static final Instant START_TIME = Instant.now();
+
+    private Client client;
+    private AtomicBoolean complete = new AtomicBoolean(false);
+    private List<Throwable> errors = new ArrayList<>();
+    private List<TopicMessage> received = new ArrayList<>();
+    private ConsensusServiceStub consensusServiceStub = new ConsensusServiceStub();
+    private Server server;
+    private TopicMessageQuery topicMessageQuery;
+
+    @BeforeAll
+    static void beforeAll() {
+        SnapshotMatcher.start();
+    }
+
+    @AfterClass
+    static void afterAll() {
+        SnapshotMatcher.validateSnapshots();
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+        client = Client.forNetwork(Collections.emptyMap());
+        client.setMirrorNetwork(List.of("in-process:test"));
+        server = InProcessServerBuilder.forName("test")
+            .addService(consensusServiceStub)
+            .directExecutor()
+            .build()
+            .start();
+        topicMessageQuery = new TopicMessageQuery();
+        topicMessageQuery.setCompletionHandler(() -> complete.set(true));
+        topicMessageQuery.setEndTime(START_TIME.plusSeconds(100L));
+        topicMessageQuery.setErrorHandler((t, r) -> errors.add(t));
+        topicMessageQuery.setMaxBackoff(Duration.ofMillis(500L));
+        topicMessageQuery.setStartTime(START_TIME);
+        topicMessageQuery.setTopicId(TopicId.fromString("0.0.1000"));
+    }
+
+    @AfterEach
+    void teardown() throws Exception {
+        consensusServiceStub.verify();
+        if (client != null) {
+            client.close();
+        }
+        if (server != null) {
+            server.shutdown();
+            server.awaitTermination();
+        }
+    }
+
+    @Test
+    void setCompletionHandlerNull() {
+        assertThatThrownBy(() -> topicMessageQuery.setCompletionHandler(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("completionHandler must not be null");
+    }
+
+    @Test
+    void setEndTimeNull() {
+        assertThatThrownBy(() -> topicMessageQuery.setEndTime(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("endTime must not be null");
+    }
+
+    @Test
+    void setErrorHandlerNull() {
+        assertThatThrownBy(() -> topicMessageQuery.setErrorHandler(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("errorHandler must not be null");
+    }
+
+    @Test
+    void setMaxAttemptsNegative() {
+        assertThatThrownBy(() -> topicMessageQuery.setMaxAttempts(-1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("maxAttempts must be positive");
+    }
+
+    @Test
+    void setMaxBackoffNull() {
+        assertThatThrownBy(() -> topicMessageQuery.setMaxBackoff(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("maxBackoff must be at least 500 ms");
+    }
+
+    @Test
+    void setMaxBackoffLow() {
+        assertThatThrownBy(() -> topicMessageQuery.setMaxBackoff(Duration.ofMillis(499L)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("maxBackoff must be at least 500 ms");
+    }
+
+    @Test
+    void setRetryHandlerNull() {
+        assertThatThrownBy(() -> topicMessageQuery.setRetryHandler(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("retryHandler must not be null");
+    }
+
+    @Test
+    void setStartTimeNull() {
+        assertThatThrownBy(() -> topicMessageQuery.setStartTime(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("startTime must not be null");
+    }
+
+    @Test
+    void setTopicIdNull() {
+        assertThatThrownBy(() -> topicMessageQuery.setTopicId(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("topicId must not be null");
+    }
+
+    @Test
+    @Timeout(3)
+    void subscribe() {
+        consensusServiceStub.requests.add(request().build());
+        consensusServiceStub.responses.add(response(1L));
+        consensusServiceStub.responses.add(response(2L));
+
+        subscribeToMirror(received::add);
+
+        assertThat(errors).isEmpty();
+        assertThat(received).hasSize(2).extracting(t -> t.sequenceNumber).containsExactly(1L, 2L);
+    }
+
+    @Test
+    @Timeout(3)
+    void subscribeChunked() {
+        ConsensusTopicResponse response1 = response(1L, 2);
+        ConsensusTopicResponse response2 = response(2L, 2);
+        consensusServiceStub.requests.add(request().build());
+        consensusServiceStub.responses.add(response1);
+        consensusServiceStub.responses.add(response2);
+
+        subscribeToMirror(received::add);
+
+        var message = ArrayUtils.addAll(response1.getMessage().toByteArray(), response2.getMessage().toByteArray());
+        assertThat(errors).isEmpty();
+        assertThat(received)
+            .hasSize(1)
+            .first()
+            .returns(toInstant(response2.getConsensusTimestamp()), t -> t.consensusTimestamp)
+            .returns(response2.getChunkInfo().getInitialTransactionID(), t-> t.transactionId.toProtobuf())
+            .returns(message, t -> t.contents)
+            .returns(response2.getRunningHash().toByteArray(), t -> t.runningHash)
+            .returns(response2.getSequenceNumber(), t -> t.sequenceNumber)
+            .extracting(t -> t.chunks)
+            .asInstanceOf(InstanceOfAssertFactories.ARRAY)
+            .hasSize(2)
+            .extracting(c -> ((TopicMessageChunk)c).sequenceNumber)
+            .contains(1L, 2L);
+    }
+
+    @Test
+    @Timeout(3)
+    void subscribeNoResponse() {
+        consensusServiceStub.requests.add(request().build());
+
+        subscribeToMirror(received::add);
+
+        assertThat(errors).isEmpty();
+        assertThat(received).isEmpty();
+    }
+
+    @Test
+    @Timeout(3)
+    void errorDuringOnNext() {
+        consensusServiceStub.requests.add(request().build());
+        consensusServiceStub.responses.add(response(1L));
+
+        subscribeToMirror(t -> {throw new RuntimeException();});
+
+        assertThat(errors).hasSize(1).first().isInstanceOf(RuntimeException.class);
+        assertThat(received).isEmpty();
+    }
+
+    @ParameterizedTest(name = "Retry recovers w/ status {0} and description {1}")
+    @CsvSource({
+        "INTERNAL, internal RST_STREAM error",
+        "INTERNAL, rst stream",
+        "NOT_FOUND, ",
+        "RESOURCE_EXHAUSTED, ",
+        "UNAVAILABLE, "
+    })
+    @Timeout(3)
+    void retryRecovers(Status.Code code, String description) {
+        consensusServiceStub.requests.add(request().build());
+        consensusServiceStub.requests.add(request().build());
+        consensusServiceStub.responses.add(code.toStatus().withDescription(description).asRuntimeException());
+        consensusServiceStub.responses.add(response(1L));
+
+        subscribeToMirror(received::add);
+
+        assertThat(received).hasSize(1).extracting(t -> t.sequenceNumber).containsExactly(1L);
+        assertThat(errors).isEmpty();
+    }
+
+    @ParameterizedTest(name = "No retry w/ status {0} and description {1}")
+    @CsvSource({
+        "INTERNAL, internal first_stream error",
+        "INTERNAL, internal error",
+        "INTERNAL, ",
+        "INVALID_ARGUMENT, "
+    })
+    @Timeout(3)
+    void noRetry(Status.Code code, String description) {
+        consensusServiceStub.requests.add(request().build());
+        consensusServiceStub.responses.add(code.toStatus().withDescription(description).asRuntimeException());
+
+        subscribeToMirror(received::add);
+
+        assertThat(received).isEmpty();
+        assertThat(errors).hasSize(1)
+            .first()
+            .isInstanceOf(StatusRuntimeException.class)
+            .extracting(t -> ((StatusRuntimeException)t).getStatus().getCode())
+            .isEqualTo(code);
+    }
+
+    @Test
+    @Timeout(3)
+    void customRetry() {
+        consensusServiceStub.requests.add(request().build());
+        consensusServiceStub.requests.add(request().build());
+        consensusServiceStub.responses.add(Status.INVALID_ARGUMENT.asRuntimeException());
+        consensusServiceStub.responses.add(response(1L));
+        topicMessageQuery.setRetryHandler(t -> true);
+
+        subscribeToMirror(received::add);
+
+        assertThat(received).hasSize(1).extracting(t -> t.sequenceNumber).containsExactly(1L);
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    @Timeout(3)
+    void retryWithLimit() {
+        ConsensusTopicResponse response = response(1L);
+        Instant nextTimestamp = toInstant(response.getConsensusTimestamp()).plusNanos(1L);
+        ConsensusTopicQuery.Builder request = request();
+        topicMessageQuery.setLimit(2);
+
+        consensusServiceStub.requests.add(request.setLimit(2L).build());
+        consensusServiceStub.requests.add(request.setConsensusStartTime(toTimestamp(nextTimestamp)).setLimit(1L).build());
+        consensusServiceStub.responses.add(response);
+        consensusServiceStub.responses.add(Status.RESOURCE_EXHAUSTED.asRuntimeException());
+        consensusServiceStub.responses.add(response(2L));
+
+        subscribeToMirror(received::add);
+
+        assertThat(received).hasSize(2).extracting(t -> t.sequenceNumber).containsExactly(1L, 2L);
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    @Timeout(3)
+    void retriesExhausted() {
+        topicMessageQuery.setMaxAttempts(1);
+        consensusServiceStub.requests.add(request().build());
+        consensusServiceStub.requests.add(request().build());
+        consensusServiceStub.responses.add(Status.RESOURCE_EXHAUSTED.asRuntimeException());
+        consensusServiceStub.responses.add(Status.RESOURCE_EXHAUSTED.asRuntimeException());
+
+        subscribeToMirror(received::add);
+
+        assertThat(received).isEmpty();
+        assertThat(errors).hasSize(1)
+            .first()
+            .isInstanceOf(StatusRuntimeException.class)
+            .extracting(t -> ((StatusRuntimeException)t).getStatus())
+            .isEqualTo(Status.RESOURCE_EXHAUSTED);
+    }
+
+    private void subscribeToMirror(Consumer<TopicMessage> onNext) {
+        SubscriptionHandle subscriptionHandle = topicMessageQuery.subscribe(client, onNext);
+        Stopwatch stopwatch = Stopwatch.createStarted();
+
+        while (!complete.get() && errors.isEmpty() && stopwatch.elapsed(TimeUnit.SECONDS) < 3) {
+            Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+        }
+
+        subscriptionHandle.unsubscribe();
+    }
+
+    private ConsensusTopicQuery.Builder request() {
+        return ConsensusTopicQuery.newBuilder()
+            .setConsensusEndTime(toTimestamp(START_TIME.plusSeconds(100L)))
+            .setConsensusStartTime(toTimestamp(START_TIME))
+            .setTopicID(TopicID.newBuilder().setTopicNum(1000).build());
+    }
+
+    private ConsensusTopicResponse response(Long sequenceNumber) {
+        return response(sequenceNumber, 0);
+    }
+
+    private ConsensusTopicResponse response(Long sequenceNumber, int total) {
+        ConsensusTopicResponse.Builder consensusTopicResponseBuilder = ConsensusTopicResponse.newBuilder();
+
+        if (total > 0) {
+            var chunkInfo = ConsensusMessageChunkInfo.newBuilder()
+                .setInitialTransactionID(TransactionID.newBuilder()
+                    .setAccountID(AccountID.newBuilder().setAccountNum(3).build())
+                    .setTransactionValidStart(toTimestamp(START_TIME))
+                    .build())
+                .setNumber(sequenceNumber.intValue())
+                .setTotal(total)
+                .build();
+            consensusTopicResponseBuilder.setChunkInfo(chunkInfo);
+        }
+
+        var message = ByteString.copyFrom(Longs.toByteArray(sequenceNumber));
+        return consensusTopicResponseBuilder
+            .setConsensusTimestamp(toTimestamp(START_TIME.plusSeconds(sequenceNumber)))
+            .setSequenceNumber(sequenceNumber)
+            .setMessage(message)
+            .setRunningHash(message)
+            .setRunningHashVersion(2L)
+            .build();
+    }
+
+    private Instant toInstant(Timestamp timestamp) {
+        return Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos());
+    }
+
+    private Timestamp toTimestamp(Instant instant) {
+        return Timestamp.newBuilder()
+            .setSeconds(instant.getEpochSecond())
+            .setNanos(instant.getNano())
+            .build();
+    }
+
+    private class ConsensusServiceStub extends ConsensusServiceGrpc.ConsensusServiceImplBase {
+
+        private final Queue<ConsensusTopicQuery> requests = new LinkedList<>();
+        private final Queue<Object> responses = new LinkedList<>();
+
+        @Override
+        public void subscribeTopic(ConsensusTopicQuery consensusTopicQuery,
+                                   StreamObserver<ConsensusTopicResponse> streamObserver) {
+            var request = requests.poll();
+            assertThat(request).isNotNull();
+            assertThat(consensusTopicQuery).isEqualTo(request);
+
+            while (!responses.isEmpty()) {
+                var response = responses.poll();
+                assertThat(response).isNotNull();
+
+                if (response instanceof Throwable) {
+                    streamObserver.onError((Throwable) response);
+                    return;
+                }
+
+                streamObserver.onNext((ConsensusTopicResponse) response);
+            }
+
+            streamObserver.onCompleted();
+        }
+
+        public void verify() {
+            assertThat(requests).isEmpty();
+            assertThat(responses).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
**Description**:
- Add a `TopicMessageQueryTest` for increased code coverage
- Change `TopicMessageQuery` reset stream regex to be more permissive and match the other SDKs
- Change `ManagedNode` to allow for in-process channels to make testing easier and more reliable
- Fix some javadoc errors in `Status` class

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
