### PR TITLE
chore: add some string-conversion stuff

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountBalance.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountBalance.java
@@ -1,5 +1,6 @@
 package com.hedera.hashgraph.sdk;
 
+import com.google.common.base.MoreObjects;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.hashgraph.sdk.proto.CryptoGetAccountBalanceResponse;
@@ -71,5 +72,13 @@ public class AccountBalance {
 
     ByteString toBytes() {
         return toProtobuf().toByteString();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("hbars", hbars)
+            .add("tokens", tokens)
+            .toString();
     }
 }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Hbar.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Hbar.java
@@ -41,7 +41,7 @@ public final class Hbar implements Comparable<Hbar> {
 
     Hbar(BigDecimal amount, HbarUnit unit) {
         var tinybars = amount.multiply(BigDecimal.valueOf(unit.tinybar));
-
+        
         if (tinybars.doubleValue() % 1 != 0) {
             throw new IllegalArgumentException("Amount and Unit combination results in a fractional value for tinybar.  Ensure tinybar value is a whole number.");
         }
@@ -64,6 +64,28 @@ public final class Hbar implements Comparable<Hbar> {
      */
     public static final Hbar MIN = Hbar.from(-50_000_000_000L);
 
+    private static int findNumber(CharSequence text) {
+        for(int i = 0; i < text.length(); i++) {
+            var c = text.charAt(i);
+            if(Character.isDigit(c) || c == '+' || c == '-') {
+                return i;
+            }
+        }
+        throw new IllegalArgumentException("Attempted to convert string \"" + text + "\" to Hbar, but no number was found");
+    }
+
+    private static HbarUnit getUnit(String symbolString) {
+        if(symbolString.length() == 0) {
+            return HbarUnit.HBAR;
+        }
+        for(var unit : HbarUnit.values()) {
+            if(unit.getSymbol().equals(symbolString)) {
+                return unit;
+            }
+        }
+        throw new IllegalArgumentException("Attempted to convert string to Hbar, but symbol \"" + symbolString + "\" was not recognized");
+    }
+
     /**
      * Converts the provided string into an amount of hbars.
      *
@@ -71,7 +93,10 @@ public final class Hbar implements Comparable<Hbar> {
      * @return {@link com.hedera.hashgraph.sdk.Hbar}
      */
     public static Hbar fromString(CharSequence text) {
-        return new Hbar(new BigDecimal(text.toString()), HbarUnit.HBAR);
+        int number_i = findNumber(text);
+        String symbolString = text.subSequence(0, number_i).toString().trim();
+        String numberString = text.subSequence(number_i, text.length()).toString().trim();
+        return new Hbar(new BigDecimal(numberString), getUnit(symbolString));
     }
 
     /**

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Hbar.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Hbar.java
@@ -1,5 +1,7 @@
 package com.hedera.hashgraph.sdk;
 
+import com.google.errorprone.annotations.Var;
+
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.Objects;
@@ -41,7 +43,7 @@ public final class Hbar implements Comparable<Hbar> {
 
     Hbar(BigDecimal amount, HbarUnit unit) {
         var tinybars = amount.multiply(BigDecimal.valueOf(unit.tinybar));
-        
+
         if (tinybars.doubleValue() % 1 != 0) {
             throw new IllegalArgumentException("Amount and Unit combination results in a fractional value for tinybar.  Ensure tinybar value is a whole number.");
         }
@@ -64,26 +66,13 @@ public final class Hbar implements Comparable<Hbar> {
      */
     public static final Hbar MIN = Hbar.from(-50_000_000_000L);
 
-    private static int findNumber(CharSequence text) {
-        for(int i = 0; i < text.length(); i++) {
-            var c = text.charAt(i);
-            if(Character.isDigit(c) || c == '+' || c == '-') {
-                return i;
-            }
-        }
-        throw new IllegalArgumentException("Attempted to convert string \"" + text + "\" to Hbar, but no number was found");
-    }
-
     private static HbarUnit getUnit(String symbolString) {
-        if(symbolString.length() == 0) {
-            return HbarUnit.HBAR;
-        }
         for(var unit : HbarUnit.values()) {
             if(unit.getSymbol().equals(symbolString)) {
                 return unit;
             }
         }
-        throw new IllegalArgumentException("Attempted to convert string to Hbar, but symbol \"" + symbolString + "\" was not recognized");
+        throw new IllegalArgumentException("Attempted to convert string to Hbar, but unit symbol \"" + symbolString + "\" was not recognized");
     }
 
     /**
@@ -93,10 +82,11 @@ public final class Hbar implements Comparable<Hbar> {
      * @return {@link com.hedera.hashgraph.sdk.Hbar}
      */
     public static Hbar fromString(CharSequence text) {
-        int number_i = findNumber(text);
-        String symbolString = text.subSequence(0, number_i).toString().trim();
-        String numberString = text.subSequence(number_i, text.length()).toString().trim();
-        return new Hbar(new BigDecimal(numberString), getUnit(symbolString));
+        String[] parts = text.toString().split(" ");
+        if(parts.length > 2) {
+            throw new IllegalArgumentException("Attempted to convert string to Hbar, but \"" + text + "\" contained more than 1 space.  Valid formats are \"N S\" or \"N\", where N is a number and S is an Hbar unit symbol");
+        }
+        return new Hbar(new BigDecimal(parts[0]), parts.length == 2 ? getUnit(parts[1]) : HbarUnit.HBAR);
     }
 
     /**

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Hbar.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Hbar.java
@@ -5,6 +5,7 @@ import com.google.errorprone.annotations.Var;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 /**
  * Represents a quantity of hbar.
@@ -13,6 +14,7 @@ import java.util.Objects;
  * in tinybars however the nominal unit is hbar.
  */
 public final class Hbar implements Comparable<Hbar> {
+    private static final Pattern FROM_STRING_PATTERN = Pattern.compile("^((?:\\+|\\-)?\\d+(?:\\.\\d+)?)(\\ (tℏ|μℏ|mℏ|ℏ|kℏ|Mℏ|Gℏ))?$");
     private final long valueInTinybar;
 
     /**
@@ -82,10 +84,11 @@ public final class Hbar implements Comparable<Hbar> {
      * @return {@link com.hedera.hashgraph.sdk.Hbar}
      */
     public static Hbar fromString(CharSequence text) {
-        String[] parts = text.toString().split(" ");
-        if(parts.length > 2) {
-            throw new IllegalArgumentException("Attempted to convert string to Hbar, but \"" + text + "\" contained more than 1 space.  Valid formats are \"N S\" or \"N\", where N is a number and S is an Hbar unit symbol");
+        var matcher = FROM_STRING_PATTERN.matcher(text);
+        if(!matcher.matches()) {
+            throw new IllegalArgumentException("Attempted to convert string to Hbar, but \"" + text + "\" was not correctly formatted");
         }
+        String[] parts = text.toString().split(" ");
         return new Hbar(new BigDecimal(parts[0]), parts.length == 2 ? getUnit(parts[1]) : HbarUnit.HBAR);
     }
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/PrivateKey.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/PrivateKey.java
@@ -335,7 +335,15 @@ public final class PrivateKey extends Key {
 
     @Override
     public String toString() {
+        return toStringDER();
+    }
+
+    public String toStringDER() {
         return Hex.toHexString(toDER());
+    }
+
+    public String toStringRaw() {
+        return Hex.toHexString(keyData);
     }
 
     @Override

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/PublicKey.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/PublicKey.java
@@ -110,7 +110,15 @@ public final class PublicKey extends Key {
 
     @Override
     public String toString() {
+        return toStringDER();
+    }
+
+    public String toStringDER() {
         return Hex.toHexString(toDER());
+    }
+
+    public String toStringRaw() {
+        return Hex.toHexString(keyData);
     }
 
     @Override

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/Ed25519PrivateKeyTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/Ed25519PrivateKeyTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class Ed25519PrivateKeyTest {
     private static final String TEST_KEY_STR = "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10";
+    private static final String TEST_KEY_STR_RAW = "db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10";
     private static final String TEST_KEY_PEM = "-----BEGIN PRIVATE KEY-----\n"
         + "MC4CAQAwBQYDK2VwBCIEINtIS4KOZLLY8SzjwKDpOguMznrxu485yXcyOUSCU44Q\n"
         + "-----END PRIVATE KEY-----\n";
@@ -118,6 +119,8 @@ class Ed25519PrivateKeyTest {
             TEST_KEY_STR,
             key.toString()
         );
+        assertEquals(TEST_KEY_STR, key.toStringDER());
+        assertEquals(TEST_KEY_STR_RAW, key.toStringRaw());
     }
 
     @Test

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/Ed25519PublicKeyTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/Ed25519PublicKeyTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class Ed25519PublicKeyTest {
     private static final String TEST_KEY_STR = "302a300506032b6570032100e0c8ec2758a5879ffac226a13c0c516b799e72e35141a0dd828f94d37988a4b7";
+    private static final String TEST_KEY_STR_RAW = "e0c8ec2758a5879ffac226a13c0c516b799e72e35141a0dd828f94d37988a4b7";
 
     @Test
     @DisplayName("private key can be recovered from bytes")
@@ -51,6 +52,8 @@ class Ed25519PublicKeyTest {
         assertNotNull(key);
         // the above are all the same key
         assertEquals(TEST_KEY_STR, key.toString());
+        assertEquals(TEST_KEY_STR, key.toStringDER());
+        assertEquals(TEST_KEY_STR_RAW, key.toStringRaw());
     }
 
     @Test

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/HbarTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/HbarTest.java
@@ -83,7 +83,9 @@ public class HbarTest {
 
     @Test
     void fromString() {
-        assertEquals(Hbar.fromString("1").toTinybars(), 100000000);
+        assertEquals(Hbar.fromString("1").toTinybars(), 100_000_000);
+        assertEquals(Hbar.fromString("ℏ 1").toTinybars(), 100_000_000);
+        assertEquals(Hbar.fromString("mℏ1").toTinybars(), 100_000);
     }
 
     @Test

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/HbarTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/HbarTest.java
@@ -86,6 +86,16 @@ public class HbarTest {
         assertEquals(Hbar.fromString("1").toTinybars(), 100_000_000);
         assertEquals(Hbar.fromString("1 ℏ").toTinybars(), 100_000_000);
         assertEquals(Hbar.fromString("1.5 mℏ").toTinybars(), 150_000);
+        assertEquals(Hbar.fromString("+1.5 mℏ").toTinybars(), 150_000);
+        assertEquals(Hbar.fromString("-1.5 mℏ").toTinybars(), -150_000);
+        assertEquals(Hbar.fromString("+3").toTinybars(), 300_000_000);
+        assertEquals(Hbar.fromString("-3").toTinybars(), -300_000_000);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Hbar.fromString("1 h");
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            Hbar.fromString("1ℏ");
+        });
     }
 
     @Test

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/HbarTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/HbarTest.java
@@ -84,8 +84,8 @@ public class HbarTest {
     @Test
     void fromString() {
         assertEquals(Hbar.fromString("1").toTinybars(), 100_000_000);
-        assertEquals(Hbar.fromString("ℏ 1").toTinybars(), 100_000_000);
-        assertEquals(Hbar.fromString("mℏ1").toTinybars(), 100_000);
+        assertEquals(Hbar.fromString("1 ℏ").toTinybars(), 100_000_000);
+        assertEquals(Hbar.fromString("1.5 mℏ").toTinybars(), 150_000);
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Sean Tedrow <sean.tedrow@launchbadge.com>

**Description**:

- Add `toString()` to `AccountBalance`
- Make `Hbar.fromString()` understand unit symbol prefixes.
- Add `toStringRaw()` and `toStringDER()` to `PrivateKey` and `PublicKey`
- Add tests for these additions.

**Related issue(s)**:

Fixes #561
