### PR TITLE
feat: implement `Client.ping[All]Async()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+ * `Client.getRequestTimeout()`
+ * `Client.pingAsync()` and `Client.pingAllAsync()` useful for validating all nodes within the
+   network before executing any real request
+ * `Client.[set|get]MaxAttempts()` default max attempts for all transactions
+ * `Client.[set|get]MaxNodeAttempts()` set max attempts to retry a node which returns bad gRPC status
+   such as `UNAVAILBLE`
+ * `Client.[set|get]NodeWaitTime()` change the default delay before attempting a node again which has
+   returned a bad gRPC status
+
 ## v2.0.9
 
 ### Fixed
@@ -19,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
- * `TokenUpdateTransaction.clearAutoRenewAccountId()` 
+ * `TokenUpdateTransaction.clearAutoRenewAccountId()`
  * Scheduled `TransferTransaction`
 
 ## v2.0.9-beta.1
@@ -60,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Null checks for most parameters to catch stray `NullPointerException`'s
 
 ### Fixed
- 
+
  * `RequestType` missing `UNCHECKED_SUBMIT` for `toString()` and `valueOf()` methods.
  * `FeeSchedules` incorrectly serializing nulls causing `NullPointerException`
 

--- a/executable-annotation/src/main/java/com/hedera/hashgraph/sdk/FunctionalExecutable.java
+++ b/executable-annotation/src/main/java/com/hedera/hashgraph/sdk/FunctionalExecutable.java
@@ -13,4 +13,8 @@ public @interface FunctionalExecutable {
 
     // empty string means make this generic
     String type() default "";
+
+    String inputType() default "";
+
+    boolean onClient() default false;
 }

--- a/sdk/src/integrationTest/java/ClientIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ClientIntegrationTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.threeten.bp.Duration;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -18,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ClientIntegrationTest {
     @Test
@@ -93,4 +95,20 @@ public class ClientIntegrationTest {
             testEnv.close();
         });
     }
+
+    @Test
+    void ping() {
+        assertDoesNotThrow(() -> {
+            var testEnv = new IntegrationTestEnv();
+            var network = testEnv.client.getNetwork();
+            var nodes = new ArrayList<AccountId>(network.values());
+
+            assertTrue(!nodes.isEmpty());
+
+            var node = nodes.get(0);
+
+            testEnv.client.ping(node);
+
+            testEnv.client.close();
+        });    }
 }

--- a/sdk/src/integrationTest/java/ClientIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ClientIntegrationTest.java
@@ -96,7 +96,7 @@ public class ClientIntegrationTest {
     @Test
     void ping() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = new IntegrationTestEnv(1);
             var network = testEnv.client.getNetwork();
             var nodes = new ArrayList<>(network.values());
 
@@ -106,14 +106,14 @@ public class ClientIntegrationTest {
 
             testEnv.client.setMaxNodeAttempts(1);
             testEnv.client.ping(node);
-            testEnv.client.close();
+            testEnv.close();
         });
     }
 
     @Test
     void pingAll() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = new IntegrationTestEnv(3);
 
             testEnv.client.setMaxNodeAttempts(1);
             testEnv.client.pingAll();
@@ -129,14 +129,14 @@ public class ClientIntegrationTest {
                 .setAccountId(node)
                 .execute(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.close();
         });
     }
 
     @Test
     void pingAllBadNetwork() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = new IntegrationTestEnv(3);
 
             testEnv.client.setMaxNodeAttempts(1);
             testEnv.client.setMaxNodesPerTransaction(2);
@@ -165,7 +165,7 @@ public class ClientIntegrationTest {
 
             assertEquals(1, testEnv.client.getNetwork().values().size());
 
-            testEnv.client.close();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -325,20 +325,18 @@ public final class Client implements AutoCloseable, WithPing, WithPingAll {
             .setAccountId(nodeAccountId)
             .setNodeAccountIds(Collections.singletonList(nodeAccountId))
             .executeAsync(this)
-            .thenApply((v) -> null);
+            .handle((balance, e) -> {
+                // Do nothing
+                return null;
+            });
     }
 
     @FunctionalExecutable(type = "Void", onClient = true)
     public synchronized CompletableFuture<Void> pingAllAsync() {
-        var list = new ArrayList<CompletableFuture<AccountBalance>>(network.network.size());
+        var list = new ArrayList<CompletableFuture<Void>>(network.network.size());
 
         for (var nodeAccountId : network.network.values()) {
-            list.add(new AccountBalanceQuery()
-                .setNodeAccountIds(Collections.singletonList(nodeAccountId))
-                .setAccountId(nodeAccountId)
-                .setNodeAccountIds(Collections.singletonList(nodeAccountId))
-                .executeAsync(this)
-            );
+            list.add(pingAsync(nodeAccountId));
         }
 
         return CompletableFuture.allOf(list.toArray(new CompletableFuture<?>[0])).thenApply((v) -> null);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonParseException;
 import java8.util.Lists;
 import java8.util.function.Consumer;
 import java8.util.function.Function;
+import java8.util.concurrent.CompletableFuture;
 import org.threeten.bp.Duration;
 
 import javax.annotation.Nullable;
@@ -28,9 +29,10 @@ import java.util.concurrent.TimeoutException;
 /**
  * Managed client for use on the Hedera Hashgraph network.
  */
-public final class Client implements AutoCloseable {
+public final class Client implements AutoCloseable, WithPing, WithPingAll {
     private static final Hbar DEFAULT_MAX_QUERY_PAYMENT = new Hbar(1);
     private static final Hbar DEFAULT_MAX_TRANSACTION_FEE = new Hbar(1);
+    static final Integer DEFAULT_MAX_ATTEMPTS = 10;
 
     Hbar maxTransactionFee = DEFAULT_MAX_QUERY_PAYMENT;
     Hbar maxQueryPayment = DEFAULT_MAX_TRANSACTION_FEE;
@@ -44,6 +46,8 @@ public final class Client implements AutoCloseable {
     private Operator operator;
 
     Duration requestTimeout = Duration.ofMinutes(2);
+
+    int maxAttempts = DEFAULT_MAX_ATTEMPTS;
 
     Client(Map<String, AccountId> network) {
         var threadFactory = new ThreadFactoryBuilder()
@@ -315,11 +319,29 @@ public final class Client implements AutoCloseable {
         return network;
     }
 
-    public void ping(AccountId nodeAccountId) throws TimeoutException, PrecheckStatusException {
-        new AccountBalanceQuery()
+    @FunctionalExecutable(type = "Void", onClient = true, inputType = "AccountId")
+    public synchronized CompletableFuture<Void> pingAsync(AccountId nodeAccountId) {
+        return new AccountBalanceQuery()
             .setAccountId(nodeAccountId)
             .setNodeAccountIds(Collections.singletonList(nodeAccountId))
-            .execute(this);
+            .executeAsync(this)
+            .thenApply((v) -> null);
+    }
+
+    @FunctionalExecutable(type = "Void", onClient = true)
+    public synchronized CompletableFuture<Void> pingAllAsync() {
+        var list = new ArrayList<CompletableFuture<AccountBalance>>(network.network.size());
+
+        for (var nodeAccountId : network.network.values()) {
+            list.add(new AccountBalanceQuery()
+                .setNodeAccountIds(Collections.singletonList(nodeAccountId))
+                .setAccountId(nodeAccountId)
+                .setNodeAccountIds(Collections.singletonList(nodeAccountId))
+                .executeAsync(this)
+            );
+        }
+
+        return CompletableFuture.allOf(list.toArray(new CompletableFuture<?>[0])).thenApply((v) -> null);
     }
 
     /**
@@ -362,6 +384,33 @@ public final class Client implements AutoCloseable {
 
         this.operator = new Operator(accountId, publicKey, transactionSigner);
         return this;
+    }
+
+    public synchronized Client setMaxAttempts(int maxAttempts) {
+        this.maxAttempts = maxAttempts;
+        return this;
+    }
+
+    public synchronized int getMaxAttempts() {
+        return maxAttempts;
+    }
+
+    public synchronized Client setMaxNodeAttempts(int maxNodeAttempts) {
+        this.network.setMaxNodeAttempts(maxNodeAttempts);
+        return this;
+    }
+
+    public synchronized int getMaxNodeAttempts() {
+        return network.getMaxNodeAttempts();
+    }
+
+    public synchronized Client setNodeWaitTime(Duration nodeWaitTime) {
+        network.setNodeWaitTime(nodeWaitTime);
+        return this;
+    }
+
+    public synchronized Duration getNodeWaitTime() {
+        return network.getNodeWaitTime();
     }
 
     public synchronized Client setMaxNodesPerTransaction(int maxNodesPerTransaction) {
@@ -446,6 +495,10 @@ public final class Client implements AutoCloseable {
     public synchronized Client setRequestTimeout(Duration requestTimeout) {
         this.requestTimeout = requestTimeout;
         return this;
+    }
+
+    public synchronized Duration getRequestTimeout() {
+        return requestTimeout;
     }
 
     @Nullable

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -47,7 +47,7 @@ public final class Client implements AutoCloseable, WithPing, WithPingAll {
 
     Duration requestTimeout = Duration.ofMinutes(2);
 
-    int maxAttempts = DEFAULT_MAX_ATTEMPTS;
+    Integer maxAttempts = null;
 
     Client(Map<String, AccountId> network) {
         var threadFactory = new ThreadFactoryBuilder()
@@ -390,7 +390,7 @@ public final class Client implements AutoCloseable, WithPing, WithPingAll {
     }
 
     public synchronized int getMaxAttempts() {
-        return maxAttempts;
+        return maxAttempts != null ? maxAttempts : DEFAULT_MAX_ATTEMPTS;
     }
 
     public synchronized Client setMaxNodeAttempts(int maxNodeAttempts) {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
@@ -20,7 +20,7 @@ import static com.hedera.hashgraph.sdk.FutureConverter.toCompletableFuture;
 abstract class Executable<SdkRequestT, ProtoRequestT, ResponseT, O> implements WithExecute<O> {
     private static final Logger logger = LoggerFactory.getLogger(Executable.class);
 
-    protected int maxAttempts = 10;
+    protected int maxAttempts = Client.DEFAULT_MAX_ATTEMPTS;
     protected int nextNodeIndex = 0;
     protected List<AccountId> nodeAccountIds = Collections.emptyList();
     protected List<Node> nodes = new ArrayList<>();
@@ -86,6 +86,10 @@ abstract class Executable<SdkRequestT, ProtoRequestT, ResponseT, O> implements W
     @Override
     @FunctionalExecutable
     public CompletableFuture<O> executeAsync(Client client) {
+        if (maxAttempts == Client.DEFAULT_MAX_ATTEMPTS) {
+            maxAttempts = client.getMaxAttempts();
+        }
+
         return onExecuteAsync(client).thenCompose((v) -> {
             if(nodeAccountIds.isEmpty()) {
                 throw new IllegalStateException("Request node account IDs were not set before executing");

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
@@ -20,7 +20,7 @@ import static com.hedera.hashgraph.sdk.FutureConverter.toCompletableFuture;
 abstract class Executable<SdkRequestT, ProtoRequestT, ResponseT, O> implements WithExecute<O> {
     private static final Logger logger = LoggerFactory.getLogger(Executable.class);
 
-    protected int maxAttempts = Client.DEFAULT_MAX_ATTEMPTS;
+    protected Integer maxAttempts;
     protected int nextNodeIndex = 0;
     protected List<AccountId> nodeAccountIds = Collections.emptyList();
     protected List<Node> nodes = new ArrayList<>();
@@ -45,7 +45,7 @@ abstract class Executable<SdkRequestT, ProtoRequestT, ResponseT, O> implements W
     }
 
     public final int getMaxAttempts() {
-        return maxAttempts;
+        return maxAttempts != null ? maxAttempts : Client.DEFAULT_MAX_ATTEMPTS;
     }
 
     public final SdkRequestT setMaxAttempts(int count) {
@@ -86,7 +86,7 @@ abstract class Executable<SdkRequestT, ProtoRequestT, ResponseT, O> implements W
     @Override
     @FunctionalExecutable
     public CompletableFuture<O> executeAsync(Client client) {
-        if (maxAttempts == Client.DEFAULT_MAX_ATTEMPTS) {
+        if (maxAttempts == null) {
             maxAttempts = client.getMaxAttempts();
         }
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Network.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Network.java
@@ -118,6 +118,18 @@ class Network {
 
         Collections.sort(nodes);
 
+        // Remove nodes which have surpassed max attempts
+        for (var i = 0; i < nodes.size(); i++) {
+            var node = Objects.requireNonNull(nodes.get(i));
+            if (node.attempts >= maxNodeAttempts) {
+                node.close(30);
+                nodes.remove(i);
+                network.remove(node.address);
+                networkNodes.remove(node.accountId);
+                i--;
+            }
+        }
+
         List<AccountId> resultNodeAccountIds = new ArrayList<>();
 
         for (int i = 0; i < getNumberOfNodesForTransaction(); i++) {
@@ -154,7 +166,7 @@ class Network {
 
     int getNumberOfNodesForTransaction() {
         if (maxNodesPerTransaction != null) {
-            return maxNodesPerTransaction;
+            return Math.min(maxNodesPerTransaction, nodes.size());
         } else {
             return (nodes.size() + 3 - 1) / 3;
         }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Network.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Network.java
@@ -17,8 +17,13 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 
 class Network {
+    static final Integer DEFAULT_MAX_NODE_ATTEMPTS = -1;
+
     HashMap<String, AccountId> network = new HashMap<>();
     HashMap<AccountId, Node> networkNodes = new HashMap<>();
+
+    private int maxNodeAttempts = DEFAULT_MAX_NODE_ATTEMPTS;
+    private Duration nodeWaitTime = Duration.ofMillis(250);
 
     @Nullable
     NetworkName networkName = null;
@@ -51,7 +56,7 @@ class Network {
             this.network = new HashMap<>(network);
 
             for (var entry : network.entrySet()) {
-                var node = new Node(entry.getValue(), entry.getKey(), executor);
+                var node = new Node(entry.getValue(), entry.getKey(), nodeWaitTime.toMillis(), executor);
                 this.networkNodes.put(entry.getValue(), node);
                 this.nodes.add(node);
             }
@@ -89,7 +94,7 @@ class Network {
         // Add new nodes that are not present in the list
         for (var entry : inverted.entrySet()) {
             if (networkNodes.get(entry.getKey()) == null) {
-                var node = new Node(entry.getKey(), entry.getValue(), executor);
+                var node = new Node(entry.getKey(), entry.getValue(), nodeWaitTime.toMillis(), executor);
 
                 nodes.add(node);
                 networkNodes.put(entry.getKey(), node);
@@ -126,6 +131,25 @@ class Network {
 
     void setMaxNodesPerTransaction(int maxNodesPerTransaction) {
         this.maxNodesPerTransaction = maxNodesPerTransaction;
+    }
+
+    void setMaxNodeAttempts(int maxNodeAttempts) {
+        this.maxNodeAttempts = maxNodeAttempts;
+    }
+
+    int getMaxNodeAttempts() {
+        return maxNodeAttempts;
+    }
+
+    void setNodeWaitTime(Duration nodeWaitTime) {
+        this.nodeWaitTime = nodeWaitTime;
+        for (var node : nodes) {
+            node.setWaitTime(nodeWaitTime.toMillis());
+        }
+    }
+
+    Duration getNodeWaitTime() {
+        return nodeWaitTime;
     }
 
     int getNumberOfNodesForTransaction() {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Network.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Network.java
@@ -119,14 +119,16 @@ class Network {
         Collections.sort(nodes);
 
         // Remove nodes which have surpassed max attempts
-        for (var i = 0; i < nodes.size(); i++) {
-            var node = Objects.requireNonNull(nodes.get(i));
-            if (node.attempts >= maxNodeAttempts) {
-                node.close(30);
-                nodes.remove(i);
-                network.remove(node.address);
-                networkNodes.remove(node.accountId);
-                i--;
+        if (maxNodeAttempts > 0) {
+            for (var i = 0; i < nodes.size(); i++) {
+                var node = Objects.requireNonNull(nodes.get(i));
+                if (node.attempts >= maxNodeAttempts) {
+                    node.close(30);
+                    nodes.remove(i);
+                    network.remove(node.address);
+                    networkNodes.remove(node.accountId);
+                    i--;
+                }
             }
         }
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Node.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Node.java
@@ -6,13 +6,23 @@ class Node extends ManagedNode implements Comparable<Node>{
     AccountId accountId;
     long delay;
     long delayUntil;
+    long waitTime;
 
-    Node(AccountId accountId, String address, ExecutorService executor) {
+    Node(AccountId accountId, String address, long waitTime, ExecutorService executor) {
         super(address, executor);
 
         this.accountId = accountId;
-        this.delay = 250;
+        this.delay = waitTime;
         this.delayUntil = 0;
+    }
+
+    void setWaitTime(long waitTime) {
+        // If delay is equal to the old waitTime we should change it to the new waitTime
+        if (delay == this.waitTime) {
+            delay = waitTime;
+        }
+
+        this.waitTime = waitTime;
     }
 
     boolean isHealthy() {
@@ -25,7 +35,7 @@ class Node extends ManagedNode implements Comparable<Node>{
     }
 
     void decreaseDelay() {
-        this.delay = Math.max(this.delay / 2, 250);
+        this.delay = Math.max(this.delay / 2, waitTime);
     }
 
     long delay() {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Node.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Node.java
@@ -7,13 +7,16 @@ class Node extends ManagedNode implements Comparable<Node>{
     long delay;
     long delayUntil;
     long waitTime;
+    long attempts;
 
     Node(AccountId accountId, String address, long waitTime, ExecutorService executor) {
         super(address, executor);
 
         this.accountId = accountId;
         this.delay = waitTime;
+        this.waitTime = waitTime;
         this.delayUntil = 0;
+        this.attempts = 0;
     }
 
     void setWaitTime(long waitTime) {
@@ -30,6 +33,7 @@ class Node extends ManagedNode implements Comparable<Node>{
     }
 
     void increaseDelay() {
+        this.attempts++;
         this.delayUntil = System.currentTimeMillis() + this.delay;
         this.delay = Math.min(this.delay * 2, 8000);
     }


### PR DESCRIPTION
**Description**:

**Related issue(s)**:

Closes: #478

**Notes for reviewer**:
`Client.getRequestTimeout()` is required to be exposed for `FunctionalExecutable` to work since it doesn't require `client` to be passed in as a parameter.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
- [X] Implement `Client.pingAll()`
- [X] Implement `Client.ping(AccountId)`
- [X] Implement `Client.[get|set]MaxNodeAttempts()`
- [X] Implement `Client.[get|set]NodeWaitTime()`
- [X] Implement `Client.[get|set]MaxAttempts()`
- [X] Implement `Client.getRequestTimeout()` - This is needed for `FunctionalExecutable` to work with `ping` and `pingAll`