### PR TITLE
Chore: clean up after tests

### DIFF
--- a/sdk/src/integrationTest/java/AccountBalanceIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountBalanceIntegrationTest.java
@@ -23,7 +23,6 @@ class AccountBalanceIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var balance = new AccountBalanceQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .execute(testEnv.client);
 
@@ -40,7 +39,6 @@ class AccountBalanceIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var balance = new AccountBalanceQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .setMaxQueryPayment(new Hbar(1));
 
@@ -62,7 +60,6 @@ class AccountBalanceIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var balance = new AccountBalanceQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .setMaxQueryPayment(new Hbar(1000000));
 
@@ -83,7 +80,6 @@ class AccountBalanceIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var balance = new AccountBalanceQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
@@ -105,7 +101,6 @@ class AccountBalanceIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new AccountBalanceQuery()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(AccountId.fromString("1.0.3"))
                     .execute(testEnv.client);
             });
@@ -123,7 +118,6 @@ class AccountBalanceIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setInitialSupply(10000)
@@ -137,7 +131,6 @@ class AccountBalanceIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             @Var var balance = new AccountBalanceQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .execute(testEnv.client);
 

--- a/sdk/src/integrationTest/java/AccountBalanceIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountBalanceIntegrationTest.java
@@ -24,7 +24,7 @@ class AccountBalanceIntegrationTest {
 
             assertTrue(balance.hbars.toTinybars() > 0);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -46,7 +46,7 @@ class AccountBalanceIntegrationTest {
             assertTrue(accBalance.hbars.toTinybars() > 0);
             assertEquals(cost.toTinybars(), 0);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -67,7 +67,7 @@ class AccountBalanceIntegrationTest {
 
             assertTrue(accBalance.hbars.toTinybars() > 0);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -88,7 +88,7 @@ class AccountBalanceIntegrationTest {
 
             assertTrue(accBalance.hbars.toTinybars() > 0);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -107,7 +107,7 @@ class AccountBalanceIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -139,7 +139,7 @@ class AccountBalanceIntegrationTest {
             assertEquals(balance.tokens.get(tokenId), 10000);
             assertEquals(balance.tokenDecimals.get(tokenId), 50);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 }

--- a/sdk/src/integrationTest/java/AccountBalanceIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountBalanceIntegrationTest.java
@@ -20,7 +20,7 @@ class AccountBalanceIntegrationTest {
     @DisplayName("Can fetch balance for client operator")
     void canFetchBalanceForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var balance = new AccountBalanceQuery()
                 .setAccountId(testEnv.operatorId)
@@ -28,7 +28,7 @@ class AccountBalanceIntegrationTest {
 
             assertTrue(balance.hbars.toTinybars() > 0);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -36,7 +36,7 @@ class AccountBalanceIntegrationTest {
     @DisplayName("Can fetch cost for the query")
     void getCostBalanceForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var balance = new AccountBalanceQuery()
                 .setAccountId(testEnv.operatorId)
@@ -49,7 +49,7 @@ class AccountBalanceIntegrationTest {
             assertTrue(accBalance.hbars.toTinybars() > 0);
             assertEquals(cost.toTinybars(), 0);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -57,7 +57,7 @@ class AccountBalanceIntegrationTest {
     @DisplayName("Can fetch cost for the query, big max set")
     void getCostBigMaxBalanceForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var balance = new AccountBalanceQuery()
                 .setAccountId(testEnv.operatorId)
@@ -69,7 +69,7 @@ class AccountBalanceIntegrationTest {
 
             assertTrue(accBalance.hbars.toTinybars() > 0);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -77,7 +77,7 @@ class AccountBalanceIntegrationTest {
     @DisplayName("Can fetch cost for the query, very small max set")
     void getCostSmallMaxBalanceForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var balance = new AccountBalanceQuery()
                 .setAccountId(testEnv.operatorId)
@@ -89,7 +89,7 @@ class AccountBalanceIntegrationTest {
 
             assertTrue(accBalance.hbars.toTinybars() > 0);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -97,7 +97,7 @@ class AccountBalanceIntegrationTest {
     @DisplayName("Cannot fetch balance for invalid account ID")
     void canNotFetchBalanceForInvalidAccountId() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new AccountBalanceQuery()
@@ -107,7 +107,7 @@ class AccountBalanceIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -115,7 +115,7 @@ class AccountBalanceIntegrationTest {
     @DisplayName("Can fetch token balances for client operator")
     void canFetchTokenBalancesForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -137,7 +137,7 @@ class AccountBalanceIntegrationTest {
             assertEquals(balance.tokens.get(tokenId), 10000);
             assertEquals(balance.tokenDecimals.get(tokenId), 50);
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 }

--- a/sdk/src/integrationTest/java/AccountBalanceIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountBalanceIntegrationTest.java
@@ -1,5 +1,10 @@
 import com.google.errorprone.annotations.Var;
-import com.hedera.hashgraph.sdk.*;
+import com.hedera.hashgraph.sdk.AccountBalanceQuery;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PrecheckStatusException;
+import com.hedera.hashgraph.sdk.Status;
+import com.hedera.hashgraph.sdk.TokenCreateTransaction;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -15,10 +20,10 @@ class AccountBalanceIntegrationTest {
     @DisplayName("Can fetch balance for client operator")
     void canFetchBalanceForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var balance = new AccountBalanceQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .execute(testEnv.client);
 
@@ -32,10 +37,10 @@ class AccountBalanceIntegrationTest {
     @DisplayName("Can fetch cost for the query")
     void getCostBalanceForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var balance = new AccountBalanceQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .setMaxQueryPayment(new Hbar(1));
 
@@ -54,10 +59,10 @@ class AccountBalanceIntegrationTest {
     @DisplayName("Can fetch cost for the query, big max set")
     void getCostBigMaxBalanceForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var balance = new AccountBalanceQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .setMaxQueryPayment(new Hbar(1000000));
 
@@ -75,10 +80,10 @@ class AccountBalanceIntegrationTest {
     @DisplayName("Can fetch cost for the query, very small max set")
     void getCostSmallMaxBalanceForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var balance = new AccountBalanceQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
@@ -96,11 +101,11 @@ class AccountBalanceIntegrationTest {
     @DisplayName("Cannot fetch balance for invalid account ID")
     void canNotFetchBalanceForInvalidAccountId() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new AccountBalanceQuery()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(AccountId.fromString("1.0.3"))
                     .execute(testEnv.client);
             });
@@ -115,10 +120,10 @@ class AccountBalanceIntegrationTest {
     @DisplayName("Can fetch token balances for client operator")
     void canFetchTokenBalancesForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setInitialSupply(10000)
@@ -132,7 +137,7 @@ class AccountBalanceIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             @Var var balance = new AccountBalanceQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .execute(testEnv.client);
 

--- a/sdk/src/integrationTest/java/AccountCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountCreateIntegrationTest.java
@@ -1,4 +1,10 @@
-import com.hedera.hashgraph.sdk.*;
+import com.hedera.hashgraph.sdk.AccountCreateTransaction;
+import com.hedera.hashgraph.sdk.AccountDeleteTransaction;
+import com.hedera.hashgraph.sdk.AccountInfoQuery;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PrecheckStatusException;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.Status;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.threeten.bp.Duration;
@@ -17,12 +23,12 @@ class AccountCreateIntegrationTest {
     @DisplayName("Can create account with only initial balance and key")
     void canCreateAccountWithOnlyInitialBalanceAndKey() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -31,7 +37,7 @@ class AccountCreateIntegrationTest {
 
             var info = new AccountInfoQuery()
                 .setAccountId(accountId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.accountId, accountId);
@@ -42,16 +48,7 @@ class AccountCreateIntegrationTest {
             assertNull(info.proxyAccountId);
             assertEquals(info.proxyReceived, Hbar.ZERO);
 
-            new AccountDeleteTransaction()
-                .setAccountId(accountId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setTransferAccountId(testEnv.operatorId)
-                .freezeWith(testEnv.client)
-                .sign(key)
-                .execute(testEnv.client)
-                .getReceipt(testEnv.client);
-
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 
@@ -59,12 +56,12 @@ class AccountCreateIntegrationTest {
     @DisplayName("Can create account with no initial balance")
     void canCreateAccountWithNoInitialBalance() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .execute(testEnv.client);
 
@@ -72,7 +69,7 @@ class AccountCreateIntegrationTest {
 
             var info = new AccountInfoQuery()
                 .setAccountId(accountId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.accountId, accountId);
@@ -83,16 +80,7 @@ class AccountCreateIntegrationTest {
             assertNull(info.proxyAccountId);
             assertEquals(info.proxyReceived, Hbar.ZERO);
 
-            new AccountDeleteTransaction()
-                .setAccountId(accountId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setTransferAccountId(testEnv.operatorId)
-                .freezeWith(testEnv.client)
-                .sign(key)
-                .execute(testEnv.client)
-                .getReceipt(testEnv.client);
-
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 
@@ -100,11 +88,11 @@ class AccountCreateIntegrationTest {
     @DisplayName("Cannot create account with no key")
     void canNotCreateAccountWithNoKey() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new AccountCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setInitialBalance(new Hbar(1))
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);

--- a/sdk/src/integrationTest/java/AccountCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountCreateIntegrationTest.java
@@ -23,7 +23,7 @@ class AccountCreateIntegrationTest {
     @DisplayName("Can create account with only initial balance and key")
     void canCreateAccountWithOnlyInitialBalanceAndKey() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -46,7 +46,7 @@ class AccountCreateIntegrationTest {
             assertNull(info.proxyAccountId);
             assertEquals(info.proxyReceived, Hbar.ZERO);
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 
@@ -54,7 +54,7 @@ class AccountCreateIntegrationTest {
     @DisplayName("Can create account with no initial balance")
     void canCreateAccountWithNoInitialBalance() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -76,7 +76,7 @@ class AccountCreateIntegrationTest {
             assertNull(info.proxyAccountId);
             assertEquals(info.proxyReceived, Hbar.ZERO);
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 
@@ -84,7 +84,7 @@ class AccountCreateIntegrationTest {
     @DisplayName("Cannot create account with no key")
     void canNotCreateAccountWithNoKey() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new AccountCreateTransaction()
@@ -95,7 +95,7 @@ class AccountCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.KEY_REQUIRED.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/AccountCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountCreateIntegrationTest.java
@@ -51,7 +51,7 @@ class AccountCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -92,7 +92,7 @@ class AccountCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -112,7 +112,7 @@ class AccountCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.KEY_REQUIRED.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/AccountCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountCreateIntegrationTest.java
@@ -28,7 +28,6 @@ class AccountCreateIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -37,7 +36,6 @@ class AccountCreateIntegrationTest {
 
             var info = new AccountInfoQuery()
                 .setAccountId(accountId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.accountId, accountId);
@@ -61,7 +59,6 @@ class AccountCreateIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .execute(testEnv.client);
 
@@ -69,7 +66,6 @@ class AccountCreateIntegrationTest {
 
             var info = new AccountInfoQuery()
                 .setAccountId(accountId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.accountId, accountId);
@@ -92,7 +88,6 @@ class AccountCreateIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new AccountCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setInitialBalance(new Hbar(1))
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);

--- a/sdk/src/integrationTest/java/AccountDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountDeleteIntegrationTest.java
@@ -18,7 +18,7 @@ class AccountDeleteIntegrationTest {
     @DisplayName("Can delete account")
     void canDeleteAccount() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -41,7 +41,7 @@ class AccountDeleteIntegrationTest {
             assertNull(info.proxyAccountId);
             assertEquals(info.proxyReceived, Hbar.ZERO);
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 
@@ -49,7 +49,7 @@ class AccountDeleteIntegrationTest {
     @DisplayName("Cannot delete invalid account ID")
     void cannotCreateAccountWithNoKey() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new AccountDeleteTransaction()
@@ -60,7 +60,7 @@ class AccountDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.ACCOUNT_ID_DOES_NOT_EXIST.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -68,7 +68,7 @@ class AccountDeleteIntegrationTest {
     @DisplayName("Cannot delete account that has not signed transaction")
     void cannotDeleteAccountThatHasNotSignedTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -89,7 +89,7 @@ class AccountDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_SIGNATURE.toString()));
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/AccountDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountDeleteIntegrationTest.java
@@ -23,7 +23,6 @@ class AccountDeleteIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -32,7 +31,6 @@ class AccountDeleteIntegrationTest {
 
             var info = new AccountInfoQuery()
                 .setAccountId(accountId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.accountId, accountId);
@@ -55,7 +53,6 @@ class AccountDeleteIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new AccountDeleteTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTransferAccountId(testEnv.operatorId)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -76,7 +73,6 @@ class AccountDeleteIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);

--- a/sdk/src/integrationTest/java/AccountDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountDeleteIntegrationTest.java
@@ -18,12 +18,12 @@ class AccountDeleteIntegrationTest {
     @DisplayName("Can delete account")
     void canDeleteAccount() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -32,7 +32,7 @@ class AccountDeleteIntegrationTest {
 
             var info = new AccountInfoQuery()
                 .setAccountId(accountId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.accountId, accountId);
@@ -43,16 +43,7 @@ class AccountDeleteIntegrationTest {
             assertNull(info.proxyAccountId);
             assertEquals(info.proxyReceived, Hbar.ZERO);
 
-            new AccountDeleteTransaction()
-                .setAccountId(accountId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setTransferAccountId(testEnv.operatorId)
-                .freezeWith(testEnv.client)
-                .sign(key)
-                .execute(testEnv.client)
-                .getReceipt(testEnv.client);
-
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 
@@ -60,11 +51,11 @@ class AccountDeleteIntegrationTest {
     @DisplayName("Cannot delete invalid account ID")
     void cannotCreateAccountWithNoKey() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new AccountDeleteTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTransferAccountId(testEnv.operatorId)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -80,12 +71,12 @@ class AccountDeleteIntegrationTest {
     @DisplayName("Cannot delete account that has not signed transaction")
     void cannotDeleteAccountThatHasNotSignedTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);

--- a/sdk/src/integrationTest/java/AccountDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountDeleteIntegrationTest.java
@@ -52,7 +52,7 @@ class AccountDeleteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -72,7 +72,7 @@ class AccountDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.ACCOUNT_ID_DOES_NOT_EXIST.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -102,7 +102,7 @@ class AccountDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_SIGNATURE.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/AccountInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountInfoIntegrationTest.java
@@ -18,16 +18,16 @@ class AccountInfoIntegrationTest {
     @DisplayName("Can query account info for client operator")
     void canQueryAccountInfoForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var info = new AccountInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .execute(testEnv.client);
 
             assertEquals(info.accountId, testEnv.operatorId);
             assertFalse(info.isDeleted);
-            assertEquals(info.key.toString(), testEnv.operatorKey.getPublicKey().toString());
+            assertEquals(info.key.toString(), testEnv.operatorKey.toString());
             assertTrue(info.balance.toTinybars() > 0);
             assertNull(info.proxyAccountId);
             assertEquals(info.proxyReceived, Hbar.ZERO);
@@ -40,10 +40,10 @@ class AccountInfoIntegrationTest {
     @DisplayName("Can get cost for account info query")
     void getCostAccountInfoForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var info = new AccountInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .setMaxQueryPayment(new Hbar(1));
 
@@ -61,10 +61,10 @@ class AccountInfoIntegrationTest {
     @DisplayName("Can get cost for account info query, with a bix max")
     void getCostBigMaxAccountInfoForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var info = new AccountInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .setMaxQueryPayment(Hbar.MAX);
 
@@ -83,10 +83,10 @@ class AccountInfoIntegrationTest {
     @DisplayName("Can get cost for account info query, with a small max")
     void getCostSmallMaxAccountInfoForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var info = new AccountInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
@@ -106,10 +106,10 @@ class AccountInfoIntegrationTest {
     @DisplayName("Insufficient tx fee error.")
     void getCostInsufficientTxFeeAccountInfoForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var info = new AccountInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .setMaxQueryPayment(Hbar.fromTinybars(10000));
 

--- a/sdk/src/integrationTest/java/AccountInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountInfoIntegrationTest.java
@@ -21,7 +21,6 @@ class AccountInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var info = new AccountInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .execute(testEnv.client);
 
@@ -43,7 +42,6 @@ class AccountInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var info = new AccountInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .setMaxQueryPayment(new Hbar(1));
 
@@ -64,7 +62,6 @@ class AccountInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var info = new AccountInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .setMaxQueryPayment(Hbar.MAX);
 
@@ -86,7 +83,6 @@ class AccountInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var info = new AccountInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
@@ -109,7 +105,6 @@ class AccountInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var info = new AccountInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .setMaxQueryPayment(Hbar.fromTinybars(10000));
 

--- a/sdk/src/integrationTest/java/AccountInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountInfoIntegrationTest.java
@@ -32,7 +32,7 @@ class AccountInfoIntegrationTest {
             assertNull(info.proxyAccountId);
             assertEquals(info.proxyReceived, Hbar.ZERO);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -53,7 +53,7 @@ class AccountInfoIntegrationTest {
 
             assertEquals(accInfo.accountId, testEnv.operatorId);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -74,7 +74,7 @@ class AccountInfoIntegrationTest {
 
             assertEquals(accInfo.accountId, testEnv.operatorId);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -98,7 +98,7 @@ class AccountInfoIntegrationTest {
 
             assertEquals(error.getMessage(), "com.hedera.hashgraph.sdk.MaxQueryPaymentExceededException: cost for AccountInfoQuery, of "+cost.toString()+", without explicit payment is greater than the maximum allowed payment of 1 tℏ");
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -119,7 +119,7 @@ class AccountInfoIntegrationTest {
 
             assertEquals(error.status.toString(), "INSUFFICIENT_TX_FEE");
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/AccountInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountInfoIntegrationTest.java
@@ -18,7 +18,7 @@ class AccountInfoIntegrationTest {
     @DisplayName("Can query account info for client operator")
     void canQueryAccountInfoForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var info = new AccountInfoQuery()
                 .setAccountId(testEnv.operatorId)
@@ -31,7 +31,7 @@ class AccountInfoIntegrationTest {
             assertNull(info.proxyAccountId);
             assertEquals(info.proxyReceived, Hbar.ZERO);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -39,7 +39,7 @@ class AccountInfoIntegrationTest {
     @DisplayName("Can get cost for account info query")
     void getCostAccountInfoForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var info = new AccountInfoQuery()
                 .setAccountId(testEnv.operatorId)
@@ -51,7 +51,7 @@ class AccountInfoIntegrationTest {
 
             assertEquals(accInfo.accountId, testEnv.operatorId);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -59,7 +59,7 @@ class AccountInfoIntegrationTest {
     @DisplayName("Can get cost for account info query, with a bix max")
     void getCostBigMaxAccountInfoForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var info = new AccountInfoQuery()
                 .setAccountId(testEnv.operatorId)
@@ -71,7 +71,7 @@ class AccountInfoIntegrationTest {
 
             assertEquals(accInfo.accountId, testEnv.operatorId);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -80,7 +80,7 @@ class AccountInfoIntegrationTest {
     @DisplayName("Can get cost for account info query, with a small max")
     void getCostSmallMaxAccountInfoForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var info = new AccountInfoQuery()
                 .setAccountId(testEnv.operatorId)
@@ -94,7 +94,7 @@ class AccountInfoIntegrationTest {
 
             assertEquals(error.getMessage(), "com.hedera.hashgraph.sdk.MaxQueryPaymentExceededException: cost for AccountInfoQuery, of "+cost.toString()+", without explicit payment is greater than the maximum allowed payment of 1 tℏ");
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -102,7 +102,7 @@ class AccountInfoIntegrationTest {
     @DisplayName("Insufficient tx fee error.")
     void getCostInsufficientTxFeeAccountInfoForClientOperator() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var info = new AccountInfoQuery()
                 .setAccountId(testEnv.operatorId)
@@ -114,7 +114,7 @@ class AccountInfoIntegrationTest {
 
             assertEquals(error.status.toString(), "INSUFFICIENT_TX_FEE");
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/AccountRecordsIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountRecordsIntegrationTest.java
@@ -12,11 +12,11 @@ class AccountRecordsIntegrationTest {
     @DisplayName("Can query account records")
     void canQueryAccountRecords() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -24,14 +24,14 @@ class AccountRecordsIntegrationTest {
             var accountId = Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
 
             new TransferTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .addHbarTransfer(testEnv.operatorId, new Hbar(1).negated())
                 .addHbarTransfer(accountId, new Hbar(1))
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TransferTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .addHbarTransfer(testEnv.operatorId, new Hbar(1))
                 .addHbarTransfer(accountId, new Hbar(1).negated())
                 .freezeWith(testEnv.client)
@@ -40,22 +40,13 @@ class AccountRecordsIntegrationTest {
                 .getReceipt(testEnv.client);
 
             var records = new AccountRecordsQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .execute(testEnv.client);
 
             assertTrue(!records.isEmpty());
 
-            new AccountDeleteTransaction()
-                .setAccountId(accountId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setTransferAccountId(testEnv.operatorId)
-                .freezeWith(testEnv.client)
-                .sign(key)
-                .execute(testEnv.client)
-                .getReceipt(testEnv.client);
-
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/AccountRecordsIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountRecordsIntegrationTest.java
@@ -16,7 +16,6 @@ class AccountRecordsIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -24,14 +23,12 @@ class AccountRecordsIntegrationTest {
             var accountId = Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
 
             new TransferTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .addHbarTransfer(testEnv.operatorId, new Hbar(1).negated())
                 .addHbarTransfer(accountId, new Hbar(1))
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TransferTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .addHbarTransfer(testEnv.operatorId, new Hbar(1))
                 .addHbarTransfer(accountId, new Hbar(1).negated())
                 .freezeWith(testEnv.client)
@@ -40,7 +37,6 @@ class AccountRecordsIntegrationTest {
                 .getReceipt(testEnv.client);
 
             var records = new AccountRecordsQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(testEnv.operatorId)
                 .execute(testEnv.client);
 

--- a/sdk/src/integrationTest/java/AccountRecordsIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountRecordsIntegrationTest.java
@@ -12,7 +12,7 @@ class AccountRecordsIntegrationTest {
     @DisplayName("Can query account records")
     void canQueryAccountRecords() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
@@ -42,7 +42,7 @@ class AccountRecordsIntegrationTest {
 
             assertTrue(!records.isEmpty());
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/AccountRecordsIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountRecordsIntegrationTest.java
@@ -55,7 +55,7 @@ class AccountRecordsIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/AccountStakersIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountStakersIntegrationTest.java
@@ -14,11 +14,11 @@ class AccountStakersIntegrationTest {
     @DisplayName("Cannot query account stakers since it is not supported")
     void cannotQueryAccountStakersSinceItIsNotSupported() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new AccountStakersQuery()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(testEnv.operatorId)
                     .setMaxQueryPayment(new Hbar(1))
                     .execute(testEnv.client);

--- a/sdk/src/integrationTest/java/AccountStakersIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountStakersIntegrationTest.java
@@ -14,7 +14,7 @@ class AccountStakersIntegrationTest {
     @DisplayName("Cannot query account stakers since it is not supported")
     void cannotQueryAccountStakersSinceItIsNotSupported() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new AccountStakersQuery()
@@ -25,7 +25,7 @@ class AccountStakersIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.NOT_SUPPORTED.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/AccountStakersIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountStakersIntegrationTest.java
@@ -26,7 +26,7 @@ class AccountStakersIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.NOT_SUPPORTED.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/AccountStakersIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountStakersIntegrationTest.java
@@ -18,7 +18,6 @@ class AccountStakersIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new AccountStakersQuery()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(testEnv.operatorId)
                     .setMaxQueryPayment(new Hbar(1))
                     .execute(testEnv.client);

--- a/sdk/src/integrationTest/java/AccountUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountUpdateIntegrationTest.java
@@ -18,13 +18,13 @@ class AccountUpdateIntegrationTest {
     @DisplayName("Can update account with a new key")
     void canUpdateAccountWithNewKey() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key1 = PrivateKey.generate();
             var key2 = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key1)
                 .execute(testEnv.client);
 
@@ -32,7 +32,7 @@ class AccountUpdateIntegrationTest {
 
             @Var var info = new AccountInfoQuery()
                 .setAccountId(accountId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.accountId, accountId);
@@ -45,7 +45,7 @@ class AccountUpdateIntegrationTest {
 
             new AccountUpdateTransaction()
                 .setAccountId(accountId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key2.getPublicKey())
                 .freezeWith(testEnv.client)
                 .sign(key1)
@@ -65,16 +65,7 @@ class AccountUpdateIntegrationTest {
             assertNull(info.proxyAccountId);
             assertEquals(info.proxyReceived, Hbar.ZERO);
 
-            new AccountDeleteTransaction()
-                .setAccountId(accountId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setTransferAccountId(testEnv.operatorId)
-                .freezeWith(testEnv.client)
-                .sign(key2)
-                .execute(testEnv.client)
-                .getReceipt(testEnv.client);
-
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(accountId, key2);
         });
     }
 
@@ -82,11 +73,11 @@ class AccountUpdateIntegrationTest {
     @DisplayName("Cannot update account when account ID is not set")
     void cannotUpdateAccountWhenAccountIdIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new AccountUpdateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });

--- a/sdk/src/integrationTest/java/AccountUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountUpdateIntegrationTest.java
@@ -74,7 +74,7 @@ class AccountUpdateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -93,7 +93,7 @@ class AccountUpdateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/AccountUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountUpdateIntegrationTest.java
@@ -18,7 +18,7 @@ class AccountUpdateIntegrationTest {
     @DisplayName("Can update account with a new key")
     void canUpdateAccountWithNewKey() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key1 = PrivateKey.generate();
             var key2 = PrivateKey.generate();
@@ -62,7 +62,7 @@ class AccountUpdateIntegrationTest {
             assertNull(info.proxyAccountId);
             assertEquals(info.proxyReceived, Hbar.ZERO);
 
-            testEnv.cleanUpAndClose(accountId, key2);
+            testEnv.close(accountId, key2);
         });
     }
 
@@ -70,7 +70,7 @@ class AccountUpdateIntegrationTest {
     @DisplayName("Cannot update account when account ID is not set")
     void cannotUpdateAccountWhenAccountIdIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new AccountUpdateTransaction()
@@ -80,7 +80,7 @@ class AccountUpdateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/AccountUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountUpdateIntegrationTest.java
@@ -24,7 +24,6 @@ class AccountUpdateIntegrationTest {
             var key2 = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key1)
                 .execute(testEnv.client);
 
@@ -32,7 +31,6 @@ class AccountUpdateIntegrationTest {
 
             @Var var info = new AccountInfoQuery()
                 .setAccountId(accountId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.accountId, accountId);
@@ -45,7 +43,6 @@ class AccountUpdateIntegrationTest {
 
             new AccountUpdateTransaction()
                 .setAccountId(accountId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key2.getPublicKey())
                 .freezeWith(testEnv.client)
                 .sign(key1)
@@ -77,7 +74,6 @@ class AccountUpdateIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new AccountUpdateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });

--- a/sdk/src/integrationTest/java/ClientIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ClientIntegrationTest.java
@@ -27,7 +27,7 @@ public class ClientIntegrationTest {
             network.put("0.testnet.hedera.com:50211", new AccountId(3));
             network.put("1.testnet.hedera.com:50211", new AccountId(4));
 
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             testEnv.client
                 .setMaxQueryPayment(new Hbar(2))
@@ -71,6 +71,8 @@ public class ClientIntegrationTest {
                 .setTransactionId(TransactionId.generate(AccountId.fromString("0.0.123-rmkyk")))
                 .execute(client);
             client.close();
+
+            // TODO: WTF is this?
         });
     }
 
@@ -78,7 +80,7 @@ public class ClientIntegrationTest {
     @DisplayName("`setMaxNodesPerTransaction()`")
     void testMaxNodesPerTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             testEnv.client.setMaxNodesPerTransaction(1);
 

--- a/sdk/src/integrationTest/java/ClientIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ClientIntegrationTest.java
@@ -6,6 +6,7 @@ import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.Hbar;
 import com.hedera.hashgraph.sdk.TransactionId;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.threeten.bp.Duration;
@@ -20,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ClientIntegrationTest {
     @Test
+    @Disabled
     @DisplayName("setNetwork() functions correctly")
     void testReplaceNodes() {
         assertDoesNotThrow(() -> {
@@ -31,9 +33,9 @@ public class ClientIntegrationTest {
 
             testEnv.client
                 .setMaxQueryPayment(new Hbar(2))
-                .setRequestTimeout(Duration.ofMinutes(2));
+                .setRequestTimeout(Duration.ofMinutes(2))
+                .setNetwork(network);
 
-            var operatorId = testEnv.client.getOperatorAccountId();
             assertNotNull(testEnv.operatorId);
 
             // Execute two simple queries so we create a channel for each network node.
@@ -57,7 +59,6 @@ public class ClientIntegrationTest {
 
             testEnv.client.setNetwork(network);
 
-            // TODO: not sure what's going on here, cleanUpAndClose() fails with PAYER_ACCOUNT_NOT_FOUND
             testEnv.client.close();
         });
     }
@@ -71,8 +72,6 @@ public class ClientIntegrationTest {
                 .setTransactionId(TransactionId.generate(AccountId.fromString("0.0.123-rmkyk")))
                 .execute(client);
             client.close();
-
-            // TODO: WTF is this?
         });
     }
 

--- a/sdk/src/integrationTest/java/ClientIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ClientIntegrationTest.java
@@ -29,7 +29,7 @@ public class ClientIntegrationTest {
             network.put("0.testnet.hedera.com:50211", new AccountId(3));
             network.put("1.testnet.hedera.com:50211", new AccountId(4));
 
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             testEnv.client
                 .setMaxQueryPayment(new Hbar(2))
@@ -79,7 +79,7 @@ public class ClientIntegrationTest {
     @DisplayName("`setMaxNodesPerTransaction()`")
     void testMaxNodesPerTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             testEnv.client.setMaxNodesPerTransaction(1);
 
@@ -90,7 +90,7 @@ public class ClientIntegrationTest {
             assertNotNull(transaction.getNodeAccountIds());
             assertEquals(1, transaction.getNodeAccountIds().size());
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ClientIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ClientIntegrationTest.java
@@ -59,7 +59,7 @@ public class ClientIntegrationTest {
 
             testEnv.client.setNetwork(network);
 
-            testEnv.client.close();
+            testEnv.close();
         });
     }
 

--- a/sdk/src/integrationTest/java/ClientIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ClientIntegrationTest.java
@@ -57,6 +57,7 @@ public class ClientIntegrationTest {
 
             testEnv.client.setNetwork(network);
 
+            // TODO: not sure what's going on here, cleanUpAndClose() fails with PAYER_ACCOUNT_NOT_FOUND
             testEnv.client.close();
         });
     }
@@ -88,7 +89,7 @@ public class ClientIntegrationTest {
             assertNotNull(transaction.getNodeAccountIds());
             assertEquals(1, transaction.getNodeAccountIds().size());
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ContractBytecodeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractBytecodeIntegrationTest.java
@@ -18,7 +18,7 @@ public class ContractBytecodeIntegrationTest {
     @DisplayName("Can query contract bytecode")
     void canQueryContractBytecode() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -53,7 +53,7 @@ public class ContractBytecodeIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -61,7 +61,7 @@ public class ContractBytecodeIntegrationTest {
     @DisplayName("Can get cost, even with a big max")
     void getCostBigMaxQueryContractBytecode() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -100,7 +100,7 @@ public class ContractBytecodeIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -108,7 +108,7 @@ public class ContractBytecodeIntegrationTest {
     @DisplayName("Error, max is smaller than set payment.")
     void getCostSmallMaxQueryContractBytecode() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -149,7 +149,7 @@ public class ContractBytecodeIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -157,7 +157,7 @@ public class ContractBytecodeIntegrationTest {
     @DisplayName("Insufficient tx fee error.")
     void getCostInsufficientTxFeeQueryContractBytecode() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -198,7 +198,7 @@ public class ContractBytecodeIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -206,7 +206,7 @@ public class ContractBytecodeIntegrationTest {
     @DisplayName("Cannot query contract bytecode when contract ID is not set")
     void cannotQueryContractBytecodeWhenContractIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractByteCodeQuery()
@@ -215,7 +215,7 @@ public class ContractBytecodeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_CONTRACT_ID.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ContractBytecodeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractBytecodeIntegrationTest.java
@@ -58,7 +58,7 @@ public class ContractBytecodeIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -110,7 +110,7 @@ public class ContractBytecodeIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -164,7 +164,7 @@ public class ContractBytecodeIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -218,7 +218,7 @@ public class ContractBytecodeIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -236,7 +236,7 @@ public class ContractBytecodeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_CONTRACT_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ContractBytecodeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractBytecodeIntegrationTest.java
@@ -21,6 +21,7 @@ public class ContractBytecodeIntegrationTest {
             var testEnv = new IntegrationTestEnv();
 
             @Var var response = new FileCreateTransaction()
+                .setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -68,6 +69,7 @@ public class ContractBytecodeIntegrationTest {
             var testEnv = new IntegrationTestEnv();
 
             @Var var response = new FileCreateTransaction()
+                .setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -119,6 +121,7 @@ public class ContractBytecodeIntegrationTest {
             var testEnv = new IntegrationTestEnv();
 
             @Var var response = new FileCreateTransaction()
+                .setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);

--- a/sdk/src/integrationTest/java/ContractBytecodeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractBytecodeIntegrationTest.java
@@ -18,10 +18,10 @@ public class ContractBytecodeIntegrationTest {
     @DisplayName("Can query contract bytecode")
     void canQueryContractBytecode() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -30,7 +30,7 @@ public class ContractBytecodeIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -40,7 +40,7 @@ public class ContractBytecodeIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var bytecode = new ContractByteCodeQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .execute(testEnv.client);
 
@@ -48,13 +48,13 @@ public class ContractBytecodeIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -66,10 +66,10 @@ public class ContractBytecodeIntegrationTest {
     @DisplayName("Can get cost, even with a big max")
     void getCostBigMaxQueryContractBytecode() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -78,7 +78,7 @@ public class ContractBytecodeIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -88,7 +88,7 @@ public class ContractBytecodeIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var bytecodeQuery = new ContractByteCodeQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setMaxQueryPayment(new Hbar(1000));
 
@@ -100,13 +100,13 @@ public class ContractBytecodeIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -118,10 +118,10 @@ public class ContractBytecodeIntegrationTest {
     @DisplayName("Error, max is smaller than set payment.")
     void getCostSmallMaxQueryContractBytecode() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -130,7 +130,7 @@ public class ContractBytecodeIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -140,7 +140,7 @@ public class ContractBytecodeIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var bytecodeQuery = new ContractByteCodeQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
@@ -154,13 +154,13 @@ public class ContractBytecodeIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -172,10 +172,10 @@ public class ContractBytecodeIntegrationTest {
     @DisplayName("Insufficient tx fee error.")
     void getCostInsufficientTxFeeQueryContractBytecode() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -184,7 +184,7 @@ public class ContractBytecodeIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -194,7 +194,7 @@ public class ContractBytecodeIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var bytecodeQuery = new ContractByteCodeQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setMaxQueryPayment(new Hbar(100));
 
@@ -208,13 +208,13 @@ public class ContractBytecodeIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -226,11 +226,11 @@ public class ContractBytecodeIntegrationTest {
     @DisplayName("Cannot query contract bytecode when contract ID is not set")
     void cannotQueryContractBytecodeWhenContractIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractByteCodeQuery()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client);
             });
 

--- a/sdk/src/integrationTest/java/ContractBytecodeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractBytecodeIntegrationTest.java
@@ -21,7 +21,6 @@ public class ContractBytecodeIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -30,7 +29,6 @@ public class ContractBytecodeIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -40,7 +38,6 @@ public class ContractBytecodeIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var bytecode = new ContractByteCodeQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .execute(testEnv.client);
 
@@ -48,13 +45,11 @@ public class ContractBytecodeIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -69,7 +64,6 @@ public class ContractBytecodeIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -78,7 +72,6 @@ public class ContractBytecodeIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -88,7 +81,6 @@ public class ContractBytecodeIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var bytecodeQuery = new ContractByteCodeQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setMaxQueryPayment(new Hbar(1000));
 
@@ -100,13 +92,11 @@ public class ContractBytecodeIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -121,7 +111,6 @@ public class ContractBytecodeIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -130,7 +119,6 @@ public class ContractBytecodeIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -140,7 +128,6 @@ public class ContractBytecodeIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var bytecodeQuery = new ContractByteCodeQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
@@ -154,13 +141,11 @@ public class ContractBytecodeIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -175,7 +160,6 @@ public class ContractBytecodeIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -184,7 +168,6 @@ public class ContractBytecodeIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -194,7 +177,6 @@ public class ContractBytecodeIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var bytecodeQuery = new ContractByteCodeQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setMaxQueryPayment(new Hbar(100));
 
@@ -208,13 +190,11 @@ public class ContractBytecodeIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -230,7 +210,6 @@ public class ContractBytecodeIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractByteCodeQuery()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client);
             });
 

--- a/sdk/src/integrationTest/java/ContractCallIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractCallIntegrationTest.java
@@ -17,7 +17,7 @@ public class ContractCallIntegrationTest {
     @DisplayName("Can call contract function")
     void canCallContractFunction() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -59,7 +59,7 @@ public class ContractCallIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -67,7 +67,7 @@ public class ContractCallIntegrationTest {
     @DisplayName("Cannot call contract function when contract function is not set")
     void cannotCallContractFunctionWhenContractFunctionIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             final var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -107,7 +107,7 @@ public class ContractCallIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.CONTRACT_REVERT_EXECUTED.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -115,7 +115,7 @@ public class ContractCallIntegrationTest {
     @DisplayName("Cannot call contract function when gas is not set")
     void cannotCallContractFunctionWhenGasIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             final var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -155,7 +155,7 @@ public class ContractCallIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INSUFFICIENT_GAS.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -163,7 +163,7 @@ public class ContractCallIntegrationTest {
     @DisplayName("Cannot call contract function when contract ID is not set")
     void cannotCallContractFunctionWhenContractIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             final var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -203,7 +203,7 @@ public class ContractCallIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_CONTRACT_ID.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -211,7 +211,7 @@ public class ContractCallIntegrationTest {
     @DisplayName("Can get cost, even with a big max")
     void getCostBigMaxContractCallFunction() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -253,7 +253,7 @@ public class ContractCallIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -261,7 +261,7 @@ public class ContractCallIntegrationTest {
     @DisplayName("Error, max is smaller than set payment.")
     void getCostSmallMaxContractCallFunction() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -304,7 +304,7 @@ public class ContractCallIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -312,7 +312,7 @@ public class ContractCallIntegrationTest {
     @DisplayName("Insufficient tx fee error.")
     void getCostInsufficientTxFeeContractCallFunction() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -355,7 +355,7 @@ public class ContractCallIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ContractCallIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractCallIntegrationTest.java
@@ -17,10 +17,10 @@ public class ContractCallIntegrationTest {
     @DisplayName("Can call contract function")
     void canCallContractFunction() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -29,7 +29,7 @@ public class ContractCallIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -39,7 +39,7 @@ public class ContractCallIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var callQuery = new ContractCallQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setGas(2000)
                 .setFunction("getMessage");
@@ -47,7 +47,7 @@ public class ContractCallIntegrationTest {
             var cost = callQuery.getCost(testEnv.client);
 
             @Var var result = callQuery
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(Objects.requireNonNull(cost))
                 .execute(testEnv.client);
 
@@ -55,13 +55,13 @@ public class ContractCallIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -73,10 +73,10 @@ public class ContractCallIntegrationTest {
     @DisplayName("Cannot call contract function when contract function is not set")
     void cannotCallContractFunctionWhenContractFunctionIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             final var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -86,7 +86,7 @@ public class ContractCallIntegrationTest {
             var contractId = Objects.requireNonNull(
                 new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -98,7 +98,7 @@ public class ContractCallIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractCallQuery()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContractId(contractId)
                     .setGas(2000)
                     .execute(testEnv.client);
@@ -106,13 +106,13 @@ public class ContractCallIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -126,10 +126,10 @@ public class ContractCallIntegrationTest {
     @DisplayName("Cannot call contract function when gas is not set")
     void cannotCallContractFunctionWhenGasIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             final var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -139,7 +139,7 @@ public class ContractCallIntegrationTest {
             var contractId = Objects.requireNonNull(
                 new ContractCreateTransaction()
                     .setAdminKey(testEnv.operatorKey)
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(2000)
                     .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                     .setBytecodeFileId(fileId)
@@ -151,7 +151,7 @@ public class ContractCallIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractCallQuery()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContractId(contractId)
                     .setFunction("getMessage")
                     .execute(testEnv.client);
@@ -159,13 +159,13 @@ public class ContractCallIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -179,10 +179,10 @@ public class ContractCallIntegrationTest {
     @DisplayName("Cannot call contract function when contract ID is not set")
     void cannotCallContractFunctionWhenContractIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             final var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -192,7 +192,7 @@ public class ContractCallIntegrationTest {
             var contractId = Objects.requireNonNull(
                 new ContractCreateTransaction()
                     .setAdminKey(testEnv.operatorKey)
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(2000)
                     .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                     .setBytecodeFileId(fileId)
@@ -204,7 +204,7 @@ public class ContractCallIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractCallQuery()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(2000)
                     .setFunction("getMessage")
                     .execute(testEnv.client);
@@ -212,13 +212,13 @@ public class ContractCallIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -232,10 +232,10 @@ public class ContractCallIntegrationTest {
     @DisplayName("Can get cost, even with a big max")
     void getCostBigMaxContractCallFunction() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -244,7 +244,7 @@ public class ContractCallIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -254,7 +254,7 @@ public class ContractCallIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var callQuery = new ContractCallQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setGas(2000)
                 .setFunction("getMessage")
@@ -269,13 +269,13 @@ public class ContractCallIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -287,10 +287,10 @@ public class ContractCallIntegrationTest {
     @DisplayName("Error, max is smaller than set payment.")
     void getCostSmallMaxContractCallFunction() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -299,7 +299,7 @@ public class ContractCallIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -309,7 +309,7 @@ public class ContractCallIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var callQuery = new ContractCallQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setGas(2000)
                 .setFunction("getMessage")
@@ -325,13 +325,13 @@ public class ContractCallIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -343,10 +343,10 @@ public class ContractCallIntegrationTest {
     @DisplayName("Insufficient tx fee error.")
     void getCostInsufficientTxFeeContractCallFunction() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -355,7 +355,7 @@ public class ContractCallIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -365,7 +365,7 @@ public class ContractCallIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var callQuery = new ContractCallQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setGas(2000)
                 .setFunction("getMessage")
@@ -381,13 +381,13 @@ public class ContractCallIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 

--- a/sdk/src/integrationTest/java/ContractCallIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractCallIntegrationTest.java
@@ -65,7 +65,7 @@ public class ContractCallIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -118,7 +118,7 @@ public class ContractCallIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.CONTRACT_REVERT_EXECUTED.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -171,7 +171,7 @@ public class ContractCallIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INSUFFICIENT_GAS.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -224,7 +224,7 @@ public class ContractCallIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_CONTRACT_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -279,7 +279,7 @@ public class ContractCallIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -335,7 +335,7 @@ public class ContractCallIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -391,7 +391,7 @@ public class ContractCallIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ContractCallIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractCallIntegrationTest.java
@@ -20,7 +20,6 @@ public class ContractCallIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -29,7 +28,6 @@ public class ContractCallIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -39,7 +37,6 @@ public class ContractCallIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var callQuery = new ContractCallQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setGas(2000)
                 .setFunction("getMessage");
@@ -47,7 +44,6 @@ public class ContractCallIntegrationTest {
             var cost = callQuery.getCost(testEnv.client);
 
             @Var var result = callQuery
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(Objects.requireNonNull(cost))
                 .execute(testEnv.client);
 
@@ -55,13 +51,11 @@ public class ContractCallIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -76,7 +70,6 @@ public class ContractCallIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             final var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -86,7 +79,6 @@ public class ContractCallIntegrationTest {
             var contractId = Objects.requireNonNull(
                 new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -98,7 +90,6 @@ public class ContractCallIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractCallQuery()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContractId(contractId)
                     .setGas(2000)
                     .execute(testEnv.client);
@@ -106,13 +97,11 @@ public class ContractCallIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -129,7 +118,6 @@ public class ContractCallIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             final var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -139,7 +127,6 @@ public class ContractCallIntegrationTest {
             var contractId = Objects.requireNonNull(
                 new ContractCreateTransaction()
                     .setAdminKey(testEnv.operatorKey)
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(2000)
                     .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                     .setBytecodeFileId(fileId)
@@ -151,7 +138,6 @@ public class ContractCallIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractCallQuery()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContractId(contractId)
                     .setFunction("getMessage")
                     .execute(testEnv.client);
@@ -159,13 +145,11 @@ public class ContractCallIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -182,7 +166,6 @@ public class ContractCallIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             final var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -192,7 +175,6 @@ public class ContractCallIntegrationTest {
             var contractId = Objects.requireNonNull(
                 new ContractCreateTransaction()
                     .setAdminKey(testEnv.operatorKey)
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(2000)
                     .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                     .setBytecodeFileId(fileId)
@@ -204,7 +186,6 @@ public class ContractCallIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractCallQuery()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(2000)
                     .setFunction("getMessage")
                     .execute(testEnv.client);
@@ -212,13 +193,11 @@ public class ContractCallIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -235,7 +214,6 @@ public class ContractCallIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -244,7 +222,6 @@ public class ContractCallIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -254,7 +231,6 @@ public class ContractCallIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var callQuery = new ContractCallQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setGas(2000)
                 .setFunction("getMessage")
@@ -269,13 +245,11 @@ public class ContractCallIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -290,7 +264,6 @@ public class ContractCallIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -299,7 +272,6 @@ public class ContractCallIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -309,7 +281,6 @@ public class ContractCallIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var callQuery = new ContractCallQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setGas(2000)
                 .setFunction("getMessage")
@@ -325,13 +296,11 @@ public class ContractCallIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -346,7 +315,6 @@ public class ContractCallIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -355,7 +323,6 @@ public class ContractCallIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -365,7 +332,6 @@ public class ContractCallIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var callQuery = new ContractCallQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setGas(2000)
                 .setFunction("getMessage")
@@ -381,13 +347,11 @@ public class ContractCallIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 

--- a/sdk/src/integrationTest/java/ContractCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractCreateIntegrationTest.java
@@ -21,7 +21,6 @@ public class ContractCreateIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -30,7 +29,6 @@ public class ContractCreateIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -40,7 +38,6 @@ public class ContractCreateIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             @Var var info = new ContractInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .execute(testEnv.client);
 
@@ -54,13 +51,11 @@ public class ContractCreateIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -75,7 +70,6 @@ public class ContractCreateIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -83,7 +77,6 @@ public class ContractCreateIntegrationTest {
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
             response = new ContractCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -93,7 +86,6 @@ public class ContractCreateIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             @Var var info = new ContractInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .execute(testEnv.client);
 
@@ -116,7 +108,6 @@ public class ContractCreateIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -126,7 +117,6 @@ public class ContractCreateIntegrationTest {
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new ContractCreateTransaction()
                     .setAdminKey(testEnv.operatorKey)
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                     .setBytecodeFileId(fileId)
                     .setContractMemo("[e2e::ContractCreateTransaction]")
@@ -138,7 +128,6 @@ public class ContractCreateIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -153,7 +142,6 @@ public class ContractCreateIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -163,7 +151,6 @@ public class ContractCreateIntegrationTest {
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new ContractCreateTransaction()
                     .setAdminKey(testEnv.operatorKey)
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(2000)
                     .setBytecodeFileId(fileId)
                     .setContractMemo("[e2e::ContractCreateTransaction]")
@@ -175,7 +162,6 @@ public class ContractCreateIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -191,7 +177,6 @@ public class ContractCreateIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new ContractCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAdminKey(testEnv.operatorKey)
                     .setGas(2000)
                     .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))

--- a/sdk/src/integrationTest/java/ContractCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractCreateIntegrationTest.java
@@ -18,7 +18,7 @@ public class ContractCreateIntegrationTest {
     @DisplayName("Can create contract")
     void canCreateContract() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -59,7 +59,7 @@ public class ContractCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -67,7 +67,7 @@ public class ContractCreateIntegrationTest {
     @DisplayName("Can create contract with no admin key")
     void canCreateContractWithNoAdminKey() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -97,7 +97,7 @@ public class ContractCreateIntegrationTest {
             assertEquals(info.storage, 926);
             assertEquals(info.contractMemo, "[e2e::ContractCreateTransaction]");
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -105,7 +105,7 @@ public class ContractCreateIntegrationTest {
     @DisplayName("Cannot create contract when gas is not set")
     void cannotCreateContractWhenGasIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -131,7 +131,7 @@ public class ContractCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -139,7 +139,7 @@ public class ContractCreateIntegrationTest {
     @DisplayName("Cannot create contract when constructor parameters are not set")
     void cannotCreateContractWhenConstructorParametersAreNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -165,7 +165,7 @@ public class ContractCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -173,7 +173,7 @@ public class ContractCreateIntegrationTest {
     @DisplayName("Cannot create contract when bytecode file ID is not set")
     void cannotCreateContractWhenBytecodeFileIdIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new ContractCreateTransaction()
@@ -187,7 +187,7 @@ public class ContractCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_FILE_ID.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ContractCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractCreateIntegrationTest.java
@@ -64,7 +64,7 @@ public class ContractCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -105,7 +105,7 @@ public class ContractCreateIntegrationTest {
             assertEquals(info.storage, 926);
             assertEquals(info.contractMemo, "[e2e::ContractCreateTransaction]");
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -142,7 +142,7 @@ public class ContractCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -179,7 +179,7 @@ public class ContractCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -202,7 +202,7 @@ public class ContractCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_FILE_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ContractCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractCreateIntegrationTest.java
@@ -18,10 +18,10 @@ public class ContractCreateIntegrationTest {
     @DisplayName("Can create contract")
     void canCreateContract() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -30,7 +30,7 @@ public class ContractCreateIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -40,7 +40,7 @@ public class ContractCreateIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             @Var var info = new ContractInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .execute(testEnv.client);
 
@@ -48,19 +48,19 @@ public class ContractCreateIntegrationTest {
             assertNotNull(info.accountId);
             assertEquals(Objects.requireNonNull(info.accountId).toString(), Objects.requireNonNull(contractId).toString());
             assertNotNull(info.adminKey);
-            assertEquals(Objects.requireNonNull(info.adminKey).toString(), Objects.requireNonNull(testEnv.operatorKey.getPublicKey()).toString());
+            assertEquals(Objects.requireNonNull(info.adminKey).toString(), Objects.requireNonNull(testEnv.operatorKey).toString());
             assertEquals(info.storage, 926);
             assertEquals(info.contractMemo, "[e2e::ContractCreateTransaction]");
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -72,10 +72,10 @@ public class ContractCreateIntegrationTest {
     @DisplayName("Can create contract with no admin key")
     void canCreateContractWithNoAdminKey() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -83,7 +83,7 @@ public class ContractCreateIntegrationTest {
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
             response = new ContractCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -93,7 +93,7 @@ public class ContractCreateIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             @Var var info = new ContractInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .execute(testEnv.client);
 
@@ -113,10 +113,10 @@ public class ContractCreateIntegrationTest {
     @DisplayName("Cannot create contract when gas is not set")
     void cannotCreateContractWhenGasIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -126,7 +126,7 @@ public class ContractCreateIntegrationTest {
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new ContractCreateTransaction()
                     .setAdminKey(testEnv.operatorKey)
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                     .setBytecodeFileId(fileId)
                     .setContractMemo("[e2e::ContractCreateTransaction]")
@@ -138,7 +138,7 @@ public class ContractCreateIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -150,10 +150,10 @@ public class ContractCreateIntegrationTest {
     @DisplayName("Cannot create contract when constructor parameters are not set")
     void cannotCreateContractWhenConstructorParametersAreNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -163,7 +163,7 @@ public class ContractCreateIntegrationTest {
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new ContractCreateTransaction()
                     .setAdminKey(testEnv.operatorKey)
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(2000)
                     .setBytecodeFileId(fileId)
                     .setContractMemo("[e2e::ContractCreateTransaction]")
@@ -175,7 +175,7 @@ public class ContractCreateIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -187,11 +187,11 @@ public class ContractCreateIntegrationTest {
     @DisplayName("Cannot create contract when bytecode file ID is not set")
     void cannotCreateContractWhenBytecodeFileIdIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new ContractCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAdminKey(testEnv.operatorKey)
                     .setGas(2000)
                     .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))

--- a/sdk/src/integrationTest/java/ContractDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractDeleteIntegrationTest.java
@@ -18,7 +18,7 @@ public class ContractDeleteIntegrationTest {
     @DisplayName("Can delete contract with admin key")
     void canDeleteContractWithAdminKey() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -59,14 +59,14 @@ public class ContractDeleteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
     @Test
     @DisplayName("Can delete contract which has no admin key")
     void cannotDeleteContractWhichHasNoAdminKey() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -106,7 +106,7 @@ public class ContractDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.MODIFYING_IMMUTABLE_CONTRACT.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -114,7 +114,7 @@ public class ContractDeleteIntegrationTest {
     @DisplayName("Cannot delete contract when contract ID is not set")
     void cannotDeleteContractWhenContractIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractDeleteTransaction()
@@ -124,7 +124,7 @@ public class ContractDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_CONTRACT_ID.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ContractDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractDeleteIntegrationTest.java
@@ -64,7 +64,7 @@ public class ContractDeleteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
     @Test
@@ -115,7 +115,7 @@ public class ContractDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.MODIFYING_IMMUTABLE_CONTRACT.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -134,7 +134,7 @@ public class ContractDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_CONTRACT_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ContractDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractDeleteIntegrationTest.java
@@ -18,10 +18,10 @@ public class ContractDeleteIntegrationTest {
     @DisplayName("Can delete contract with admin key")
     void canDeleteContractWithAdminKey() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -30,7 +30,7 @@ public class ContractDeleteIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -41,26 +41,26 @@ public class ContractDeleteIntegrationTest {
 
             @Var var info = new ContractInfoQuery()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.contractId, contractId);
             assertNotNull(info.accountId);
             assertEquals(Objects.requireNonNull(info.accountId).toString(), contractId.toString());
             assertNotNull(info.adminKey);
-            assertEquals(Objects.requireNonNull(info.adminKey).toString(), Objects.requireNonNull(testEnv.operatorKey.getPublicKey()).toString());
+            assertEquals(Objects.requireNonNull(info.adminKey).toString(), Objects.requireNonNull(testEnv.operatorKey).toString());
             assertEquals(info.storage, 926);
             assertEquals(info.contractMemo, "[e2e::ContractCreateTransaction]");
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -71,10 +71,10 @@ public class ContractDeleteIntegrationTest {
     @DisplayName("Can delete contract which has no admin key")
     void cannotDeleteContractWhichHasNoAdminKey() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -82,7 +82,7 @@ public class ContractDeleteIntegrationTest {
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
             var contractId = Objects.requireNonNull(new ContractCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -94,7 +94,7 @@ public class ContractDeleteIntegrationTest {
 
             @Var var info = new ContractInfoQuery()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.contractId, contractId);
@@ -108,7 +108,7 @@ public class ContractDeleteIntegrationTest {
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new ContractDeleteTransaction()
                     .setContractId(contractId)
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });
@@ -123,11 +123,11 @@ public class ContractDeleteIntegrationTest {
     @DisplayName("Cannot delete contract when contract ID is not set")
     void cannotDeleteContractWhenContractIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractDeleteTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });

--- a/sdk/src/integrationTest/java/ContractDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractDeleteIntegrationTest.java
@@ -21,7 +21,6 @@ public class ContractDeleteIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -30,7 +29,6 @@ public class ContractDeleteIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -41,7 +39,6 @@ public class ContractDeleteIntegrationTest {
 
             @Var var info = new ContractInfoQuery()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.contractId, contractId);
@@ -54,13 +51,11 @@ public class ContractDeleteIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -74,7 +69,6 @@ public class ContractDeleteIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -82,7 +76,6 @@ public class ContractDeleteIntegrationTest {
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
             var contractId = Objects.requireNonNull(new ContractCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -94,7 +87,6 @@ public class ContractDeleteIntegrationTest {
 
             @Var var info = new ContractInfoQuery()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.contractId, contractId);
@@ -108,7 +100,6 @@ public class ContractDeleteIntegrationTest {
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new ContractDeleteTransaction()
                     .setContractId(contractId)
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });
@@ -127,7 +118,6 @@ public class ContractDeleteIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractDeleteTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });

--- a/sdk/src/integrationTest/java/ContractExecuteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractExecuteIntegrationTest.java
@@ -16,10 +16,10 @@ public class ContractExecuteIntegrationTest {
     @DisplayName("Can execute contract methods")
     void canExecuteContractMethods() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -28,7 +28,7 @@ public class ContractExecuteIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -39,7 +39,7 @@ public class ContractExecuteIntegrationTest {
 
             new ContractExecuteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(10000)
                 .setFunction("setMessage", new ContractFunctionParameters().addString("new message"))
                 .execute(testEnv.client)
@@ -47,13 +47,13 @@ public class ContractExecuteIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -65,11 +65,11 @@ public class ContractExecuteIntegrationTest {
     @DisplayName("Cannot execute contract when contract ID is not set")
     void cannotExecuteContractWhenContractIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractExecuteTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(10000)
                     .setFunction("setMessage", new ContractFunctionParameters().addString("new message"))
                     .execute(testEnv.client)
@@ -86,10 +86,10 @@ public class ContractExecuteIntegrationTest {
     @DisplayName("Cannot execute contract when contract function parameters are not set")
     void cannotExecuteContractWhenContractFunctionParametersAreNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -99,7 +99,7 @@ public class ContractExecuteIntegrationTest {
             var contractId = Objects.requireNonNull(
                 new ContractCreateTransaction()
                     .setAdminKey(testEnv.operatorKey)
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(2000)
                     .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                     .setBytecodeFileId(fileId)
@@ -112,7 +112,7 @@ public class ContractExecuteIntegrationTest {
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new ContractExecuteTransaction()
                     .setContractId(contractId)
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(10000)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -122,13 +122,13 @@ public class ContractExecuteIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -140,10 +140,10 @@ public class ContractExecuteIntegrationTest {
     @DisplayName("Cannot execute contract when gas is not set")
     void cannotExecuteContractWhenGasIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -153,7 +153,7 @@ public class ContractExecuteIntegrationTest {
             var contractId = Objects.requireNonNull(
                 new ContractCreateTransaction()
                     .setAdminKey(testEnv.operatorKey)
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(2000)
                     .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                     .setBytecodeFileId(fileId)
@@ -167,7 +167,7 @@ public class ContractExecuteIntegrationTest {
                 new ContractExecuteTransaction()
                     .setContractId(contractId)
                     .setFunction("setMessage", new ContractFunctionParameters().addString("new message"))
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });
@@ -176,13 +176,13 @@ public class ContractExecuteIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 

--- a/sdk/src/integrationTest/java/ContractExecuteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractExecuteIntegrationTest.java
@@ -19,7 +19,6 @@ public class ContractExecuteIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -28,7 +27,6 @@ public class ContractExecuteIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -39,7 +37,6 @@ public class ContractExecuteIntegrationTest {
 
             new ContractExecuteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(10000)
                 .setFunction("setMessage", new ContractFunctionParameters().addString("new message"))
                 .execute(testEnv.client)
@@ -47,13 +44,11 @@ public class ContractExecuteIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -69,7 +64,6 @@ public class ContractExecuteIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractExecuteTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(10000)
                     .setFunction("setMessage", new ContractFunctionParameters().addString("new message"))
                     .execute(testEnv.client)
@@ -89,7 +83,6 @@ public class ContractExecuteIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -99,7 +92,6 @@ public class ContractExecuteIntegrationTest {
             var contractId = Objects.requireNonNull(
                 new ContractCreateTransaction()
                     .setAdminKey(testEnv.operatorKey)
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(2000)
                     .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                     .setBytecodeFileId(fileId)
@@ -112,7 +104,6 @@ public class ContractExecuteIntegrationTest {
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new ContractExecuteTransaction()
                     .setContractId(contractId)
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(10000)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -122,13 +113,11 @@ public class ContractExecuteIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -143,7 +132,6 @@ public class ContractExecuteIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -153,7 +141,6 @@ public class ContractExecuteIntegrationTest {
             var contractId = Objects.requireNonNull(
                 new ContractCreateTransaction()
                     .setAdminKey(testEnv.operatorKey)
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(2000)
                     .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                     .setBytecodeFileId(fileId)
@@ -167,7 +154,6 @@ public class ContractExecuteIntegrationTest {
                 new ContractExecuteTransaction()
                     .setContractId(contractId)
                     .setFunction("setMessage", new ContractFunctionParameters().addString("new message"))
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });
@@ -176,13 +162,11 @@ public class ContractExecuteIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 

--- a/sdk/src/integrationTest/java/ContractExecuteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractExecuteIntegrationTest.java
@@ -57,7 +57,7 @@ public class ContractExecuteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -78,7 +78,7 @@ public class ContractExecuteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_CONTRACT_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -132,7 +132,7 @@ public class ContractExecuteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -186,7 +186,7 @@ public class ContractExecuteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ContractExecuteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractExecuteIntegrationTest.java
@@ -16,7 +16,7 @@ public class ContractExecuteIntegrationTest {
     @DisplayName("Can execute contract methods")
     void canExecuteContractMethods() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -52,7 +52,7 @@ public class ContractExecuteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -60,7 +60,7 @@ public class ContractExecuteIntegrationTest {
     @DisplayName("Cannot execute contract when contract ID is not set")
     void cannotExecuteContractWhenContractIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractExecuteTransaction()
@@ -72,7 +72,7 @@ public class ContractExecuteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_CONTRACT_ID.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -80,7 +80,7 @@ public class ContractExecuteIntegrationTest {
     @DisplayName("Cannot execute contract when contract function parameters are not set")
     void cannotExecuteContractWhenContractFunctionParametersAreNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -121,7 +121,7 @@ public class ContractExecuteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -129,7 +129,7 @@ public class ContractExecuteIntegrationTest {
     @DisplayName("Cannot execute contract when gas is not set")
     void cannotExecuteContractWhenGasIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -170,7 +170,7 @@ public class ContractExecuteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ContractInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractInfoIntegrationTest.java
@@ -22,7 +22,6 @@ public class ContractInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -31,7 +30,6 @@ public class ContractInfoIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -42,7 +40,6 @@ public class ContractInfoIntegrationTest {
 
             @Var var info = new ContractInfoQuery()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.contractId, contractId);
@@ -55,13 +52,11 @@ public class ContractInfoIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -76,7 +71,6 @@ public class ContractInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -84,7 +78,6 @@ public class ContractInfoIntegrationTest {
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
             response = new ContractCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -95,7 +88,6 @@ public class ContractInfoIntegrationTest {
 
             @Var var info = new ContractInfoQuery()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.contractId, contractId);
@@ -118,7 +110,6 @@ public class ContractInfoIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractInfoQuery()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client);
             });
 
@@ -135,7 +126,6 @@ public class ContractInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -144,7 +134,6 @@ public class ContractInfoIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -154,7 +143,6 @@ public class ContractInfoIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var infoQuery = new ContractInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setMaxQueryPayment(new Hbar(10000));
 
@@ -165,13 +153,11 @@ public class ContractInfoIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -186,7 +172,6 @@ public class ContractInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -195,7 +180,6 @@ public class ContractInfoIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -205,7 +189,6 @@ public class ContractInfoIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var infoQuery = new ContractInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
@@ -219,13 +202,11 @@ public class ContractInfoIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -240,7 +221,6 @@ public class ContractInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -249,7 +229,6 @@ public class ContractInfoIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -259,7 +238,6 @@ public class ContractInfoIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var infoQuery = new ContractInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setMaxQueryPayment(new Hbar(100));
 
@@ -273,13 +251,11 @@ public class ContractInfoIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 

--- a/sdk/src/integrationTest/java/ContractInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractInfoIntegrationTest.java
@@ -19,10 +19,10 @@ public class ContractInfoIntegrationTest {
     @DisplayName("Can query contract info")
     void canQueryContractInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -31,7 +31,7 @@ public class ContractInfoIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -42,26 +42,26 @@ public class ContractInfoIntegrationTest {
 
             @Var var info = new ContractInfoQuery()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.contractId, contractId);
             assertNotNull(info.accountId);
             assertEquals(Objects.requireNonNull(info.accountId).toString(), contractId.toString());
             assertNotNull(info.adminKey);
-            assertEquals(Objects.requireNonNull(info.adminKey).toString(), Objects.requireNonNull(testEnv.operatorKey.getPublicKey()).toString());
+            assertEquals(Objects.requireNonNull(info.adminKey).toString(), Objects.requireNonNull(testEnv.operatorKey).toString());
             assertEquals(info.storage, 926);
             assertEquals(info.contractMemo, "[e2e::ContractCreateTransaction]");
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -73,10 +73,10 @@ public class ContractInfoIntegrationTest {
     @DisplayName("Can query contract info when admin key is null")
     void canQueryContractInfoWhenAdminKeyIsNull() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -84,7 +84,7 @@ public class ContractInfoIntegrationTest {
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
             response = new ContractCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -95,7 +95,7 @@ public class ContractInfoIntegrationTest {
 
             @Var var info = new ContractInfoQuery()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.contractId, contractId);
@@ -114,11 +114,11 @@ public class ContractInfoIntegrationTest {
     @DisplayName("Cannot query contract info when contract ID is not set")
     void cannotQueryContractInfoWhenContractIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractInfoQuery()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client);
             });
 
@@ -132,10 +132,10 @@ public class ContractInfoIntegrationTest {
     @DisplayName("Can get cost, even with a big max")
     void getCostBigMaxContractInfoFunction() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -144,7 +144,7 @@ public class ContractInfoIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -154,7 +154,7 @@ public class ContractInfoIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var infoQuery = new ContractInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setMaxQueryPayment(new Hbar(10000));
 
@@ -165,13 +165,13 @@ public class ContractInfoIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -183,10 +183,10 @@ public class ContractInfoIntegrationTest {
     @DisplayName("Error, max is smaller than set payment.")
     void getCostSmallMaxContractInfoFunction() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -195,7 +195,7 @@ public class ContractInfoIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -205,7 +205,7 @@ public class ContractInfoIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var infoQuery = new ContractInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
@@ -219,13 +219,13 @@ public class ContractInfoIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -237,10 +237,10 @@ public class ContractInfoIntegrationTest {
     @DisplayName("Insufficient tx fee error.")
     void getCostInsufficientTxFeeContractInfoFunction() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -249,7 +249,7 @@ public class ContractInfoIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -259,7 +259,7 @@ public class ContractInfoIntegrationTest {
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
             var infoQuery = new ContractInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractId(contractId)
                 .setMaxQueryPayment(new Hbar(100));
 
@@ -273,13 +273,13 @@ public class ContractInfoIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 

--- a/sdk/src/integrationTest/java/ContractInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractInfoIntegrationTest.java
@@ -19,7 +19,7 @@ public class ContractInfoIntegrationTest {
     @DisplayName("Can query contract info")
     void canQueryContractInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -60,7 +60,7 @@ public class ContractInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -68,7 +68,7 @@ public class ContractInfoIntegrationTest {
     @DisplayName("Can query contract info when admin key is null")
     void canQueryContractInfoWhenAdminKeyIsNull() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -98,7 +98,7 @@ public class ContractInfoIntegrationTest {
             assertEquals(info.storage, 926);
             assertEquals(info.contractMemo, "[e2e::ContractCreateTransaction]");
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -106,7 +106,7 @@ public class ContractInfoIntegrationTest {
     @DisplayName("Cannot query contract info when contract ID is not set")
     void cannotQueryContractInfoWhenContractIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractInfoQuery()
@@ -115,7 +115,7 @@ public class ContractInfoIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_CONTRACT_ID.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -123,7 +123,7 @@ public class ContractInfoIntegrationTest {
     @DisplayName("Can get cost, even with a big max")
     void getCostBigMaxContractInfoFunction() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -161,7 +161,7 @@ public class ContractInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -169,7 +169,7 @@ public class ContractInfoIntegrationTest {
     @DisplayName("Error, max is smaller than set payment.")
     void getCostSmallMaxContractInfoFunction() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -210,7 +210,7 @@ public class ContractInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -218,7 +218,7 @@ public class ContractInfoIntegrationTest {
     @DisplayName("Insufficient tx fee error.")
     void getCostInsufficientTxFeeContractInfoFunction() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -259,7 +259,7 @@ public class ContractInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ContractInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractInfoIntegrationTest.java
@@ -65,7 +65,7 @@ public class ContractInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -106,7 +106,7 @@ public class ContractInfoIntegrationTest {
             assertEquals(info.storage, 926);
             assertEquals(info.contractMemo, "[e2e::ContractCreateTransaction]");
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -124,7 +124,7 @@ public class ContractInfoIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_CONTRACT_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -175,7 +175,7 @@ public class ContractInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -229,7 +229,7 @@ public class ContractInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -283,7 +283,7 @@ public class ContractInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ContractUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractUpdateIntegrationTest.java
@@ -85,7 +85,7 @@ public class ContractUpdateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -105,7 +105,7 @@ public class ContractUpdateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_CONTRACT_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -146,7 +146,7 @@ public class ContractUpdateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.MODIFYING_IMMUTABLE_CONTRACT.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ContractUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractUpdateIntegrationTest.java
@@ -18,11 +18,11 @@ public class ContractUpdateIntegrationTest {
     @DisplayName("Can update contract")
     void canUpdateContract() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
             ;
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -31,7 +31,7 @@ public class ContractUpdateIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -42,46 +42,46 @@ public class ContractUpdateIntegrationTest {
 
             @Var var info = new ContractInfoQuery()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.contractId, contractId);
             assertNotNull(info.accountId);
             assertEquals(Objects.requireNonNull(info.accountId).toString(), contractId.toString());
             assertNotNull(info.adminKey);
-            assertEquals(Objects.requireNonNull(info.adminKey).toString(), Objects.requireNonNull(testEnv.operatorKey.getPublicKey()).toString());
+            assertEquals(Objects.requireNonNull(info.adminKey).toString(), Objects.requireNonNull(testEnv.operatorKey).toString());
             assertEquals(info.storage, 926);
             assertEquals(info.contractMemo, "[e2e::ContractCreateTransaction]");
 
             new ContractUpdateTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractMemo("[e2e::ContractUpdateTransaction]")
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             info = new ContractInfoQuery()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.contractId, contractId);
             assertNotNull(info.accountId);
             assertEquals(Objects.requireNonNull(info.accountId).toString(), contractId.toString());
             assertNotNull(info.adminKey);
-            assertEquals(Objects.requireNonNull(info.adminKey).toString(), Objects.requireNonNull(testEnv.operatorKey.getPublicKey()).toString());
+            assertEquals(Objects.requireNonNull(info.adminKey).toString(), Objects.requireNonNull(testEnv.operatorKey).toString());
             assertEquals(info.storage, 926);
             assertEquals(info.contractMemo, "[e2e::ContractUpdateTransaction]");
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -93,11 +93,11 @@ public class ContractUpdateIntegrationTest {
     @DisplayName("Cannot update contract when contract ID is not set")
     void cannotUpdateContractWhenContractIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractUpdateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContractMemo("[e2e::ContractUpdateTransaction]")
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -113,10 +113,10 @@ public class ContractUpdateIntegrationTest {
     @DisplayName("Cannot update contract that is immutable")
     void cannotUpdateContractThatIsImmutable() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -125,7 +125,7 @@ public class ContractUpdateIntegrationTest {
 
             var contractId = Objects.requireNonNull(
                 new ContractCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(2000)
                     .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                     .setBytecodeFileId(fileId)
@@ -138,7 +138,7 @@ public class ContractUpdateIntegrationTest {
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new ContractUpdateTransaction()
                     .setContractId(contractId)
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContractMemo("[e2e::ContractUpdateTransaction]")
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);

--- a/sdk/src/integrationTest/java/ContractUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractUpdateIntegrationTest.java
@@ -22,7 +22,6 @@ public class ContractUpdateIntegrationTest {
             ;
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -31,7 +30,6 @@ public class ContractUpdateIntegrationTest {
 
             response = new ContractCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setGas(2000)
                 .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                 .setBytecodeFileId(fileId)
@@ -42,7 +40,6 @@ public class ContractUpdateIntegrationTest {
 
             @Var var info = new ContractInfoQuery()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.contractId, contractId);
@@ -55,14 +52,12 @@ public class ContractUpdateIntegrationTest {
 
             new ContractUpdateTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContractMemo("[e2e::ContractUpdateTransaction]")
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             info = new ContractInfoQuery()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.contractId, contractId);
@@ -75,13 +70,11 @@ public class ContractUpdateIntegrationTest {
 
             new ContractDeleteTransaction()
                 .setContractId(contractId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -97,7 +90,6 @@ public class ContractUpdateIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractUpdateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContractMemo("[e2e::ContractUpdateTransaction]")
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -116,7 +108,6 @@ public class ContractUpdateIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             @Var var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents(SMART_CONTRACT_BYTECODE)
                 .execute(testEnv.client);
@@ -125,7 +116,6 @@ public class ContractUpdateIntegrationTest {
 
             var contractId = Objects.requireNonNull(
                 new ContractCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(2000)
                     .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                     .setBytecodeFileId(fileId)
@@ -138,7 +128,6 @@ public class ContractUpdateIntegrationTest {
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new ContractUpdateTransaction()
                     .setContractId(contractId)
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContractMemo("[e2e::ContractUpdateTransaction]")
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);

--- a/sdk/src/integrationTest/java/ContractUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractUpdateIntegrationTest.java
@@ -18,7 +18,7 @@ public class ContractUpdateIntegrationTest {
     @DisplayName("Can update contract")
     void canUpdateContract() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
             ;
 
             @Var var response = new FileCreateTransaction()
@@ -78,7 +78,7 @@ public class ContractUpdateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -86,7 +86,7 @@ public class ContractUpdateIntegrationTest {
     @DisplayName("Cannot update contract when contract ID is not set")
     void cannotUpdateContractWhenContractIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new ContractUpdateTransaction()
@@ -97,7 +97,7 @@ public class ContractUpdateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_CONTRACT_ID.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -105,7 +105,7 @@ public class ContractUpdateIntegrationTest {
     @DisplayName("Cannot update contract that is immutable")
     void cannotUpdateContractThatIsImmutable() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             @Var var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -135,7 +135,7 @@ public class ContractUpdateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.MODIFYING_IMMUTABLE_CONTRACT.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/FeeSchedulesTest.java
+++ b/sdk/src/integrationTest/java/FeeSchedulesTest.java
@@ -13,7 +13,7 @@ public class FeeSchedulesTest {
     @DisplayName("FeeSchedules (CurrentAndNextFeeSchedule) is fetched and parsed from file 0.0.111")
     void canFetchFeeSchedules() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             ByteString feeSchedulesBytes = new FileContentsQuery()
                 .setFileId(new FileId(0, 0, 111))

--- a/sdk/src/integrationTest/java/FeeSchedulesTest.java
+++ b/sdk/src/integrationTest/java/FeeSchedulesTest.java
@@ -13,7 +13,7 @@ public class FeeSchedulesTest {
     @DisplayName("FeeSchedules (CurrentAndNextFeeSchedule) is fetched and parsed from file 0.0.111")
     void canFetchFeeSchedules() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             ByteString feeSchedulesBytes = new FileContentsQuery()
                 .setFileId(new FileId(0, 0, 111))
@@ -26,7 +26,7 @@ public class FeeSchedulesTest {
              */
             assertNotNull(feeSchedules.getCurrent());
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/FeeSchedulesTest.java
+++ b/sdk/src/integrationTest/java/FeeSchedulesTest.java
@@ -18,15 +18,15 @@ public class FeeSchedulesTest {
             ByteString feeSchedulesBytes = new FileContentsQuery()
                 .setFileId(new FileId(0, 0, 111))
                 .execute(testEnv.client);
-            
+
             FeeSchedules feeSchedules = FeeSchedules.fromBytes(feeSchedulesBytes.toByteArray());
-            
+
             /*
              * Test whether the file 0.0.111 actually contains stuff
              */
             assertNotNull(feeSchedules.getCurrent());
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/FileAppendIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileAppendIntegrationTest.java
@@ -67,7 +67,7 @@ public class FileAppendIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -122,7 +122,7 @@ public class FileAppendIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/FileAppendIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileAppendIntegrationTest.java
@@ -20,10 +20,10 @@ public class FileAppendIntegrationTest {
     @DisplayName("Can append to file")
     void canAppendToFile() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withTwoNodes();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -31,7 +31,7 @@ public class FileAppendIntegrationTest {
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
             @Var var info = new FileInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setFileId(fileId)
                 .execute(testEnv.client);
 
@@ -40,18 +40,18 @@ public class FileAppendIntegrationTest {
             assertFalse(info.isDeleted);
             assertNotNull(info.keys);
             assertNull(info.keys.getThreshold());
-            assertEquals(info.keys, KeyList.of(testEnv.operatorKey.getPublicKey()));
+            assertEquals(info.keys, KeyList.of(testEnv.operatorKey));
 
             new FileAppendTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setContents("[e2e::FileAppendTransaction]")
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             info = new FileInfoQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -59,11 +59,11 @@ public class FileAppendIntegrationTest {
             assertFalse(info.isDeleted);
             assertNotNull(info.keys);
             assertNull(info.keys.getThreshold());
-            assertEquals(info.keys, KeyList.of(testEnv.operatorKey.getPublicKey()));
+            assertEquals(info.keys, KeyList.of(testEnv.operatorKey));
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -75,10 +75,10 @@ public class FileAppendIntegrationTest {
     @DisplayName("Can append large contents to file")
     void canAppendLargeContentsToFile() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withTwoNodes();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -86,7 +86,7 @@ public class FileAppendIntegrationTest {
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
             @Var var info = new FileInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setFileId(fileId)
                 .execute(testEnv.client);
 
@@ -95,18 +95,18 @@ public class FileAppendIntegrationTest {
             assertFalse(info.isDeleted);
             assertNotNull(info.keys);
             assertNull(info.keys.getThreshold());
-            assertEquals(info.keys, KeyList.of(testEnv.operatorKey.getPublicKey()));
+            assertEquals(info.keys, KeyList.of(testEnv.operatorKey));
 
             new FileAppendTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setContents(Contents.BIG_CONTENTS)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             info = new FileInfoQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -114,11 +114,11 @@ public class FileAppendIntegrationTest {
             assertFalse(info.isDeleted);
             assertNotNull(info.keys);
             assertNull(info.keys.getThreshold());
-            assertEquals(info.keys, KeyList.of(testEnv.operatorKey.getPublicKey()));
+            assertEquals(info.keys, KeyList.of(testEnv.operatorKey));
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 

--- a/sdk/src/integrationTest/java/FileAppendIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileAppendIntegrationTest.java
@@ -21,7 +21,7 @@ public class FileAppendIntegrationTest {
     void canAppendToFile() {
         assertDoesNotThrow(() -> {
             // There are potential bugs in FileAppendTransaction which require more than one node to trigger.
-            var testEnv = IntegrationTestEnv.withTwoNodes();
+            var testEnv = new IntegrationTestEnv(2);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -63,7 +63,7 @@ public class FileAppendIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -72,7 +72,7 @@ public class FileAppendIntegrationTest {
     void canAppendLargeContentsToFile() {
         assertDoesNotThrow(() -> {
             // There are potential bugs in FileAppendTransaction which require more than one node to trigger.
-            var testEnv = IntegrationTestEnv.withTwoNodes();
+            var testEnv = new IntegrationTestEnv(2);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -114,7 +114,7 @@ public class FileAppendIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/FileAppendIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileAppendIntegrationTest.java
@@ -24,7 +24,6 @@ public class FileAppendIntegrationTest {
             var testEnv = IntegrationTestEnv.withTwoNodes();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -32,7 +31,6 @@ public class FileAppendIntegrationTest {
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
             @Var var info = new FileInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setFileId(fileId)
                 .execute(testEnv.client);
 
@@ -45,14 +43,12 @@ public class FileAppendIntegrationTest {
 
             new FileAppendTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setContents("[e2e::FileAppendTransaction]")
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             info = new FileInfoQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -64,7 +60,6 @@ public class FileAppendIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -80,7 +75,6 @@ public class FileAppendIntegrationTest {
             var testEnv = IntegrationTestEnv.withTwoNodes();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -88,7 +82,6 @@ public class FileAppendIntegrationTest {
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
             @Var var info = new FileInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setFileId(fileId)
                 .execute(testEnv.client);
 
@@ -101,14 +94,12 @@ public class FileAppendIntegrationTest {
 
             new FileAppendTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setContents(Contents.BIG_CONTENTS)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             info = new FileInfoQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -120,7 +111,6 @@ public class FileAppendIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 

--- a/sdk/src/integrationTest/java/FileAppendIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileAppendIntegrationTest.java
@@ -20,6 +20,7 @@ public class FileAppendIntegrationTest {
     @DisplayName("Can append to file")
     void canAppendToFile() {
         assertDoesNotThrow(() -> {
+            // There are potential bugs in FileAppendTransaction which require more than one node to trigger.
             var testEnv = IntegrationTestEnv.withTwoNodes();
 
             var response = new FileCreateTransaction()
@@ -75,6 +76,7 @@ public class FileAppendIntegrationTest {
     @DisplayName("Can append large contents to file")
     void canAppendLargeContentsToFile() {
         assertDoesNotThrow(() -> {
+            // There are potential bugs in FileAppendTransaction which require more than one node to trigger.
             var testEnv = IntegrationTestEnv.withTwoNodes();
 
             var response = new FileCreateTransaction()

--- a/sdk/src/integrationTest/java/FileContentsIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileContentsIntegrationTest.java
@@ -37,7 +37,7 @@ public class FileContentsIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -67,7 +67,7 @@ public class FileContentsIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -84,7 +84,7 @@ public class FileContentsIntegrationTest {
 
            assertTrue(error.getMessage().contains(Status.INVALID_FILE_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -119,7 +119,7 @@ public class FileContentsIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -156,7 +156,7 @@ public class FileContentsIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -193,7 +193,7 @@ public class FileContentsIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/FileContentsIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileContentsIntegrationTest.java
@@ -14,7 +14,7 @@ public class FileContentsIntegrationTest {
     @DisplayName("Can query file contents")
     void canQueryFileContents() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -34,7 +34,7 @@ public class FileContentsIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -42,7 +42,7 @@ public class FileContentsIntegrationTest {
     @DisplayName("Can query empty file contents")
     void canQueryEmptyFileContents() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -61,7 +61,7 @@ public class FileContentsIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -69,7 +69,7 @@ public class FileContentsIntegrationTest {
     @DisplayName("Cannot query file contents when file ID is not set")
     void cannotQueryFileContentsWhenFileIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
            var error = assertThrows(PrecheckStatusException.class, () -> {
                new FileContentsQuery()
@@ -78,7 +78,7 @@ public class FileContentsIntegrationTest {
 
            assertTrue(error.getMessage().contains(Status.INVALID_FILE_ID.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -86,7 +86,7 @@ public class FileContentsIntegrationTest {
     @DisplayName("Can get cost, even with a big max")
     void getCostBigMaxQueryFileContents() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -110,7 +110,7 @@ public class FileContentsIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -118,7 +118,7 @@ public class FileContentsIntegrationTest {
     @DisplayName("Error, max is smaller than set payment.")
     void getCostSmallMaxQueryFileContents() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -144,7 +144,7 @@ public class FileContentsIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -152,7 +152,7 @@ public class FileContentsIntegrationTest {
     @DisplayName("Insufficient tx fee error.")
     void getCostInsufficientTxFeeQueryFileContents() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -178,7 +178,7 @@ public class FileContentsIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/FileContentsIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileContentsIntegrationTest.java
@@ -14,10 +14,10 @@ public class FileContentsIntegrationTest {
     @DisplayName("Can query file contents")
     void canQueryFileContents() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -26,14 +26,14 @@ public class FileContentsIntegrationTest {
 
             var contents = new FileContentsQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(contents.toStringUtf8(), "[e2e::FileCreateTransaction]");
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -45,10 +45,10 @@ public class FileContentsIntegrationTest {
     @DisplayName("Can query empty file contents")
     void canQueryEmptyFileContents() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .execute(testEnv.client);
 
@@ -56,14 +56,14 @@ public class FileContentsIntegrationTest {
 
             var contents = new FileContentsQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(contents.size(), 0);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -75,7 +75,7 @@ public class FileContentsIntegrationTest {
     @DisplayName("Cannot query file contents when file ID is not set")
     void cannotQueryFileContentsWhenFileIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
            var error = assertThrows(PrecheckStatusException.class, () -> {
                new FileContentsQuery()
@@ -92,10 +92,10 @@ public class FileContentsIntegrationTest {
     @DisplayName("Can get cost, even with a big max")
     void getCostBigMaxQueryFileContents() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -104,7 +104,7 @@ public class FileContentsIntegrationTest {
 
             var contentsQuery = new FileContentsQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(new Hbar(1000));
 
             var cost = contentsQuery.getCost(testEnv.client);
@@ -115,7 +115,7 @@ public class FileContentsIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -127,10 +127,10 @@ public class FileContentsIntegrationTest {
     @DisplayName("Error, max is smaller than set payment.")
     void getCostSmallMaxQueryFileContents() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -139,7 +139,7 @@ public class FileContentsIntegrationTest {
 
             var contentsQuery = new FileContentsQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
             var cost = contentsQuery.getCost(testEnv.client);
@@ -152,7 +152,7 @@ public class FileContentsIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -164,10 +164,10 @@ public class FileContentsIntegrationTest {
     @DisplayName("Insufficient tx fee error.")
     void getCostInsufficientTxFeeQueryFileContents() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -176,7 +176,7 @@ public class FileContentsIntegrationTest {
 
             var contentsQuery = new FileContentsQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(new Hbar(100));
 
             var cost = contentsQuery.getCost(testEnv.client);
@@ -189,7 +189,7 @@ public class FileContentsIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 

--- a/sdk/src/integrationTest/java/FileContentsIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileContentsIntegrationTest.java
@@ -17,7 +17,6 @@ public class FileContentsIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -26,14 +25,12 @@ public class FileContentsIntegrationTest {
 
             var contents = new FileContentsQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(contents.toStringUtf8(), "[e2e::FileCreateTransaction]");
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -48,7 +45,6 @@ public class FileContentsIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .execute(testEnv.client);
 
@@ -56,14 +52,12 @@ public class FileContentsIntegrationTest {
 
             var contents = new FileContentsQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(contents.size(), 0);
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -95,7 +89,6 @@ public class FileContentsIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -104,7 +97,6 @@ public class FileContentsIntegrationTest {
 
             var contentsQuery = new FileContentsQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(new Hbar(1000));
 
             var cost = contentsQuery.getCost(testEnv.client);
@@ -115,7 +107,6 @@ public class FileContentsIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -130,7 +121,6 @@ public class FileContentsIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -139,7 +129,6 @@ public class FileContentsIntegrationTest {
 
             var contentsQuery = new FileContentsQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
             var cost = contentsQuery.getCost(testEnv.client);
@@ -152,7 +141,6 @@ public class FileContentsIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -167,7 +155,6 @@ public class FileContentsIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -176,7 +163,6 @@ public class FileContentsIntegrationTest {
 
             var contentsQuery = new FileContentsQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(new Hbar(100));
 
             var cost = contentsQuery.getCost(testEnv.client);
@@ -189,7 +175,6 @@ public class FileContentsIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 

--- a/sdk/src/integrationTest/java/FileCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileCreateIntegrationTest.java
@@ -20,10 +20,10 @@ public class FileCreateIntegrationTest {
     @DisplayName("Can create file")
     void canCreateFile() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -32,7 +32,7 @@ public class FileCreateIntegrationTest {
 
             @Var var info = new FileInfoQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -40,11 +40,11 @@ public class FileCreateIntegrationTest {
             assertFalse(info.isDeleted);
             assertNotNull(info.keys);
             assertNull(info.keys.getThreshold());
-            assertEquals(info.keys, KeyList.of(testEnv.operatorKey.getPublicKey()));
+            assertEquals(info.keys, KeyList.of(testEnv.operatorKey));
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -56,10 +56,10 @@ public class FileCreateIntegrationTest {
     @DisplayName("Can create file with no contents")
     void canCreateFileWithNoContents() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .execute(testEnv.client);
 
@@ -67,7 +67,7 @@ public class FileCreateIntegrationTest {
 
             @Var var info = new FileInfoQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -75,11 +75,11 @@ public class FileCreateIntegrationTest {
             assertFalse(info.isDeleted);
             assertNotNull(info.keys);
             assertNull(info.keys.getThreshold());
-            assertEquals(info.keys, KeyList.of(testEnv.operatorKey.getPublicKey()));
+            assertEquals(info.keys, KeyList.of(testEnv.operatorKey));
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -91,17 +91,17 @@ public class FileCreateIntegrationTest {
     @DisplayName("Can create file with no keys")
     void canCreateFileWithNoKeys() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
             @Var var info = new FileInfoQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);

--- a/sdk/src/integrationTest/java/FileCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileCreateIntegrationTest.java
@@ -20,7 +20,7 @@ public class FileCreateIntegrationTest {
     @DisplayName("Can create file")
     void canCreateFile() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -45,7 +45,7 @@ public class FileCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -53,7 +53,7 @@ public class FileCreateIntegrationTest {
     @DisplayName("Can create file with no contents")
     void canCreateFileWithNoContents() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -77,7 +77,7 @@ public class FileCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -85,7 +85,7 @@ public class FileCreateIntegrationTest {
     @DisplayName("Can create file with no keys")
     void canCreateFileWithNoKeys() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .execute(testEnv.client);
@@ -101,7 +101,7 @@ public class FileCreateIntegrationTest {
             assertFalse(info.isDeleted);
             assertNull(info.keys);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/FileCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileCreateIntegrationTest.java
@@ -23,7 +23,6 @@ public class FileCreateIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -32,7 +31,6 @@ public class FileCreateIntegrationTest {
 
             @Var var info = new FileInfoQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -44,7 +42,6 @@ public class FileCreateIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -59,7 +56,6 @@ public class FileCreateIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .execute(testEnv.client);
 
@@ -67,7 +63,6 @@ public class FileCreateIntegrationTest {
 
             @Var var info = new FileInfoQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -79,7 +74,6 @@ public class FileCreateIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -94,14 +88,12 @@ public class FileCreateIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
             @Var var info = new FileInfoQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);

--- a/sdk/src/integrationTest/java/FileCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileCreateIntegrationTest.java
@@ -48,7 +48,7 @@ public class FileCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -83,7 +83,7 @@ public class FileCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -109,7 +109,7 @@ public class FileCreateIntegrationTest {
             assertFalse(info.isDeleted);
             assertNull(info.keys);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/FileDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileDeleteIntegrationTest.java
@@ -46,7 +46,7 @@ public class FileDeleteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -83,7 +83,7 @@ public class FileDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.UNAUTHORIZED.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/FileDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileDeleteIntegrationTest.java
@@ -21,7 +21,6 @@ public class FileDeleteIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -30,7 +29,6 @@ public class FileDeleteIntegrationTest {
 
             @Var var info = new FileInfoQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -42,7 +40,6 @@ public class FileDeleteIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -57,7 +54,6 @@ public class FileDeleteIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
 
@@ -65,7 +61,6 @@ public class FileDeleteIntegrationTest {
 
             @Var var info = new FileInfoQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -76,7 +71,6 @@ public class FileDeleteIntegrationTest {
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new FileDeleteTransaction()
                     .setFileId(fileId)
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });

--- a/sdk/src/integrationTest/java/FileDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileDeleteIntegrationTest.java
@@ -18,10 +18,10 @@ public class FileDeleteIntegrationTest {
     @DisplayName("Can delete file")
     void canDeleteFile() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -30,7 +30,7 @@ public class FileDeleteIntegrationTest {
 
             @Var var info = new FileInfoQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -38,11 +38,11 @@ public class FileDeleteIntegrationTest {
             assertFalse(info.isDeleted);
             assertNotNull(info.keys);
             assertNull(info.keys.getThreshold());
-            assertEquals(info.keys, KeyList.of(testEnv.operatorKey.getPublicKey()));
+            assertEquals(info.keys, KeyList.of(testEnv.operatorKey));
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -54,10 +54,10 @@ public class FileDeleteIntegrationTest {
     @DisplayName("Cannot delete immutable file")
     void cannotDeleteImmutableFile() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
 
@@ -65,7 +65,7 @@ public class FileDeleteIntegrationTest {
 
             @Var var info = new FileInfoQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -76,7 +76,7 @@ public class FileDeleteIntegrationTest {
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new FileDeleteTransaction()
                     .setFileId(fileId)
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });

--- a/sdk/src/integrationTest/java/FileDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileDeleteIntegrationTest.java
@@ -18,7 +18,7 @@ public class FileDeleteIntegrationTest {
     @DisplayName("Can delete file")
     void canDeleteFile() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -43,7 +43,7 @@ public class FileDeleteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -51,7 +51,7 @@ public class FileDeleteIntegrationTest {
     @DisplayName("Cannot delete immutable file")
     void cannotDeleteImmutableFile() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setContents("[e2e::FileCreateTransaction]")
@@ -77,7 +77,7 @@ public class FileDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.UNAUTHORIZED.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/FileInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileInfoIntegrationTest.java
@@ -26,7 +26,6 @@ public class FileInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -35,7 +34,6 @@ public class FileInfoIntegrationTest {
 
             @Var var info = new FileInfoQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -47,7 +45,6 @@ public class FileInfoIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -62,14 +59,12 @@ public class FileInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
             @Var var info = new FileInfoQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -88,7 +83,6 @@ public class FileInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -97,7 +91,6 @@ public class FileInfoIntegrationTest {
 
             @Var var infoQuery = new FileInfoQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(new Hbar(1000));
 
             var cost = infoQuery.getCost(testEnv.client);
@@ -106,7 +99,6 @@ public class FileInfoIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -121,7 +113,6 @@ public class FileInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -130,7 +121,6 @@ public class FileInfoIntegrationTest {
 
             @Var var infoQuery = new FileInfoQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
             var cost = infoQuery.getCost(testEnv.client);
@@ -144,7 +134,6 @@ public class FileInfoIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -159,7 +148,6 @@ public class FileInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -168,7 +156,6 @@ public class FileInfoIntegrationTest {
 
             @Var var infoQuery = new FileInfoQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
             var cost = infoQuery.getCost(testEnv.client);
@@ -181,7 +168,6 @@ public class FileInfoIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 

--- a/sdk/src/integrationTest/java/FileInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileInfoIntegrationTest.java
@@ -51,7 +51,7 @@ public class FileInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -77,7 +77,7 @@ public class FileInfoIntegrationTest {
             assertFalse(info.isDeleted);
             assertNull(info.keys);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -110,7 +110,7 @@ public class FileInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -148,7 +148,7 @@ public class FileInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -185,7 +185,7 @@ public class FileInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/FileInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileInfoIntegrationTest.java
@@ -23,10 +23,10 @@ public class FileInfoIntegrationTest {
     @DisplayName("Can query file info")
     void canQueryFileInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -35,7 +35,7 @@ public class FileInfoIntegrationTest {
 
             @Var var info = new FileInfoQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -43,11 +43,11 @@ public class FileInfoIntegrationTest {
             assertFalse(info.isDeleted);
             assertNotNull(info.keys);
             assertNull(info.keys.getThreshold());
-            assertEquals(info.keys, KeyList.of(testEnv.operatorKey.getPublicKey()));
+            assertEquals(info.keys, KeyList.of(testEnv.operatorKey));
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -59,17 +59,17 @@ public class FileInfoIntegrationTest {
     @DisplayName("Can query file info with no admin key or contents")
     void canQueryFileInfoWithNoAdminKeyOrContents() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
             @Var var info = new FileInfoQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -85,10 +85,10 @@ public class FileInfoIntegrationTest {
     @DisplayName("Can get cost, even with a big max")
     void getCostBigMaxQueryFileInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -97,7 +97,7 @@ public class FileInfoIntegrationTest {
 
             @Var var infoQuery = new FileInfoQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(new Hbar(1000));
 
             var cost = infoQuery.getCost(testEnv.client);
@@ -106,7 +106,7 @@ public class FileInfoIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -118,10 +118,10 @@ public class FileInfoIntegrationTest {
     @DisplayName("Error, max is smaller than set payment.")
     void getCostSmallMaxQueryFileInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -130,7 +130,7 @@ public class FileInfoIntegrationTest {
 
             @Var var infoQuery = new FileInfoQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
             var cost = infoQuery.getCost(testEnv.client);
@@ -144,7 +144,7 @@ public class FileInfoIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -156,10 +156,10 @@ public class FileInfoIntegrationTest {
     @DisplayName("Insufficient tx fee error.")
     void getCostInsufficientTxFeeQueryFileInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -168,7 +168,7 @@ public class FileInfoIntegrationTest {
 
             @Var var infoQuery = new FileInfoQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
             var cost = infoQuery.getCost(testEnv.client);
@@ -181,7 +181,7 @@ public class FileInfoIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 

--- a/sdk/src/integrationTest/java/FileInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileInfoIntegrationTest.java
@@ -23,7 +23,7 @@ public class FileInfoIntegrationTest {
     @DisplayName("Can query file info")
     void canQueryFileInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -48,7 +48,7 @@ public class FileInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -56,7 +56,7 @@ public class FileInfoIntegrationTest {
     @DisplayName("Can query file info with no admin key or contents")
     void canQueryFileInfoWithNoAdminKeyOrContents() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .execute(testEnv.client);
@@ -72,7 +72,7 @@ public class FileInfoIntegrationTest {
             assertFalse(info.isDeleted);
             assertNull(info.keys);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -80,7 +80,7 @@ public class FileInfoIntegrationTest {
     @DisplayName("Can get cost, even with a big max")
     void getCostBigMaxQueryFileInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -102,7 +102,7 @@ public class FileInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -110,7 +110,7 @@ public class FileInfoIntegrationTest {
     @DisplayName("Error, max is smaller than set payment.")
     void getCostSmallMaxQueryFileInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -137,7 +137,7 @@ public class FileInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -145,7 +145,7 @@ public class FileInfoIntegrationTest {
     @DisplayName("Insufficient tx fee error.")
     void getCostInsufficientTxFeeQueryFileInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -171,7 +171,7 @@ public class FileInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/FileUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileUpdateIntegrationTest.java
@@ -18,7 +18,7 @@ public class FileUpdateIntegrationTest {
     @DisplayName("Can update file")
     void canUpdateFile() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setKeys(testEnv.operatorKey)
@@ -60,7 +60,7 @@ public class FileUpdateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -68,7 +68,7 @@ public class FileUpdateIntegrationTest {
     @DisplayName("Cannot update immutable file")
     void cannotUpdateImmutableFile() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new FileCreateTransaction()
                 .setContents("[e2e::FileCreateTransaction]")
@@ -95,7 +95,7 @@ public class FileUpdateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.UNAUTHORIZED.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -103,7 +103,7 @@ public class FileUpdateIntegrationTest {
     @DisplayName("Cannot update file when file ID is not set")
     void cannotUpdateFileWhenFileIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new FileUpdateTransaction()
@@ -114,7 +114,7 @@ public class FileUpdateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_FILE_ID.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/FileUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileUpdateIntegrationTest.java
@@ -18,10 +18,10 @@ public class FileUpdateIntegrationTest {
     @DisplayName("Can update file")
     void canUpdateFile() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -30,7 +30,7 @@ public class FileUpdateIntegrationTest {
 
             @Var var info = new FileInfoQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -38,18 +38,18 @@ public class FileUpdateIntegrationTest {
             assertFalse(info.isDeleted);
             assertNotNull(info.keys);
             assertNull(info.keys.getThreshold());
-            assertEquals(info.keys, KeyList.of(testEnv.operatorKey.getPublicKey()));
+            assertEquals(info.keys, KeyList.of(testEnv.operatorKey));
 
             new FileUpdateTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContents("[e2e::FileUpdateTransaction]")
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             info = new FileInfoQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -57,11 +57,11 @@ public class FileUpdateIntegrationTest {
             assertFalse(info.isDeleted);
             assertNotNull(info.keys);
             assertNull(info.keys.getThreshold());
-            assertEquals(info.keys, KeyList.of(testEnv.operatorKey.getPublicKey()));
+            assertEquals(info.keys, KeyList.of(testEnv.operatorKey));
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -73,10 +73,10 @@ public class FileUpdateIntegrationTest {
     @DisplayName("Cannot update immutable file")
     void cannotUpdateImmutableFile() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
 
@@ -84,7 +84,7 @@ public class FileUpdateIntegrationTest {
 
             var info = new FileInfoQuery()
                 .setFileId(fileId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -95,7 +95,7 @@ public class FileUpdateIntegrationTest {
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new FileUpdateTransaction()
                     .setFileId(fileId)
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContents("[e2e::FileUpdateTransaction]")
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -111,11 +111,11 @@ public class FileUpdateIntegrationTest {
     @DisplayName("Cannot update file when file ID is not set")
     void cannotUpdateFileWhenFileIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new FileUpdateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContents("[e2e::FileUpdateTransaction]")
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);

--- a/sdk/src/integrationTest/java/FileUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileUpdateIntegrationTest.java
@@ -21,7 +21,6 @@ public class FileUpdateIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKeys(testEnv.operatorKey)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
@@ -30,7 +29,6 @@ public class FileUpdateIntegrationTest {
 
             @Var var info = new FileInfoQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -42,14 +40,12 @@ public class FileUpdateIntegrationTest {
 
             new FileUpdateTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContents("[e2e::FileUpdateTransaction]")
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             info = new FileInfoQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -61,7 +57,6 @@ public class FileUpdateIntegrationTest {
 
             new FileDeleteTransaction()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
@@ -76,7 +71,6 @@ public class FileUpdateIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new FileCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setContents("[e2e::FileCreateTransaction]")
                 .execute(testEnv.client);
 
@@ -84,7 +78,6 @@ public class FileUpdateIntegrationTest {
 
             var info = new FileInfoQuery()
                 .setFileId(fileId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.fileId, fileId);
@@ -95,7 +88,6 @@ public class FileUpdateIntegrationTest {
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new FileUpdateTransaction()
                     .setFileId(fileId)
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContents("[e2e::FileUpdateTransaction]")
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -115,7 +107,6 @@ public class FileUpdateIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new FileUpdateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContents("[e2e::FileUpdateTransaction]")
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);

--- a/sdk/src/integrationTest/java/FileUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/FileUpdateIntegrationTest.java
@@ -65,7 +65,7 @@ public class FileUpdateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -103,7 +103,7 @@ public class FileUpdateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.UNAUTHORIZED.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -123,7 +123,7 @@ public class FileUpdateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_FILE_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/IntegrationTestEnv.java
+++ b/sdk/src/integrationTest/java/IntegrationTestEnv.java
@@ -91,19 +91,16 @@ public class IntegrationTestEnv {
             while(true) {
                 var node = nodes.get(index);
                 try {
-                    var accountBalance = new AccountBalanceQuery()
+                    new AccountBalanceQuery()
                         .setNodeAccountIds(Collections.singletonList(node.getValue()))
                         .setMaxAttempts(1)
                         .setAccountId(client.getOperatorAccountId())
                         .execute(client);
                     nodes.remove(index);
-                    System.out.println("Account balance: " + accountBalance.hbars);
-                    System.out.println("Picked node: " + node.getValue());
                     outMap.put(node.getKey(), node.getValue());
                     return;
                 } catch(Exception exc) {
                 }
-                System.out.println("Node " + node + " failed");
                 index++;
                 if(index >= nodes.size()) {
                     attempts++;
@@ -145,21 +142,16 @@ public class IntegrationTestEnv {
             .setKey(key)
             .execute(client);
         var nodeId = response.nodeId;
-        System.out.println("Picked node: " + nodeId);
         client.setOperator(response.getReceipt(client).accountId, key);
         var inverseNetwork = HashBiMap.create(client.getNetwork()).inverse();
         var newNetwork = new HashMap<String, AccountId>();
         newNetwork.put(Objects.requireNonNull(inverseNetwork.get(nodeId)), nodeId);
         client.setNetwork(newNetwork);
-        var accountBalance = new AccountBalanceQuery()
-            .setAccountId(originalOperatorId)
-            .execute(client);
-        System.out.println("Account balance: " + accountBalance.hbars);
         return new IntegrationTestEnv(client, originalOperatorId);
     }
 
     public static IntegrationTestEnv withThrowawayAccount() throws Exception {
-        return withThrowawayAccount(5);
+        return withThrowawayAccount(20);
     }
 
     public void cleanUpAndClose(

--- a/sdk/src/integrationTest/java/IntegrationTestEnv.java
+++ b/sdk/src/integrationTest/java/IntegrationTestEnv.java
@@ -128,6 +128,7 @@ public class IntegrationTestEnv {
         nodeGetter.nextNode(network);
         nodeGetter.nextNode(network);
         client.setNetwork(network);
+        client.setMaxNodesPerTransaction(2);
         return new IntegrationTestEnv(client, client.getOperatorAccountId());
     }
 

--- a/sdk/src/integrationTest/java/LiveHashAddIntegrationTest.java
+++ b/sdk/src/integrationTest/java/LiveHashAddIntegrationTest.java
@@ -19,7 +19,7 @@ class LiveHashAddIntegrationTest {
     @DisplayName("Cannot create live hash because it's not supported")
     void cannotCreateLiveHashBecauseItsNotSupported() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -42,7 +42,7 @@ class LiveHashAddIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.NOT_SUPPORTED.toString()));
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/LiveHashAddIntegrationTest.java
+++ b/sdk/src/integrationTest/java/LiveHashAddIntegrationTest.java
@@ -54,7 +54,7 @@ class LiveHashAddIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.NOT_SUPPORTED.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/LiveHashAddIntegrationTest.java
+++ b/sdk/src/integrationTest/java/LiveHashAddIntegrationTest.java
@@ -19,15 +19,15 @@ class LiveHashAddIntegrationTest {
     @DisplayName("Cannot create live hash because it's not supported")
     void cannotCreateLiveHashBecauseItsNotSupported() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
-                .setNodeAccountIds(Collections.singletonList(new AccountId(5)))
+                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .execute(testEnv.client);
 
             var accountId = Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
@@ -36,25 +36,16 @@ class LiveHashAddIntegrationTest {
                 new LiveHashAddTransaction()
                     .setAccountId(accountId)
                     .setDuration(Duration.ofDays(30))
-                    .setNodeAccountIds(Collections.singletonList(new AccountId(5)))
+                    //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                     .setHash(HASH)
                     .setKeys(key)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });
 
-            new AccountDeleteTransaction()
-                .setAccountId(accountId)
-                .setNodeAccountIds(Collections.singletonList(new AccountId(5)))
-                .setTransferAccountId(testEnv.operatorId)
-                .freezeWith(testEnv.client)
-                .sign(key)
-                .execute(testEnv.client)
-                .getReceipt(testEnv.client);
-
             assertTrue(error.getMessage().contains(Status.NOT_SUPPORTED.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/LiveHashAddIntegrationTest.java
+++ b/sdk/src/integrationTest/java/LiveHashAddIntegrationTest.java
@@ -24,10 +24,8 @@ class LiveHashAddIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
-                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .execute(testEnv.client);
 
             var accountId = Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
@@ -36,7 +34,6 @@ class LiveHashAddIntegrationTest {
                 new LiveHashAddTransaction()
                     .setAccountId(accountId)
                     .setDuration(Duration.ofDays(30))
-                    //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                     .setHash(HASH)
                     .setKeys(key)
                     .execute(testEnv.client)

--- a/sdk/src/integrationTest/java/LiveHashDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/LiveHashDeleteIntegrationTest.java
@@ -22,17 +22,14 @@ class LiveHashDeleteIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
-                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .execute(testEnv.client);
 
             var accountId = Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new LiveHashDeleteTransaction()
-                    //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                     .setAccountId(accountId)
                     .setHash(HASH)
                     .execute(testEnv.client)

--- a/sdk/src/integrationTest/java/LiveHashDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/LiveHashDeleteIntegrationTest.java
@@ -50,7 +50,7 @@ class LiveHashDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.NOT_SUPPORTED.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/LiveHashDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/LiveHashDeleteIntegrationTest.java
@@ -17,40 +17,31 @@ class LiveHashDeleteIntegrationTest {
     @DisplayName("Cannot delete live hash because it's not supported")
     void cannotDeleteLiveHashBecauseItsNotSupported() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
-                .setNodeAccountIds(Collections.singletonList(new AccountId(5)))
+                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .execute(testEnv.client);
 
             var accountId = Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new LiveHashDeleteTransaction()
-                    .setNodeAccountIds(Collections.singletonList(new AccountId(5)))
+                    //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                     .setAccountId(accountId)
                     .setHash(HASH)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });
 
-            new AccountDeleteTransaction()
-                .setAccountId(accountId)
-                .setNodeAccountIds(Collections.singletonList(new AccountId(5)))
-                .setTransferAccountId(testEnv.operatorId)
-                .freezeWith(testEnv.client)
-                .sign(key)
-                .execute(testEnv.client)
-                .getReceipt(testEnv.client);
-
             assertTrue(error.getMessage().contains(Status.NOT_SUPPORTED.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/LiveHashDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/LiveHashDeleteIntegrationTest.java
@@ -17,7 +17,7 @@ class LiveHashDeleteIntegrationTest {
     @DisplayName("Cannot delete live hash because it's not supported")
     void cannotDeleteLiveHashBecauseItsNotSupported() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -38,7 +38,7 @@ class LiveHashDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.NOT_SUPPORTED.toString()));
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/NetworkVersionInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/NetworkVersionInfoIntegrationTest.java
@@ -9,12 +9,12 @@ public class NetworkVersionInfoIntegrationTest {
     @DisplayName("Cannot query network version info")
     void cannotQueryNetworkVersionInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             new NetworkVersionInfoQuery()
                 .execute(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/NetworkVersionInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/NetworkVersionInfoIntegrationTest.java
@@ -9,10 +9,10 @@ public class NetworkVersionInfoIntegrationTest {
     @DisplayName("Cannot query network version info")
     void cannotQueryNetworkVersionInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             new NetworkVersionInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             testEnv.cleanUpAndClose();

--- a/sdk/src/integrationTest/java/NetworkVersionInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/NetworkVersionInfoIntegrationTest.java
@@ -15,7 +15,7 @@ public class NetworkVersionInfoIntegrationTest {
                 .setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/NetworkVersionInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/NetworkVersionInfoIntegrationTest.java
@@ -12,7 +12,6 @@ public class NetworkVersionInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             new NetworkVersionInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             testEnv.cleanUpAndClose();

--- a/sdk/src/integrationTest/java/ReceiptQueryIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ReceiptQueryIntegrationTest.java
@@ -13,30 +13,22 @@ public class ReceiptQueryIntegrationTest {
     @DisplayName("Can get Receipt")
     void canGetTransactionReceipt() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
-                .setNodeAccountIds(Collections.singletonList(new AccountId(5)))
+                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .execute(testEnv.client);
 
             var receipt = new TransactionReceiptQuery()
                 .setTransactionId(response.transactionId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
-            new AccountDeleteTransaction()
-                .setAccountId(receipt.accountId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setTransferAccountId(testEnv.operatorId)
-                .freezeWith(testEnv.client)
-                .sign(key)
-                .execute(testEnv.client);
-
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(receipt.accountId, key);
         });
     }
 
@@ -44,34 +36,26 @@ public class ReceiptQueryIntegrationTest {
     @DisplayName("Can get Record")
     void canGetTransactionRecord() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
-                .setNodeAccountIds(Collections.singletonList(new AccountId(5)))
+                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .execute(testEnv.client);
 
             new TransactionReceiptQuery()
                 .setTransactionId(response.transactionId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             var record = new TransactionRecordQuery()
                 .setTransactionId(response.transactionId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
-            new AccountDeleteTransaction()
-                .setAccountId(record.receipt.accountId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setTransferAccountId(testEnv.operatorId)
-                .freezeWith(testEnv.client)
-                .sign(key)
-                .execute(testEnv.client);
-
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(record.receipt.accountId, key);
         });
     }
 
@@ -79,37 +63,29 @@ public class ReceiptQueryIntegrationTest {
     @DisplayName("Can get Record cost")
     void getCostTransactionRecord() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
-                .setNodeAccountIds(Collections.singletonList(new AccountId(5)))
+                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .execute(testEnv.client);
 
             new TransactionReceiptQuery()
                 .setTransactionId(response.transactionId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             var recordQuery = new TransactionRecordQuery()
-                .setTransactionId(response.transactionId)
-                .setNodeAccountIds(testEnv.nodeAccountIds);
+                .setTransactionId(response.transactionId);
+                //.setNodeAccountIds(testEnv.nodeAccountIds);
 
             var cost = recordQuery.getCost(testEnv.client);
 
             var record = recordQuery.execute(testEnv.client);
 
-            new AccountDeleteTransaction()
-                .setAccountId(record.receipt.accountId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setTransferAccountId(testEnv.operatorId)
-                .freezeWith(testEnv.client)
-                .sign(key)
-                .execute(testEnv.client);
-
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(record.receipt.accountId, key);
         });
     }
 
@@ -117,38 +93,30 @@ public class ReceiptQueryIntegrationTest {
     @DisplayName("Can get Record cost with big max set")
     void getCostBigMaxTransactionRecord() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
-                .setNodeAccountIds(Collections.singletonList(new AccountId(5)))
+                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .execute(testEnv.client);
 
             new TransactionReceiptQuery()
                 .setTransactionId(response.transactionId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             var recordQuery = new TransactionRecordQuery()
                 .setTransactionId(response.transactionId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(new Hbar(1000));
 
             var cost = recordQuery.getCost(testEnv.client);
 
             var record = recordQuery.execute(testEnv.client);
 
-            new AccountDeleteTransaction()
-                .setAccountId(record.receipt.accountId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setTransferAccountId(testEnv.operatorId)
-                .freezeWith(testEnv.client)
-                .sign(key)
-                .execute(testEnv.client);
-
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(record.receipt.accountId, key);
         });
     }
 
@@ -156,23 +124,23 @@ public class ReceiptQueryIntegrationTest {
     @DisplayName("Error at very small max, getRecord")
     void getCostSmallMaxTransactionRecord() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
-                .setNodeAccountIds(Collections.singletonList(new AccountId(5)))
+                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .execute(testEnv.client);
 
             var receipt = new TransactionReceiptQuery()
                 .setTransactionId(response.transactionId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             var recordQuery = new TransactionRecordQuery()
                 .setTransactionId(response.transactionId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
             var cost = recordQuery.getCost(testEnv.client);
@@ -183,16 +151,7 @@ public class ReceiptQueryIntegrationTest {
 
             assertEquals(error.getMessage(), "com.hedera.hashgraph.sdk.MaxQueryPaymentExceededException: cost for TransactionRecordQuery, of "+cost.toString()+", without explicit payment is greater than the maximum allowed payment of 1 tℏ");
 
-
-            new AccountDeleteTransaction()
-                .setAccountId(receipt.accountId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setTransferAccountId(testEnv.operatorId)
-                .freezeWith(testEnv.client)
-                .sign(key)
-                .execute(testEnv.client);
-
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(receipt.accountId, key);
         });
     }
 
@@ -200,22 +159,22 @@ public class ReceiptQueryIntegrationTest {
     @DisplayName("Insufficient transaction fee error for transaction record query")
     void getCostInsufficientTxFeeTransactionRecord() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .execute(testEnv.client);
 
             var receipt = new TransactionReceiptQuery()
                 .setTransactionId(response.transactionId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             var recordQuery = new TransactionRecordQuery()
-                .setTransactionId(response.transactionId)
-                .setNodeAccountIds(testEnv.nodeAccountIds);
+                .setTransactionId(response.transactionId);
+                //.setNodeAccountIds(testEnv.nodeAccountIds);
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 recordQuery.setQueryPayment(Hbar.fromTinybars(1)).execute(testEnv.client);
@@ -223,15 +182,7 @@ public class ReceiptQueryIntegrationTest {
 
             assertEquals(error.status.toString(), "INSUFFICIENT_TX_FEE");
 
-            new AccountDeleteTransaction()
-                .setAccountId(receipt.accountId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setTransferAccountId(testEnv.operatorId)
-                .freezeWith(testEnv.client)
-                .sign(key)
-                .execute(testEnv.client);
-
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(receipt.accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/ReceiptQueryIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ReceiptQueryIntegrationTest.java
@@ -36,7 +36,7 @@ public class ReceiptQueryIntegrationTest {
                 .sign(key)
                 .execute(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -71,7 +71,7 @@ public class ReceiptQueryIntegrationTest {
                 .sign(key)
                 .execute(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -109,7 +109,7 @@ public class ReceiptQueryIntegrationTest {
                 .sign(key)
                 .execute(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -148,7 +148,7 @@ public class ReceiptQueryIntegrationTest {
                 .sign(key)
                 .execute(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -192,7 +192,7 @@ public class ReceiptQueryIntegrationTest {
                 .sign(key)
                 .execute(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -231,7 +231,7 @@ public class ReceiptQueryIntegrationTest {
                 .sign(key)
                 .execute(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ReceiptQueryIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ReceiptQueryIntegrationTest.java
@@ -18,14 +18,11 @@ public class ReceiptQueryIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
-                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .execute(testEnv.client);
 
             var receipt = new TransactionReceiptQuery()
                 .setTransactionId(response.transactionId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             testEnv.cleanUpAndClose(receipt.accountId, key);
@@ -40,19 +37,15 @@ public class ReceiptQueryIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
-                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .execute(testEnv.client);
 
             new TransactionReceiptQuery()
                 .setTransactionId(response.transactionId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             var record = new TransactionRecordQuery()
                 .setTransactionId(response.transactionId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             testEnv.cleanUpAndClose(record.receipt.accountId, key);
@@ -67,19 +60,15 @@ public class ReceiptQueryIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
-                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .execute(testEnv.client);
 
             new TransactionReceiptQuery()
                 .setTransactionId(response.transactionId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             var recordQuery = new TransactionRecordQuery()
                 .setTransactionId(response.transactionId);
-                //.setNodeAccountIds(testEnv.nodeAccountIds);
 
             var cost = recordQuery.getCost(testEnv.client);
 
@@ -97,19 +86,15 @@ public class ReceiptQueryIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
-                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .execute(testEnv.client);
 
             new TransactionReceiptQuery()
                 .setTransactionId(response.transactionId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             var recordQuery = new TransactionRecordQuery()
                 .setTransactionId(response.transactionId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(new Hbar(1000));
 
             var cost = recordQuery.getCost(testEnv.client);
@@ -128,19 +113,15 @@ public class ReceiptQueryIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
-                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .execute(testEnv.client);
 
             var receipt = new TransactionReceiptQuery()
                 .setTransactionId(response.transactionId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             var recordQuery = new TransactionRecordQuery()
                 .setTransactionId(response.transactionId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
             var cost = recordQuery.getCost(testEnv.client);
@@ -163,18 +144,15 @@ public class ReceiptQueryIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .execute(testEnv.client);
 
             var receipt = new TransactionReceiptQuery()
                 .setTransactionId(response.transactionId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             var recordQuery = new TransactionRecordQuery()
                 .setTransactionId(response.transactionId);
-                //.setNodeAccountIds(testEnv.nodeAccountIds);
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 recordQuery.setQueryPayment(Hbar.fromTinybars(1)).execute(testEnv.client);

--- a/sdk/src/integrationTest/java/ReceiptQueryIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ReceiptQueryIntegrationTest.java
@@ -13,7 +13,7 @@ public class ReceiptQueryIntegrationTest {
     @DisplayName("Can get Receipt")
     void canGetTransactionReceipt() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -25,7 +25,7 @@ public class ReceiptQueryIntegrationTest {
                 .setTransactionId(response.transactionId)
                 .execute(testEnv.client);
 
-            testEnv.cleanUpAndClose(receipt.accountId, key);
+            testEnv.close(receipt.accountId, key);
         });
     }
 
@@ -33,7 +33,7 @@ public class ReceiptQueryIntegrationTest {
     @DisplayName("Can get Record")
     void canGetTransactionRecord() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
@@ -48,7 +48,7 @@ public class ReceiptQueryIntegrationTest {
                 .setTransactionId(response.transactionId)
                 .execute(testEnv.client);
 
-            testEnv.cleanUpAndClose(record.receipt.accountId, key);
+            testEnv.close(record.receipt.accountId, key);
         });
     }
 
@@ -56,7 +56,7 @@ public class ReceiptQueryIntegrationTest {
     @DisplayName("Can get Record cost")
     void getCostTransactionRecord() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
@@ -74,7 +74,7 @@ public class ReceiptQueryIntegrationTest {
 
             var record = recordQuery.execute(testEnv.client);
 
-            testEnv.cleanUpAndClose(record.receipt.accountId, key);
+            testEnv.close(record.receipt.accountId, key);
         });
     }
 
@@ -82,7 +82,7 @@ public class ReceiptQueryIntegrationTest {
     @DisplayName("Can get Record cost with big max set")
     void getCostBigMaxTransactionRecord() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
@@ -101,7 +101,7 @@ public class ReceiptQueryIntegrationTest {
 
             var record = recordQuery.execute(testEnv.client);
 
-            testEnv.cleanUpAndClose(record.receipt.accountId, key);
+            testEnv.close(record.receipt.accountId, key);
         });
     }
 
@@ -109,7 +109,7 @@ public class ReceiptQueryIntegrationTest {
     @DisplayName("Error at very small max, getRecord")
     void getCostSmallMaxTransactionRecord() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
@@ -132,7 +132,7 @@ public class ReceiptQueryIntegrationTest {
 
             assertEquals(error.getMessage(), "com.hedera.hashgraph.sdk.MaxQueryPaymentExceededException: cost for TransactionRecordQuery, of "+cost.toString()+", without explicit payment is greater than the maximum allowed payment of 1 tℏ");
 
-            testEnv.cleanUpAndClose(receipt.accountId, key);
+            testEnv.close(receipt.accountId, key);
         });
     }
 
@@ -140,7 +140,7 @@ public class ReceiptQueryIntegrationTest {
     @DisplayName("Insufficient transaction fee error for transaction record query")
     void getCostInsufficientTxFeeTransactionRecord() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
@@ -160,7 +160,7 @@ public class ReceiptQueryIntegrationTest {
 
             assertEquals(error.status.toString(), "INSUFFICIENT_TX_FEE");
 
-            testEnv.cleanUpAndClose(receipt.accountId, key);
+            testEnv.close(receipt.accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/ScheduleCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ScheduleCreateIntegrationTest.java
@@ -44,7 +44,7 @@ public class ScheduleCreateIntegrationTest {
 
             assertNotNull(info.executedAt);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -78,7 +78,7 @@ public class ScheduleCreateIntegrationTest {
             assertNotNull(info.executedAt);
             assertNotNull(info.getScheduledTransaction());
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -112,7 +112,7 @@ public class ScheduleCreateIntegrationTest {
             assertNotNull(info.executedAt);
             assertNotNull(info.getScheduledTransaction());
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -186,13 +186,14 @@ public class ScheduleCreateIntegrationTest {
 
             assertNotNull(info.executedAt);
 
-            testEnv.client.close();
+            // TODO: we lose account, I think I have to manually delete account using KeyList
+            testEnv.cleanUpAndClose();
         });
     }
 
     @Test
     @DisplayName("Can schedule token transfer")
-    void canScheduleTokenTransaction() {
+    void canScheduleTokenTransfer() {
         assertDoesNotThrow(() -> {
             var testEnv = new IntegrationTestEnv();
 
@@ -215,6 +216,7 @@ public class ScheduleCreateIntegrationTest {
                 .setTokenSymbol("F")
                 .setInitialSupply(100)
                 .setTreasuryAccountId(testEnv.operatorId)
+                .setAdminKey(testEnv.operatorKey)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client)
                 .tokenId;
@@ -252,7 +254,7 @@ public class ScheduleCreateIntegrationTest {
 
             assertEquals(balanceQuery.tokens.get(tokenId), 10);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 
@@ -346,7 +348,7 @@ public class ScheduleCreateIntegrationTest {
 
             assertNotNull(info.executedAt);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ScheduleCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ScheduleCreateIntegrationTest.java
@@ -25,7 +25,6 @@ public class ScheduleCreateIntegrationTest {
             var key = PrivateKey.generate();
 
             var transaction = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(10));
 
@@ -39,7 +38,6 @@ public class ScheduleCreateIntegrationTest {
 
             var info = new ScheduleInfoQuery()
                 .setScheduleId(scheduleId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertNotNull(info.executedAt);
@@ -58,7 +56,6 @@ public class ScheduleCreateIntegrationTest {
             var key = PrivateKey.generate();
 
             var transaction = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(10));
 
@@ -72,7 +69,6 @@ public class ScheduleCreateIntegrationTest {
 
             var info = new ScheduleInfoQuery()
                 .setScheduleId(scheduleId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertNotNull(info.executedAt);
@@ -106,7 +102,6 @@ public class ScheduleCreateIntegrationTest {
 
             var info = new ScheduleInfoQuery()
                 .setScheduleId(scheduleId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertNotNull(info.executedAt);
@@ -134,7 +129,6 @@ public class ScheduleCreateIntegrationTest {
 
             // Creat the account with the `KeyList`
             TransactionResponse response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(keyList)
                 .setInitialBalance(new Hbar(10))
                 .execute(testEnv.client);
@@ -156,7 +150,6 @@ public class ScheduleCreateIntegrationTest {
 
             // Schedule the transactoin
             ScheduleCreateTransaction scheduled = transfer.schedule();
-            //.setNodeAccountIds(testEnv.nodeAccountIds);
 
             receipt = scheduled.execute(testEnv.client).getReceipt(testEnv.client);
 
@@ -165,7 +158,6 @@ public class ScheduleCreateIntegrationTest {
 
             // Get the schedule info to see if `signatories` is populated with 2/3 signatures
             ScheduleInfo info = new ScheduleInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setScheduleId(scheduleId)
                 .execute(testEnv.client);
 
@@ -174,14 +166,12 @@ public class ScheduleCreateIntegrationTest {
             // Finally send this last signature to Hedera. This last signature _should_ mean the transaction executes
             // since all 3 signatures have been provided.
             ScheduleSignTransaction signTransaction = new ScheduleSignTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setScheduleId(scheduleId)
                 .freezeWith(testEnv.client);
 
             signTransaction.sign(key1).sign(key2).sign(key3).execute(testEnv.client).getReceipt(testEnv.client);
 
             info = new ScheduleInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setScheduleId(scheduleId)
                 .execute(testEnv.client);
 
@@ -201,7 +191,6 @@ public class ScheduleCreateIntegrationTest {
             PrivateKey key = PrivateKey.generate();
 
             var accountId = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setReceiverSignatureRequired(true)
                 .setKey(key)
                 .setInitialBalance(new Hbar(10))
@@ -212,7 +201,6 @@ public class ScheduleCreateIntegrationTest {
                 .accountId;
 
             var tokenId = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setInitialSupply(100)
@@ -223,7 +211,6 @@ public class ScheduleCreateIntegrationTest {
                 .tokenId;
 
             new TokenAssociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -235,20 +222,17 @@ public class ScheduleCreateIntegrationTest {
                 .addTokenTransfer(tokenId, testEnv.operatorId, -10)
                 .addTokenTransfer(tokenId, accountId, 10)
                 .schedule()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client)
                 .scheduleId;
 
             var balanceQuery1 = new AccountBalanceQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .execute(testEnv.client);
 
             assertEquals(balanceQuery1.tokens.get(tokenId), 0);
 
             new ScheduleSignTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setScheduleId(scheduleId)
                 .freezeWith(testEnv.client)
                 .sign(key)
@@ -256,7 +240,6 @@ public class ScheduleCreateIntegrationTest {
                 .getReceipt(testEnv.client);
 
             var balanceQuery2 = new AccountBalanceQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .execute(testEnv.client);
 
@@ -309,7 +292,6 @@ public class ScheduleCreateIntegrationTest {
 
             // create schedule
             var scheduledTx = transaction.schedule()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setPayerAccountId(testEnv.operatorId)
                 .setScheduleMemo("mirror scheduled E2E signature on create and sign_" + Instant.now());
@@ -329,7 +311,6 @@ public class ScheduleCreateIntegrationTest {
             // verify schedule has been created and has 1 of 2 signatures
             var info = new ScheduleInfoQuery()
                 .setScheduleId(scheduleId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertNotNull(info);
@@ -351,7 +332,6 @@ public class ScheduleCreateIntegrationTest {
 
             info = new ScheduleInfoQuery()
                 .setScheduleId(scheduleId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertNotNull(info.executedAt);

--- a/sdk/src/integrationTest/java/ScheduleCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ScheduleCreateIntegrationTest.java
@@ -20,12 +20,12 @@ public class ScheduleCreateIntegrationTest {
     @DisplayName("Can create schedule")
     void canCreateSchedule() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
             var transaction = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(10));
 
@@ -39,7 +39,7 @@ public class ScheduleCreateIntegrationTest {
 
             var info = new ScheduleInfoQuery()
                 .setScheduleId(scheduleId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertNotNull(info.executedAt);
@@ -53,12 +53,12 @@ public class ScheduleCreateIntegrationTest {
     @DisplayName("Can get Transaction")
     void canGetTransactionSchedule() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
             var transaction = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(10));
 
@@ -72,7 +72,7 @@ public class ScheduleCreateIntegrationTest {
 
             var info = new ScheduleInfoQuery()
                 .setScheduleId(scheduleId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertNotNull(info.executedAt);
@@ -87,7 +87,7 @@ public class ScheduleCreateIntegrationTest {
     @DisplayName("Can create schedule with schedule()")
     void canCreateWithSchedule() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
@@ -106,7 +106,7 @@ public class ScheduleCreateIntegrationTest {
 
             var info = new ScheduleInfoQuery()
                 .setScheduleId(scheduleId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertNotNull(info.executedAt);
@@ -120,7 +120,7 @@ public class ScheduleCreateIntegrationTest {
     @DisplayName("Can sign schedule")
     void canSignSchedule2() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             PrivateKey key1 = PrivateKey.generate();
             PrivateKey key2 = PrivateKey.generate();
@@ -134,7 +134,7 @@ public class ScheduleCreateIntegrationTest {
 
             // Creat the account with the `KeyList`
             TransactionResponse response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(keyList)
                 .setInitialBalance(new Hbar(10))
                 .execute(testEnv.client);
@@ -155,7 +155,8 @@ public class ScheduleCreateIntegrationTest {
                 .addHbarTransfer(testEnv.operatorId, new Hbar(1));
 
             // Schedule the transactoin
-            ScheduleCreateTransaction scheduled = transfer.schedule().setNodeAccountIds(testEnv.nodeAccountIds);
+            ScheduleCreateTransaction scheduled = transfer.schedule();
+            //.setNodeAccountIds(testEnv.nodeAccountIds);
 
             receipt = scheduled.execute(testEnv.client).getReceipt(testEnv.client);
 
@@ -164,7 +165,7 @@ public class ScheduleCreateIntegrationTest {
 
             // Get the schedule info to see if `signatories` is populated with 2/3 signatures
             ScheduleInfo info = new ScheduleInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setScheduleId(scheduleId)
                 .execute(testEnv.client);
 
@@ -173,14 +174,14 @@ public class ScheduleCreateIntegrationTest {
             // Finally send this last signature to Hedera. This last signature _should_ mean the transaction executes
             // since all 3 signatures have been provided.
             ScheduleSignTransaction signTransaction = new ScheduleSignTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setScheduleId(scheduleId)
                 .freezeWith(testEnv.client);
 
             signTransaction.sign(key1).sign(key2).sign(key3).execute(testEnv.client).getReceipt(testEnv.client);
 
             info = new ScheduleInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setScheduleId(scheduleId)
                 .execute(testEnv.client);
 
@@ -195,12 +196,12 @@ public class ScheduleCreateIntegrationTest {
     @DisplayName("Can schedule token transfer")
     void canScheduleTokenTransfer() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount(20);
 
             PrivateKey key = PrivateKey.generate();
 
             var accountId = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setReceiverSignatureRequired(true)
                 .setKey(key)
                 .setInitialBalance(new Hbar(10))
@@ -211,7 +212,7 @@ public class ScheduleCreateIntegrationTest {
                 .accountId;
 
             var tokenId = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setInitialSupply(100)
@@ -222,7 +223,7 @@ public class ScheduleCreateIntegrationTest {
                 .tokenId;
 
             new TokenAssociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -234,25 +235,32 @@ public class ScheduleCreateIntegrationTest {
                 .addTokenTransfer(tokenId, testEnv.operatorId, -10)
                 .addTokenTransfer(tokenId, accountId, 10)
                 .schedule()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client)
-                .scheduleId;;
+                .scheduleId;
+
+            var balanceQuery1 = new AccountBalanceQuery()
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
+                .setAccountId(accountId)
+                .execute(testEnv.client);
+
+            assertEquals(balanceQuery1.tokens.get(tokenId), 0);
 
             new ScheduleSignTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setScheduleId(scheduleId)
                 .freezeWith(testEnv.client)
                 .sign(key)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            var balanceQuery = new AccountBalanceQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+            var balanceQuery2 = new AccountBalanceQuery()
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .execute(testEnv.client);
 
-            assertEquals(balanceQuery.tokens.get(tokenId), 10);
+            assertEquals(balanceQuery2.tokens.get(tokenId), 10);
 
             testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
@@ -262,7 +270,7 @@ public class ScheduleCreateIntegrationTest {
     @DisplayName("Can schedule topic message")
     void canScheduleTopicMessage() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             // Generate 3 random keys
             var key1 = PrivateKey.generate();
@@ -301,7 +309,7 @@ public class ScheduleCreateIntegrationTest {
 
             // create schedule
             var scheduledTx = transaction.schedule()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setPayerAccountId(testEnv.operatorId)
                 .setScheduleMemo("mirror scheduled E2E signature on create and sign_" + Instant.now());
@@ -321,7 +329,7 @@ public class ScheduleCreateIntegrationTest {
             // verify schedule has been created and has 1 of 2 signatures
             var info = new ScheduleInfoQuery()
                 .setScheduleId(scheduleId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertNotNull(info);
@@ -343,7 +351,7 @@ public class ScheduleCreateIntegrationTest {
 
             info = new ScheduleInfoQuery()
                 .setScheduleId(scheduleId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertNotNull(info.executedAt);

--- a/sdk/src/integrationTest/java/ScheduleCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ScheduleCreateIntegrationTest.java
@@ -20,7 +20,7 @@ public class ScheduleCreateIntegrationTest {
     @DisplayName("Can create schedule")
     void canCreateSchedule() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -42,7 +42,7 @@ public class ScheduleCreateIntegrationTest {
 
             assertNotNull(info.executedAt);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -51,7 +51,7 @@ public class ScheduleCreateIntegrationTest {
     @DisplayName("Can get Transaction")
     void canGetTransactionSchedule() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -74,7 +74,7 @@ public class ScheduleCreateIntegrationTest {
             assertNotNull(info.executedAt);
             assertNotNull(info.getScheduledTransaction());
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -83,7 +83,7 @@ public class ScheduleCreateIntegrationTest {
     @DisplayName("Can create schedule with schedule()")
     void canCreateWithSchedule() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -107,7 +107,7 @@ public class ScheduleCreateIntegrationTest {
             assertNotNull(info.executedAt);
             assertNotNull(info.getScheduledTransaction());
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -115,7 +115,7 @@ public class ScheduleCreateIntegrationTest {
     @DisplayName("Can sign schedule")
     void canSignSchedule2() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             PrivateKey key1 = PrivateKey.generate();
             PrivateKey key2 = PrivateKey.generate();
@@ -185,7 +185,7 @@ public class ScheduleCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -193,7 +193,7 @@ public class ScheduleCreateIntegrationTest {
     @DisplayName("Can schedule token transfer")
     void canScheduleTokenTransfer() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             PrivateKey key = PrivateKey.generate();
 
@@ -252,7 +252,7 @@ public class ScheduleCreateIntegrationTest {
 
             assertEquals(balanceQuery2.tokens.get(tokenId), 10);
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 
@@ -260,7 +260,7 @@ public class ScheduleCreateIntegrationTest {
     @DisplayName("Can schedule topic message")
     void canScheduleTopicMessage() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             // Generate 3 random keys
             var key1 = PrivateKey.generate();
@@ -343,7 +343,7 @@ public class ScheduleCreateIntegrationTest {
 
             assertNotNull(info.executedAt);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/ScheduleCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ScheduleCreateIntegrationTest.java
@@ -177,7 +177,14 @@ public class ScheduleCreateIntegrationTest {
 
             assertNotNull(info.executedAt);
 
-            // TODO: we lose account, I think I have to manually delete account using KeyList
+            new AccountDeleteTransaction()
+                .setAccountId(accountId)
+                .setTransferAccountId(testEnv.operatorId)
+                .freezeWith(testEnv.client)
+                .sign(key1).sign(key2).sign(key3)
+                .execute(testEnv.client)
+                .getReceipt(testEnv.client);
+
             testEnv.cleanUpAndClose();
         });
     }
@@ -186,7 +193,7 @@ public class ScheduleCreateIntegrationTest {
     @DisplayName("Can schedule token transfer")
     void canScheduleTokenTransfer() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount(20);
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             PrivateKey key = PrivateKey.generate();
 

--- a/sdk/src/integrationTest/java/SystemIntegrationTest.java
+++ b/sdk/src/integrationTest/java/SystemIntegrationTest.java
@@ -17,7 +17,7 @@ public class SystemIntegrationTest {
     @DisplayName("All system transactions are not supported")
     void allSystemTransactionsAreNotSupported() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var fileId = Objects.requireNonNull(
                 new FileCreateTransaction()
@@ -73,7 +73,7 @@ public class SystemIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.NOT_SUPPORTED.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/SystemIntegrationTest.java
+++ b/sdk/src/integrationTest/java/SystemIntegrationTest.java
@@ -17,11 +17,11 @@ public class SystemIntegrationTest {
     @DisplayName("All system transactions are not supported")
     void allSystemTransactionsAreNotSupported() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var fileId = Objects.requireNonNull(
                 new FileCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContents(SMART_CONTRACT_BYTECODE)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client)
@@ -31,7 +31,7 @@ public class SystemIntegrationTest {
             var contractId = Objects.requireNonNull(
                 new ContractCreateTransaction()
                     .setAdminKey(testEnv.operatorKey)
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(2000)
                     .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                     .setBytecodeFileId(fileId)
@@ -43,7 +43,7 @@ public class SystemIntegrationTest {
 
             @Var var error = assertThrows(PrecheckStatusException.class, () -> {
                 new SystemDeleteTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContractId(contractId)
                     .setExpirationTime(Instant.now())
                     .execute(testEnv.client);
@@ -53,7 +53,7 @@ public class SystemIntegrationTest {
 
             error = assertThrows(PrecheckStatusException.class, () -> {
                 new SystemDeleteTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setFileId(fileId)
                     .setExpirationTime(Instant.now())
                     .execute(testEnv.client);
@@ -63,7 +63,7 @@ public class SystemIntegrationTest {
 
             error = assertThrows(PrecheckStatusException.class, () -> {
                 new SystemUndeleteTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContractId(contractId)
                     .execute(testEnv.client);
             });
@@ -72,7 +72,7 @@ public class SystemIntegrationTest {
 
             error = assertThrows(PrecheckStatusException.class, () -> {
                 new SystemUndeleteTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setFileId(fileId)
                     .execute(testEnv.client);
             });

--- a/sdk/src/integrationTest/java/SystemIntegrationTest.java
+++ b/sdk/src/integrationTest/java/SystemIntegrationTest.java
@@ -79,7 +79,7 @@ public class SystemIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.NOT_SUPPORTED.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/SystemIntegrationTest.java
+++ b/sdk/src/integrationTest/java/SystemIntegrationTest.java
@@ -21,7 +21,6 @@ public class SystemIntegrationTest {
 
             var fileId = Objects.requireNonNull(
                 new FileCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContents(SMART_CONTRACT_BYTECODE)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client)
@@ -31,7 +30,6 @@ public class SystemIntegrationTest {
             var contractId = Objects.requireNonNull(
                 new ContractCreateTransaction()
                     .setAdminKey(testEnv.operatorKey)
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setGas(2000)
                     .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
                     .setBytecodeFileId(fileId)
@@ -43,7 +41,6 @@ public class SystemIntegrationTest {
 
             @Var var error = assertThrows(PrecheckStatusException.class, () -> {
                 new SystemDeleteTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContractId(contractId)
                     .setExpirationTime(Instant.now())
                     .execute(testEnv.client);
@@ -53,7 +50,6 @@ public class SystemIntegrationTest {
 
             error = assertThrows(PrecheckStatusException.class, () -> {
                 new SystemDeleteTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setFileId(fileId)
                     .setExpirationTime(Instant.now())
                     .execute(testEnv.client);
@@ -63,7 +59,6 @@ public class SystemIntegrationTest {
 
             error = assertThrows(PrecheckStatusException.class, () -> {
                 new SystemUndeleteTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setContractId(contractId)
                     .execute(testEnv.client);
             });
@@ -72,7 +67,6 @@ public class SystemIntegrationTest {
 
             error = assertThrows(PrecheckStatusException.class, () -> {
                 new SystemUndeleteTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setFileId(fileId)
                     .execute(testEnv.client);
             });

--- a/sdk/src/integrationTest/java/TokenAssociateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenAssociateIntegrationTest.java
@@ -14,12 +14,12 @@ class TokenAssociateIntegrationTest {
     @DisplayName("Can associate account with token")
     void canAssociateAccountWithToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -28,7 +28,7 @@ class TokenAssociateIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -46,7 +46,7 @@ class TokenAssociateIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -62,12 +62,12 @@ class TokenAssociateIntegrationTest {
     @DisplayName("Can execute token associate transaction even when token IDs are not set")
     void canExecuteTokenAssociateTransactionEvenWhenTokenIDsAreNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -75,7 +75,7 @@ class TokenAssociateIntegrationTest {
             var accountId = Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
 
             new TokenAssociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .freezeWith(testEnv.client)
                 .sign(key)
@@ -90,12 +90,12 @@ class TokenAssociateIntegrationTest {
     @DisplayName("Cannot associate account with tokens when account ID is not set")
     void cannotAssociateAccountWithTokensWhenAccountIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -104,7 +104,7 @@ class TokenAssociateIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenAssociateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .freezeWith(testEnv.client)
                     .sign(key)
                     .execute(testEnv.client)
@@ -121,12 +121,12 @@ class TokenAssociateIntegrationTest {
     @DisplayName("Cannot associate account with tokens when account does not sign transaction")
     void cannotAssociateAccountWhenAccountDoesNotSignTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -135,7 +135,7 @@ class TokenAssociateIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -154,7 +154,7 @@ class TokenAssociateIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenAssociateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .setTokenIds(Collections.singletonList(tokenId))
                     .execute(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenAssociateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenAssociateIntegrationTest.java
@@ -19,7 +19,6 @@ class TokenAssociateIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -28,7 +27,6 @@ class TokenAssociateIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -46,7 +44,6 @@ class TokenAssociateIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -67,7 +64,6 @@ class TokenAssociateIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -75,7 +71,6 @@ class TokenAssociateIntegrationTest {
             var accountId = Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
 
             new TokenAssociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .freezeWith(testEnv.client)
                 .sign(key)
@@ -95,7 +90,6 @@ class TokenAssociateIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -104,7 +98,6 @@ class TokenAssociateIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenAssociateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .freezeWith(testEnv.client)
                     .sign(key)
                     .execute(testEnv.client)
@@ -126,7 +119,6 @@ class TokenAssociateIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -135,7 +127,6 @@ class TokenAssociateIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -154,7 +145,6 @@ class TokenAssociateIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenAssociateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .setTokenIds(Collections.singletonList(tokenId))
                     .execute(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenAssociateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenAssociateIntegrationTest.java
@@ -54,7 +54,7 @@ class TokenAssociateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 
@@ -82,7 +82,7 @@ class TokenAssociateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 
@@ -113,7 +113,7 @@ class TokenAssociateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 
@@ -163,7 +163,7 @@ class TokenAssociateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_SIGNATURE.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenAssociateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenAssociateIntegrationTest.java
@@ -14,7 +14,7 @@ class TokenAssociateIntegrationTest {
     @DisplayName("Can associate account with token")
     void canAssociateAccountWithToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -51,7 +51,7 @@ class TokenAssociateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 
@@ -59,7 +59,7 @@ class TokenAssociateIntegrationTest {
     @DisplayName("Can execute token associate transaction even when token IDs are not set")
     void canExecuteTokenAssociateTransactionEvenWhenTokenIDsAreNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -77,7 +77,7 @@ class TokenAssociateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 
@@ -85,7 +85,7 @@ class TokenAssociateIntegrationTest {
     @DisplayName("Cannot associate account with tokens when account ID is not set")
     void cannotAssociateAccountWithTokensWhenAccountIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -106,7 +106,7 @@ class TokenAssociateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 
@@ -114,7 +114,7 @@ class TokenAssociateIntegrationTest {
     @DisplayName("Cannot associate account with tokens when account does not sign transaction")
     void cannotAssociateAccountWhenAccountDoesNotSignTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -153,7 +153,7 @@ class TokenAssociateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_SIGNATURE.toString()));
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenBurnIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenBurnIntegrationTest.java
@@ -16,7 +16,7 @@ class TokenBurnIntegrationTest {
     @DisplayName("Can burn tokens")
     void canBurnTokens() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -42,7 +42,7 @@ class TokenBurnIntegrationTest {
 
             assertEquals(receipt.totalSupply, 1000000 - 10);
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -50,7 +50,7 @@ class TokenBurnIntegrationTest {
     @DisplayName("Cannot burn tokens when token ID is not set")
     void cannotBurnTokensWhenTokenIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenBurnTransaction()
@@ -61,7 +61,7 @@ class TokenBurnIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -69,7 +69,7 @@ class TokenBurnIntegrationTest {
     @DisplayName("Cannot burn tokens when amount is not set")
     void cannotBurnTokensWhenAmountIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -96,7 +96,7 @@ class TokenBurnIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_BURN_AMOUNT.toString()));
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -104,7 +104,7 @@ class TokenBurnIntegrationTest {
     @DisplayName("Cannot burn tokens when supply key does not sign transaction")
     void cannotBurnTokensWhenSupplyKeyDoesNotSignTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -132,7 +132,7 @@ class TokenBurnIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_SIGNATURE.toString()));
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -141,7 +141,7 @@ class TokenBurnIntegrationTest {
     @DisplayName("Can burn NFTs")
     void canBurnNfts() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var createReceipt = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -183,7 +183,7 @@ class TokenBurnIntegrationTest {
                 assertTrue(serialsLeft.remove(info.nftId.serial));
             }
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenBurnIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenBurnIntegrationTest.java
@@ -16,10 +16,10 @@ class TokenBurnIntegrationTest {
     @DisplayName("Can burn tokens")
     void canBurnTokens() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -36,7 +36,7 @@ class TokenBurnIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             var receipt = new TokenBurnTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAmount(10)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
@@ -52,11 +52,11 @@ class TokenBurnIntegrationTest {
     @DisplayName("Cannot burn tokens when token ID is not set")
     void cannotBurnTokensWhenTokenIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenBurnTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAmount(10)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -72,10 +72,10 @@ class TokenBurnIntegrationTest {
     @DisplayName("Cannot burn tokens when amount is not set")
     void cannotBurnTokensWhenAmountIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -93,7 +93,7 @@ class TokenBurnIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenBurnTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -109,10 +109,10 @@ class TokenBurnIntegrationTest {
     @DisplayName("Cannot burn tokens when supply key does not sign transaction")
     void cannotBurnTokensWhenSupplyKeyDoesNotSignTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -130,7 +130,7 @@ class TokenBurnIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenBurnTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .setAmount(10)
                     .execute(testEnv.client)
@@ -148,10 +148,10 @@ class TokenBurnIntegrationTest {
     @DisplayName("Can burn NFTs")
     void canBurnNfts() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var createReceipt = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)
@@ -168,14 +168,14 @@ class TokenBurnIntegrationTest {
             var tokenId = Objects.requireNonNull(createReceipt.tokenId);
 
             var mintReceipt = new TokenMintTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMetadata(NftMetadataGenerator.generate((byte)10))
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TokenBurnTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setSerials(mintReceipt.serials.subList(0, 4))
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
@@ -185,7 +185,7 @@ class TokenBurnIntegrationTest {
             var serialsLeft = new ArrayList<Long>(mintReceipt.serials.subList(4, 10));
 
             var nftInfos = new TokenNftInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .byTokenId(tokenId)
                 .setEnd(6)
                 .execute(testEnv.client);

--- a/sdk/src/integrationTest/java/TokenBurnIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenBurnIntegrationTest.java
@@ -44,7 +44,7 @@ class TokenBurnIntegrationTest {
 
             assertEquals(receipt.totalSupply, 1000000 - 10);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -64,7 +64,7 @@ class TokenBurnIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -101,7 +101,7 @@ class TokenBurnIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_BURN_AMOUNT.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -139,7 +139,7 @@ class TokenBurnIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_SIGNATURE.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -166,7 +166,7 @@ class TokenBurnIntegrationTest {
                 .getReceipt(testEnv.client);
 
             var tokenId = Objects.requireNonNull(createReceipt.tokenId);
-            
+
             var mintReceipt = new TokenMintTransaction()
                 .setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
@@ -189,12 +189,12 @@ class TokenBurnIntegrationTest {
                 .byTokenId(tokenId)
                 .setEnd(6)
                 .execute(testEnv.client);
-            
+
             for(var info : nftInfos) {
                 assertTrue(serialsLeft.remove(info.nftId.serial));
             }
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenBurnIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenBurnIntegrationTest.java
@@ -19,7 +19,6 @@ class TokenBurnIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -36,7 +35,6 @@ class TokenBurnIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             var receipt = new TokenBurnTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAmount(10)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
@@ -56,7 +54,6 @@ class TokenBurnIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenBurnTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAmount(10)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -75,7 +72,6 @@ class TokenBurnIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -93,7 +89,6 @@ class TokenBurnIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenBurnTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -112,7 +107,6 @@ class TokenBurnIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -130,7 +124,6 @@ class TokenBurnIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenBurnTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .setAmount(10)
                     .execute(testEnv.client)
@@ -151,7 +144,6 @@ class TokenBurnIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var createReceipt = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)
@@ -168,14 +160,12 @@ class TokenBurnIntegrationTest {
             var tokenId = Objects.requireNonNull(createReceipt.tokenId);
 
             var mintReceipt = new TokenMintTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMetadata(NftMetadataGenerator.generate((byte)10))
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TokenBurnTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setSerials(mintReceipt.serials.subList(0, 4))
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
@@ -185,7 +175,6 @@ class TokenBurnIntegrationTest {
             var serialsLeft = new ArrayList<Long>(mintReceipt.serials.subList(4, 10));
 
             var nftInfos = new TokenNftInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .byTokenId(tokenId)
                 .setEnd(6)
                 .execute(testEnv.client);

--- a/sdk/src/integrationTest/java/TokenCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenCreateIntegrationTest.java
@@ -38,7 +38,7 @@ class TokenCreateIntegrationTest {
 
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -48,14 +48,16 @@ class TokenCreateIntegrationTest {
         assertDoesNotThrow(() -> {
             var testEnv = new IntegrationTestEnv();
 
-            new TokenCreateTransaction()
+            var tokenId = new TokenCreateTransaction()
                 .setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
                 .execute(testEnv.client)
-                .getReceipt(testEnv.client);
+                .getReceipt(testEnv.client)
+                .tokenId;
 
+            // TODO: we lose this account
             testEnv.client.close();
         });
     }
@@ -78,7 +80,7 @@ class TokenCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.MISSING_TOKEN_NAME.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -100,7 +102,7 @@ class TokenCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.MISSING_TOKEN_SYMBOL.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -122,7 +124,7 @@ class TokenCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TREASURY_ACCOUNT_FOR_TOKEN.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -145,7 +147,7 @@ class TokenCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_SIGNATURE.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -171,7 +173,7 @@ class TokenCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_SIGNATURE.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -195,11 +197,12 @@ class TokenCreateIntegrationTest {
                 .setFeeCollectorAccountId(testEnv.operatorId)
             );
 
-            new TokenCreateTransaction()
+            var tokenId = new TokenCreateTransaction()
                 .setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
+                .setAdminKey(testEnv.operatorKey)
                 .setCustomFees(customFees)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
@@ -423,7 +426,7 @@ class TokenCreateIntegrationTest {
 
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenCreateIntegrationTest.java
@@ -45,7 +45,7 @@ class TokenCreateIntegrationTest {
     @DisplayName("Can create token with minimal properties set")
     void canCreateTokenWithMinimalPropertiesSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount(new Hbar(5));
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount(new Hbar(10));
 
             var tokenId = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -197,7 +197,8 @@ class TokenCreateIntegrationTest {
                 .setAdminKey(testEnv.operatorKey)
                 .setCustomFees(customFees)
                 .execute(testEnv.client)
-                .getReceipt(testEnv.client);
+                .getReceipt(testEnv.client)
+                .tokenId;
             testEnv.close(tokenId);
         });
     }
@@ -230,13 +231,13 @@ class TokenCreateIntegrationTest {
     @DisplayName("Cannot create custom fee list with > 10 entries")
     void cannotCreateMoreThanTenCustomFees() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
+                    .setAdminKey(testEnv.operatorKey)
                     .setTreasuryAccountId(testEnv.operatorId)
                     .setCustomFees(createFixedFeeList(11, testEnv.operatorId))
                     .execute(testEnv.client)
@@ -245,7 +246,7 @@ class TokenCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.CUSTOM_FEES_LIST_TOO_LONG.toString()));
 
-            testEnv.client.close();
+            testEnv.close();
         });
     }
 
@@ -254,18 +255,19 @@ class TokenCreateIntegrationTest {
     @DisplayName("Can create custom fee list with 10 fixed fees")
     void canCreateTenFixedFees() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
-            new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+            var tokenId = new TokenCreateTransaction()
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
+                .setAdminKey(testEnv.operatorKey)
                 .setCustomFees(createFixedFeeList(10, testEnv.operatorId))
                 .execute(testEnv.client)
-                .getReceipt(testEnv.client);
+                .getReceipt(testEnv.client)
+                .tokenId;
 
-            testEnv.close();
+            testEnv.close(tokenId);
         });
     }
 
@@ -274,18 +276,19 @@ class TokenCreateIntegrationTest {
     @DisplayName("Can create custom fee list with 10 fractional fees")
     void canCreateTenFractionalFees() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
-            new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+            var tokenId = new TokenCreateTransaction()
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
+                .setAdminKey(testEnv.operatorKey)
                 .setTreasuryAccountId(testEnv.operatorId)
                 .setCustomFees(createFractionalFeeList(10, testEnv.operatorId))
                 .execute(testEnv.client)
-                .getReceipt(testEnv.client);
+                .getReceipt(testEnv.client)
+                .tokenId;
 
-            testEnv.close();
+            testEnv.close(tokenId);
         });
     }
 
@@ -293,14 +296,14 @@ class TokenCreateIntegrationTest {
     @DisplayName("Cannot create a token with a custom fee where min > max")
     void cannotCreateMinGreaterThanMax() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setTreasuryAccountId(testEnv.operatorId)
+                    .setAdminKey(testEnv.operatorKey)
                     .setCustomFees(Collections.singletonList(new CustomFractionalFee()
                         .setNumerator(1)
                         .setDenominator(3)
@@ -321,13 +324,13 @@ class TokenCreateIntegrationTest {
     @DisplayName("Cannot create a token with invalid fee collector account ID")
     void cannotCreateInvalidFeeCollector() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
+                    .setAdminKey(testEnv.operatorKey)
                     .setTreasuryAccountId(testEnv.operatorId)
                     .setCustomFees(Collections.singletonList(new CustomFixedFee()
                         .setAmount(1)))
@@ -337,7 +340,7 @@ class TokenCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_CUSTOM_FEE_COLLECTOR.toString()));
 
-            testEnv.client.close();
+            testEnv.close();
         });
     }
 
@@ -345,13 +348,13 @@ class TokenCreateIntegrationTest {
     @DisplayName("Cannot create a token with a negative custom fee")
     void cannotCreateNegativeFee() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
+                    .setAdminKey(testEnv.operatorKey)
                     .setTreasuryAccountId(testEnv.operatorId)
                     .setCustomFees(Collections.singletonList(new CustomFixedFee()
                         .setAmount(-1)
@@ -362,7 +365,7 @@ class TokenCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.CUSTOM_FEE_MUST_BE_POSITIVE.toString()));
 
-            testEnv.client.close();
+            testEnv.close();
         });
     }
 
@@ -371,14 +374,14 @@ class TokenCreateIntegrationTest {
     @DisplayName("Cannot create custom fee with 0 denominator")
     void cannotCreateZeroDenominator() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setTreasuryAccountId(testEnv.operatorId)
+                    .setAdminKey(testEnv.operatorKey)
                     .setCustomFees(Collections.singletonList(new CustomFractionalFee()
                         .setNumerator(1)
                         .setDenominator(0)
@@ -391,7 +394,7 @@ class TokenCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.FRACTION_DIVIDES_BY_ZERO.toString()));
 
-            testEnv.client.close();
+            testEnv.close();
         });
     }
 

--- a/sdk/src/integrationTest/java/TokenCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenCreateIntegrationTest.java
@@ -18,7 +18,7 @@ class TokenCreateIntegrationTest {
     @DisplayName("Can create token with operator as all keys")
     void canCreateTokenWithOperatorAsAllKeys() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -37,7 +37,7 @@ class TokenCreateIntegrationTest {
 
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -45,7 +45,7 @@ class TokenCreateIntegrationTest {
     @DisplayName("Can create token with minimal properties set")
     void canCreateTokenWithMinimalPropertiesSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount(5);
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount(new Hbar(5));
 
             var tokenId = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -64,7 +64,7 @@ class TokenCreateIntegrationTest {
     @DisplayName("Cannot create token when token name is not set")
     void cannotCreateTokenWhenTokenNameIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenCreateTransaction()
@@ -77,7 +77,7 @@ class TokenCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.MISSING_TOKEN_NAME.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -85,7 +85,7 @@ class TokenCreateIntegrationTest {
     @DisplayName("Cannot create token when token symbol is not set")
     void cannotCreateTokenWhenTokenSymbolIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenCreateTransaction()
@@ -98,7 +98,7 @@ class TokenCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.MISSING_TOKEN_SYMBOL.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -106,7 +106,7 @@ class TokenCreateIntegrationTest {
     @DisplayName("Cannot create token when token treasury account ID is not set")
     void cannotCreateTokenWhenTokenTreasuryAccountIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenCreateTransaction()
@@ -119,7 +119,7 @@ class TokenCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TREASURY_ACCOUNT_FOR_TOKEN.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -127,7 +127,7 @@ class TokenCreateIntegrationTest {
     @DisplayName("Cannot create token when token treasury account ID does not sign transaction")
     void cannotCreateTokenWhenTokenTreasuryAccountIDDoesNotSignTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenCreateTransaction()
@@ -141,7 +141,7 @@ class TokenCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_SIGNATURE.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -149,7 +149,7 @@ class TokenCreateIntegrationTest {
     @DisplayName("Cannot create token when admin key does not sign transaction")
     void cannotCreateTokenWhenAdminKeyDoesNotSignTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -166,7 +166,7 @@ class TokenCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_SIGNATURE.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -175,7 +175,7 @@ class TokenCreateIntegrationTest {
     @DisplayName("Can create token with custom fees")
     void canCreateTokenWithCustomFees() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var customFees = new ArrayList<CustomFee>();
             customFees.add(new CustomFixedFee()
@@ -198,7 +198,7 @@ class TokenCreateIntegrationTest {
                 .setCustomFees(customFees)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
-            testEnv.client.close();
+            testEnv.close(tokenId);
         });
     }
 
@@ -265,7 +265,7 @@ class TokenCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.close();
         });
     }
 
@@ -285,7 +285,7 @@ class TokenCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.close();
         });
     }
 
@@ -313,7 +313,7 @@ class TokenCreateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT.toString()));
 
-            testEnv.client.close();
+            testEnv.close();
         });
     }
 
@@ -400,7 +400,7 @@ class TokenCreateIntegrationTest {
     @DisplayName("Can create NFT")
     void canCreateNfts() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -417,7 +417,7 @@ class TokenCreateIntegrationTest {
 
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenCreateIntegrationTest.java
@@ -21,7 +21,6 @@ class TokenCreateIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -49,7 +48,6 @@ class TokenCreateIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var tokenId = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -70,7 +68,6 @@ class TokenCreateIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenSymbol("F")
                     .setTreasuryAccountId(testEnv.operatorId)
                     .execute(testEnv.client)
@@ -92,7 +89,6 @@ class TokenCreateIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTreasuryAccountId(testEnv.operatorId)
                     .execute(testEnv.client)
@@ -114,7 +110,6 @@ class TokenCreateIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .execute(testEnv.client)
@@ -136,7 +131,6 @@ class TokenCreateIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setTreasuryAccountId(AccountId.fromString("0.0.3"))
@@ -161,7 +155,6 @@ class TokenCreateIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setTreasuryAccountId(testEnv.operatorId)
@@ -198,7 +191,6 @@ class TokenCreateIntegrationTest {
             );
 
             var tokenId = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -411,7 +403,6 @@ class TokenCreateIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)

--- a/sdk/src/integrationTest/java/TokenCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenCreateIntegrationTest.java
@@ -18,10 +18,10 @@ class TokenCreateIntegrationTest {
     @DisplayName("Can create token with operator as all keys")
     void canCreateTokenWithOperatorAsAllKeys() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -46,10 +46,10 @@ class TokenCreateIntegrationTest {
     @DisplayName("Can create token with minimal properties set")
     void canCreateTokenWithMinimalPropertiesSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var tokenId = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -66,11 +66,11 @@ class TokenCreateIntegrationTest {
     @DisplayName("Cannot create token when token name is not set")
     void cannotCreateTokenWhenTokenNameIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenSymbol("F")
                     .setTreasuryAccountId(testEnv.operatorId)
                     .execute(testEnv.client)
@@ -88,11 +88,11 @@ class TokenCreateIntegrationTest {
     @DisplayName("Cannot create token when token symbol is not set")
     void cannotCreateTokenWhenTokenSymbolIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTreasuryAccountId(testEnv.operatorId)
                     .execute(testEnv.client)
@@ -110,11 +110,11 @@ class TokenCreateIntegrationTest {
     @DisplayName("Cannot create token when token treasury account ID is not set")
     void cannotCreateTokenWhenTokenTreasuryAccountIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .execute(testEnv.client)
@@ -132,11 +132,11 @@ class TokenCreateIntegrationTest {
     @DisplayName("Cannot create token when token treasury account ID does not sign transaction")
     void cannotCreateTokenWhenTokenTreasuryAccountIDDoesNotSignTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setTreasuryAccountId(AccountId.fromString("0.0.3"))
@@ -155,13 +155,13 @@ class TokenCreateIntegrationTest {
     @DisplayName("Cannot create token when admin key does not sign transaction")
     void cannotCreateTokenWhenAdminKeyDoesNotSignTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setTreasuryAccountId(testEnv.operatorId)
@@ -182,7 +182,7 @@ class TokenCreateIntegrationTest {
     @DisplayName("Can create token with custom fees")
     void canCreateTokenWithCustomFees() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var customFees = new ArrayList<CustomFee>();
             customFees.add(new CustomFixedFee()
@@ -198,7 +198,7 @@ class TokenCreateIntegrationTest {
             );
 
             var tokenId = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -408,10 +408,10 @@ class TokenCreateIntegrationTest {
     @DisplayName("Can create NFT")
     void canCreateNfts() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)

--- a/sdk/src/integrationTest/java/TokenCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenCreateIntegrationTest.java
@@ -45,7 +45,7 @@ class TokenCreateIntegrationTest {
     @DisplayName("Can create token with minimal properties set")
     void canCreateTokenWithMinimalPropertiesSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount(5);
 
             var tokenId = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -55,7 +55,7 @@ class TokenCreateIntegrationTest {
                 .getReceipt(testEnv.client)
                 .tokenId;
 
-            // TODO: we lose this account
+            // we lose this IntegrationTestEnv throwaway account
             testEnv.client.close();
         });
     }

--- a/sdk/src/integrationTest/java/TokenDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenDeleteIntegrationTest.java
@@ -40,7 +40,7 @@ class TokenDeleteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -67,7 +67,7 @@ class TokenDeleteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -102,7 +102,14 @@ class TokenDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_SIGNATURE.toString()));
 
-            testEnv.client.close();
+            new TokenDeleteTransaction()
+                .setTokenId(tokenId)
+                .freezeWith(testEnv.client)
+                .sign(key)
+                .execute(testEnv.client)
+                .getReceipt(testEnv.client);
+
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -122,7 +129,7 @@ class TokenDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenDeleteIntegrationTest.java
@@ -11,14 +11,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TokenDeleteIntegrationTest {
     @Test
-    @Disabled
     @DisplayName("Can delete token")
     void canDeleteToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -35,7 +34,7 @@ class TokenDeleteIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             new TokenDeleteTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
@@ -45,14 +44,13 @@ class TokenDeleteIntegrationTest {
     }
 
     @Test
-    @Disabled
     @DisplayName("Can delete token with only admin key set")
     void canDeleteTokenWithOnlyAdminKeySet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -61,27 +59,20 @@ class TokenDeleteIntegrationTest {
 
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
-            new TokenDeleteTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setTokenId(tokenId)
-                .execute(testEnv.client)
-                .getReceipt(testEnv.client);
-
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
     @Test
-    @Disabled
     @DisplayName("Cannot delete token when admin key does not sign transaction")
     void cannotDeleteTokenWhenAdminKeyDoesNotSignTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -94,7 +85,7 @@ class TokenDeleteIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenDeleteTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -114,15 +105,14 @@ class TokenDeleteIntegrationTest {
     }
 
     @Test
-    @Disabled
     @DisplayName("Cannot delete token when token ID is not set")
     void cannotDeleteTokenWhenTokenIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
-            var error = assertThrows(ReceiptStatusException.class, () -> {
+            var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenDeleteTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });

--- a/sdk/src/integrationTest/java/TokenDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenDeleteIntegrationTest.java
@@ -14,7 +14,7 @@ class TokenDeleteIntegrationTest {
     @DisplayName("Can delete token")
     void canDeleteToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -37,7 +37,7 @@ class TokenDeleteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -45,7 +45,7 @@ class TokenDeleteIntegrationTest {
     @DisplayName("Can delete token with only admin key set")
     void canDeleteTokenWithOnlyAdminKeySet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -56,7 +56,7 @@ class TokenDeleteIntegrationTest {
 
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -64,7 +64,7 @@ class TokenDeleteIntegrationTest {
     @DisplayName("Cannot delete token when admin key does not sign transaction")
     void cannotDeleteTokenWhenAdminKeyDoesNotSignTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -95,7 +95,7 @@ class TokenDeleteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -103,7 +103,7 @@ class TokenDeleteIntegrationTest {
     @DisplayName("Cannot delete token when token ID is not set")
     void cannotDeleteTokenWhenTokenIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenDeleteTransaction()
@@ -113,7 +113,7 @@ class TokenDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenDeleteIntegrationTest.java
@@ -17,7 +17,6 @@ class TokenDeleteIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -34,7 +33,6 @@ class TokenDeleteIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             new TokenDeleteTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
@@ -50,7 +48,6 @@ class TokenDeleteIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -72,7 +69,6 @@ class TokenDeleteIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -85,7 +81,6 @@ class TokenDeleteIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenDeleteTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -112,7 +107,6 @@ class TokenDeleteIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenDeleteTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });

--- a/sdk/src/integrationTest/java/TokenDissociateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenDissociateIntegrationTest.java
@@ -14,12 +14,12 @@ class TokenDissociateIntegrationTest {
     @DisplayName("Can dissociate account with token")
     void canAssociateAccountWithToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -28,7 +28,7 @@ class TokenDissociateIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -46,7 +46,7 @@ class TokenDissociateIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -55,7 +55,7 @@ class TokenDissociateIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenDissociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -71,12 +71,12 @@ class TokenDissociateIntegrationTest {
     @DisplayName("Can execute token dissociate transaction even when token IDs are not set")
     void canExecuteTokenDissociateTransactionEvenWhenTokenIDsAreNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -84,7 +84,7 @@ class TokenDissociateIntegrationTest {
             var accountId = Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
 
             new TokenDissociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .freezeWith(testEnv.client)
                 .sign(key)
@@ -99,12 +99,12 @@ class TokenDissociateIntegrationTest {
     @DisplayName("Cannot dissociate account with tokens when account ID is not set")
     void cannotDissociateAccountWithTokensWhenAccountIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -113,7 +113,7 @@ class TokenDissociateIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenDissociateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .freezeWith(testEnv.client)
                     .sign(key)
                     .execute(testEnv.client)
@@ -130,12 +130,12 @@ class TokenDissociateIntegrationTest {
     @DisplayName("Cannot dissociate account with tokens when account does not sign transaction")
     void cannotDissociateAccountWhenAccountDoesNotSignTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -144,7 +144,7 @@ class TokenDissociateIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -163,7 +163,7 @@ class TokenDissociateIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenDissociateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .setTokenIds(Collections.singletonList(tokenId))
                     .execute(testEnv.client)
@@ -180,12 +180,12 @@ class TokenDissociateIntegrationTest {
     @DisplayName("Cannot dissociate account from token when account was not associated with")
     void cannotDissociateAccountFromTokenWhenAccountWasNotAssociatedWith() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -194,7 +194,7 @@ class TokenDissociateIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -213,7 +213,7 @@ class TokenDissociateIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenDissociateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .setTokenIds(Collections.singletonList(tokenId))
                     .freezeWith(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenDissociateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenDissociateIntegrationTest.java
@@ -19,7 +19,6 @@ class TokenDissociateIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -28,7 +27,6 @@ class TokenDissociateIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -46,7 +44,6 @@ class TokenDissociateIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -55,7 +52,6 @@ class TokenDissociateIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenDissociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -76,7 +72,6 @@ class TokenDissociateIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -84,7 +79,6 @@ class TokenDissociateIntegrationTest {
             var accountId = Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
 
             new TokenDissociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .freezeWith(testEnv.client)
                 .sign(key)
@@ -104,7 +98,6 @@ class TokenDissociateIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -113,7 +106,6 @@ class TokenDissociateIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenDissociateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .freezeWith(testEnv.client)
                     .sign(key)
                     .execute(testEnv.client)
@@ -135,7 +127,6 @@ class TokenDissociateIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -144,7 +135,6 @@ class TokenDissociateIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -163,7 +153,6 @@ class TokenDissociateIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenDissociateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .setTokenIds(Collections.singletonList(tokenId))
                     .execute(testEnv.client)
@@ -185,7 +174,6 @@ class TokenDissociateIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -194,7 +182,6 @@ class TokenDissociateIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -213,7 +200,6 @@ class TokenDissociateIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenDissociateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .setTokenIds(Collections.singletonList(tokenId))
                     .freezeWith(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenDissociateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenDissociateIntegrationTest.java
@@ -14,7 +14,7 @@ class TokenDissociateIntegrationTest {
     @DisplayName("Can dissociate account with token")
     void canAssociateAccountWithToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -59,7 +59,7 @@ class TokenDissociateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 
@@ -67,7 +67,7 @@ class TokenDissociateIntegrationTest {
     @DisplayName("Can execute token dissociate transaction even when token IDs are not set")
     void canExecuteTokenDissociateTransactionEvenWhenTokenIDsAreNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -85,7 +85,7 @@ class TokenDissociateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 
@@ -93,7 +93,7 @@ class TokenDissociateIntegrationTest {
     @DisplayName("Cannot dissociate account with tokens when account ID is not set")
     void cannotDissociateAccountWithTokensWhenAccountIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -114,7 +114,7 @@ class TokenDissociateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 
@@ -122,7 +122,7 @@ class TokenDissociateIntegrationTest {
     @DisplayName("Cannot dissociate account with tokens when account does not sign transaction")
     void cannotDissociateAccountWhenAccountDoesNotSignTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -161,7 +161,7 @@ class TokenDissociateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_SIGNATURE.toString()));
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 
@@ -169,7 +169,7 @@ class TokenDissociateIntegrationTest {
     @DisplayName("Cannot dissociate account from token when account was not associated with")
     void cannotDissociateAccountFromTokenWhenAccountWasNotAssociatedWith() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -210,7 +210,7 @@ class TokenDissociateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.toString()));
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenDissociateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenDissociateIntegrationTest.java
@@ -63,7 +63,7 @@ class TokenDissociateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 
@@ -91,7 +91,7 @@ class TokenDissociateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 
@@ -109,7 +109,7 @@ class TokenDissociateIntegrationTest {
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
 
-            Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
+            var accountId = Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenDissociateTransaction()
@@ -122,7 +122,7 @@ class TokenDissociateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 
@@ -172,7 +172,7 @@ class TokenDissociateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_SIGNATURE.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 
@@ -224,7 +224,7 @@ class TokenDissociateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenFeeScheduleUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenFeeScheduleUpdateIntegrationTest.java
@@ -139,10 +139,9 @@ class TokenFeeScheduleUpdateIntegrationTest {
     @DisplayName("Cannot update fee schedule with any key other than fee schedule key")
     void cannotUpdateWithAnyOtherKey() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -176,7 +175,7 @@ class TokenFeeScheduleUpdateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_SIGNATURE.toString()));
 
-            testEnv.client.close();
+            testEnv.close(tokenId);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenFeeScheduleUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenFeeScheduleUpdateIntegrationTest.java
@@ -134,6 +134,7 @@ class TokenFeeScheduleUpdateIntegrationTest {
             assertEquals(fixedCount, 1);
             assertEquals(fractionalCount, 1);
 
+            testEnv.cleanUpAndClose(tokenId);
             testEnv.client.close();
         });
     }

--- a/sdk/src/integrationTest/java/TokenFeeScheduleUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenFeeScheduleUpdateIntegrationTest.java
@@ -15,13 +15,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class TokenFeeScheduleUpdateIntegrationTest {
     @Test
-    @DisplayName("Can update token")
+    @DisplayName("Can update token fees")
     void canUpdateToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -39,7 +39,7 @@ class TokenFeeScheduleUpdateIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             @Var var info = new TokenInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .execute(testEnv.client);
 
@@ -53,12 +53,12 @@ class TokenFeeScheduleUpdateIntegrationTest {
             assertNotNull(info.wipeKey);
             assertNotNull(info.kycKey);
             assertNotNull(info.supplyKey);
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.adminKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.freezeKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.wipeKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.kycKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.supplyKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.feeScheduleKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.adminKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.freezeKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.wipeKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.kycKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.supplyKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.feeScheduleKey.toString());
             assertNotNull(info.defaultFreezeStatus);
             assertFalse(info.defaultFreezeStatus);
             assertNotNull(info.defaultKycStatus);
@@ -85,7 +85,7 @@ class TokenFeeScheduleUpdateIntegrationTest {
                 .getReceipt(testEnv.client);
 
             info = new TokenInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .execute(testEnv.client);
 
@@ -99,12 +99,12 @@ class TokenFeeScheduleUpdateIntegrationTest {
             assertNotNull(info.wipeKey);
             assertNotNull(info.kycKey);
             assertNotNull(info.supplyKey);
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.adminKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.freezeKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.wipeKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.kycKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.supplyKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.feeScheduleKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.adminKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.freezeKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.wipeKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.kycKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.supplyKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.feeScheduleKey.toString());
             assertNotNull(info.defaultFreezeStatus);
             assertFalse(info.defaultFreezeStatus);
             assertNotNull(info.defaultKycStatus);

--- a/sdk/src/integrationTest/java/TokenFeeScheduleUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenFeeScheduleUpdateIntegrationTest.java
@@ -21,7 +21,6 @@ class TokenFeeScheduleUpdateIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -39,7 +38,6 @@ class TokenFeeScheduleUpdateIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             @Var var info = new TokenInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .execute(testEnv.client);
 
@@ -85,7 +83,6 @@ class TokenFeeScheduleUpdateIntegrationTest {
                 .getReceipt(testEnv.client);
 
             info = new TokenInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .execute(testEnv.client);
 

--- a/sdk/src/integrationTest/java/TokenFeeScheduleUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenFeeScheduleUpdateIntegrationTest.java
@@ -18,7 +18,7 @@ class TokenFeeScheduleUpdateIntegrationTest {
     @DisplayName("Can update token fees")
     void canUpdateToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -131,8 +131,7 @@ class TokenFeeScheduleUpdateIntegrationTest {
             assertEquals(fixedCount, 1);
             assertEquals(fractionalCount, 1);
 
-            testEnv.cleanUpAndClose(tokenId);
-            testEnv.client.close();
+            testEnv.close(tokenId);
         });
     }
 

--- a/sdk/src/integrationTest/java/TokenFreezeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenFreezeIntegrationTest.java
@@ -19,7 +19,6 @@ class TokenFreezeIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -28,7 +27,6 @@ class TokenFreezeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -46,7 +44,6 @@ class TokenFreezeIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -55,7 +52,6 @@ class TokenFreezeIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenFreezeTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .freezeWith(testEnv.client)
@@ -76,7 +72,6 @@ class TokenFreezeIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -85,7 +80,6 @@ class TokenFreezeIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenFreezeTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .freezeWith(testEnv.client)
                     .sign(key)
@@ -108,7 +102,6 @@ class TokenFreezeIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -126,7 +119,6 @@ class TokenFreezeIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenFreezeTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .freezeWith(testEnv.client)
                     .sign(key)
@@ -149,7 +141,6 @@ class TokenFreezeIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -158,7 +149,6 @@ class TokenFreezeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -177,7 +167,6 @@ class TokenFreezeIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenFreezeTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .setTokenId(tokenId)
                     .freezeWith(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenFreezeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenFreezeIntegrationTest.java
@@ -63,7 +63,7 @@ class TokenFreezeIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 
@@ -95,7 +95,7 @@ class TokenFreezeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 
@@ -136,7 +136,7 @@ class TokenFreezeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -188,7 +188,7 @@ class TokenFreezeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenFreezeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenFreezeIntegrationTest.java
@@ -14,7 +14,7 @@ class TokenFreezeIntegrationTest {
     @DisplayName("Can freeze account with token")
     void canFreezeAccountWithToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -59,7 +59,7 @@ class TokenFreezeIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 
@@ -67,7 +67,7 @@ class TokenFreezeIntegrationTest {
     @DisplayName("Cannot freeze account on token when token ID is not set")
     void cannotFreezeAccountOnTokenWhenTokenIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -89,7 +89,7 @@ class TokenFreezeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 
@@ -97,7 +97,7 @@ class TokenFreezeIntegrationTest {
     @DisplayName("Cannot freeze account on token when account ID is not set")
     void cannotFreezeAccountOnTokenWhenAccountIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -128,7 +128,7 @@ class TokenFreezeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -136,7 +136,7 @@ class TokenFreezeIntegrationTest {
     @DisplayName("Cannot freeze account on token when account was not associated with")
     void cannotFreezeAccountOnTokenWhenAccountWasNotAssociatedWith() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -177,7 +177,7 @@ class TokenFreezeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.toString()));
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenFreezeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenFreezeIntegrationTest.java
@@ -14,12 +14,12 @@ class TokenFreezeIntegrationTest {
     @DisplayName("Can freeze account with token")
     void canFreezeAccountWithToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -28,7 +28,7 @@ class TokenFreezeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -46,7 +46,7 @@ class TokenFreezeIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -55,7 +55,7 @@ class TokenFreezeIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenFreezeTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .freezeWith(testEnv.client)
@@ -71,12 +71,12 @@ class TokenFreezeIntegrationTest {
     @DisplayName("Cannot freeze account on token when token ID is not set")
     void cannotFreezeAccountOnTokenWhenTokenIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -85,7 +85,7 @@ class TokenFreezeIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenFreezeTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .freezeWith(testEnv.client)
                     .sign(key)
@@ -103,12 +103,12 @@ class TokenFreezeIntegrationTest {
     @DisplayName("Cannot freeze account on token when account ID is not set")
     void cannotFreezeAccountOnTokenWhenAccountIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -126,7 +126,7 @@ class TokenFreezeIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenFreezeTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .freezeWith(testEnv.client)
                     .sign(key)
@@ -144,12 +144,12 @@ class TokenFreezeIntegrationTest {
     @DisplayName("Cannot freeze account on token when account was not associated with")
     void cannotFreezeAccountOnTokenWhenAccountWasNotAssociatedWith() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -158,7 +158,7 @@ class TokenFreezeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -177,7 +177,7 @@ class TokenFreezeIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenFreezeTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .setTokenId(tokenId)
                     .freezeWith(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenGrantKycIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenGrantKycIntegrationTest.java
@@ -14,12 +14,12 @@ class TokenGrantKycIntegrationTest {
     @DisplayName("Can grant kyc to account with token")
     void canGrantKycAccountWithToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -28,7 +28,7 @@ class TokenGrantKycIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -46,7 +46,7 @@ class TokenGrantKycIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -55,7 +55,7 @@ class TokenGrantKycIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenGrantKycTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .freezeWith(testEnv.client)
@@ -71,12 +71,12 @@ class TokenGrantKycIntegrationTest {
     @DisplayName("Cannot grant kyc to account on token when token ID is not set")
     void cannotGrantKycToAccountOnTokenWhenTokenIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -85,7 +85,7 @@ class TokenGrantKycIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenGrantKycTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .freezeWith(testEnv.client)
                     .sign(key)
@@ -93,18 +93,9 @@ class TokenGrantKycIntegrationTest {
                     .getReceipt(testEnv.client);
             });
 
-            new AccountDeleteTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setAccountId(accountId)
-                .setTransferAccountId(testEnv.operatorId)
-                .freezeWith(testEnv.client)
-                .sign(key)
-                .execute(testEnv.client)
-                .getReceipt(testEnv.client);
-
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 
@@ -112,12 +103,12 @@ class TokenGrantKycIntegrationTest {
     @DisplayName("Cannot grant kyc to account on token when account ID is not set")
     void cannotGrantKycToAccountOnTokenWhenAccountIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -135,7 +126,7 @@ class TokenGrantKycIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenGrantKycTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .freezeWith(testEnv.client)
                     .sign(key)
@@ -153,12 +144,12 @@ class TokenGrantKycIntegrationTest {
     @DisplayName("Cannot grant kyc to account on token when account was not associated with")
     void cannotGrantKycToAccountOnTokenWhenAccountWasNotAssociatedWith() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -167,7 +158,7 @@ class TokenGrantKycIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -186,7 +177,7 @@ class TokenGrantKycIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenGrantKycTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .setTokenId(tokenId)
                     .freezeWith(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenGrantKycIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenGrantKycIntegrationTest.java
@@ -19,7 +19,6 @@ class TokenGrantKycIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -28,7 +27,6 @@ class TokenGrantKycIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -46,7 +44,6 @@ class TokenGrantKycIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -55,7 +52,6 @@ class TokenGrantKycIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenGrantKycTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .freezeWith(testEnv.client)
@@ -76,7 +72,6 @@ class TokenGrantKycIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -85,7 +80,6 @@ class TokenGrantKycIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenGrantKycTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .freezeWith(testEnv.client)
                     .sign(key)
@@ -108,7 +102,6 @@ class TokenGrantKycIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -126,7 +119,6 @@ class TokenGrantKycIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenGrantKycTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .freezeWith(testEnv.client)
                     .sign(key)
@@ -149,7 +141,6 @@ class TokenGrantKycIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -158,7 +149,6 @@ class TokenGrantKycIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -177,7 +167,6 @@ class TokenGrantKycIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenGrantKycTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .setTokenId(tokenId)
                     .freezeWith(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenGrantKycIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenGrantKycIntegrationTest.java
@@ -14,7 +14,7 @@ class TokenGrantKycIntegrationTest {
     @DisplayName("Can grant kyc to account with token")
     void canGrantKycAccountWithToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -59,7 +59,7 @@ class TokenGrantKycIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 
@@ -67,7 +67,7 @@ class TokenGrantKycIntegrationTest {
     @DisplayName("Cannot grant kyc to account on token when token ID is not set")
     void cannotGrantKycToAccountOnTokenWhenTokenIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -89,7 +89,7 @@ class TokenGrantKycIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 
@@ -97,7 +97,7 @@ class TokenGrantKycIntegrationTest {
     @DisplayName("Cannot grant kyc to account on token when account ID is not set")
     void cannotGrantKycToAccountOnTokenWhenAccountIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -128,7 +128,7 @@ class TokenGrantKycIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -136,7 +136,7 @@ class TokenGrantKycIntegrationTest {
     @DisplayName("Cannot grant kyc to account on token when account was not associated with")
     void cannotGrantKycToAccountOnTokenWhenAccountWasNotAssociatedWith() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -177,7 +177,7 @@ class TokenGrantKycIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.toString()));
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenGrantKycIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenGrantKycIntegrationTest.java
@@ -63,7 +63,7 @@ class TokenGrantKycIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 
@@ -104,7 +104,7 @@ class TokenGrantKycIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -145,7 +145,7 @@ class TokenGrantKycIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -197,7 +197,7 @@ class TokenGrantKycIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenInfoIntegrationTest.java
@@ -19,7 +19,7 @@ class TokenInfoIntegrationTest {
     @DisplayName("Can query token info when all keys are different")
     void canQueryTokenInfoWhenAllKeysAreDifferent() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key1 = PrivateKey.generate();
             var key2 = PrivateKey.generate();
@@ -78,7 +78,7 @@ class TokenInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -86,7 +86,7 @@ class TokenInfoIntegrationTest {
     @DisplayName("Can query token with minimal properties")
     void canQueryTokenInfoWhenTokenIsCreatedWithMinimalProperties() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount(5);
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount(new Hbar(5));
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -126,7 +126,7 @@ class TokenInfoIntegrationTest {
     @DisplayName("Can query NFT")
     void canQueryNfts() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -170,7 +170,7 @@ class TokenInfoIntegrationTest {
             assertEquals(info.supplyType, TokenSupplyType.FINITE);
             assertEquals(info.maxSupply, 5000);
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -178,7 +178,7 @@ class TokenInfoIntegrationTest {
     @DisplayName("Get cost of token info query")
     void getCostQueryTokenInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -196,7 +196,7 @@ class TokenInfoIntegrationTest {
 
             infoQuery.setQueryPayment(cost).execute(testEnv.client);
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -204,7 +204,7 @@ class TokenInfoIntegrationTest {
     @DisplayName("Get cost of token info query, with big max")
     void getCostBigMaxQueryTokenInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -223,7 +223,7 @@ class TokenInfoIntegrationTest {
 
             infoQuery.setQueryPayment(cost).execute(testEnv.client);
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -231,7 +231,7 @@ class TokenInfoIntegrationTest {
     @DisplayName("Can query token info when all keys are different")
     void getCostSmallMaxTokenInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -254,7 +254,7 @@ class TokenInfoIntegrationTest {
 
             assertEquals(error.getMessage(), "com.hedera.hashgraph.sdk.MaxQueryPaymentExceededException: cost for TokenInfoQuery, of "+cost.toString()+", without explicit payment is greater than the maximum allowed payment of 1 tℏ");
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -262,7 +262,7 @@ class TokenInfoIntegrationTest {
     @DisplayName("Throws insufficient transaction fee error")
     void getCostInsufficientTxFeeQueryTokenInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -285,7 +285,7 @@ class TokenInfoIntegrationTest {
 
             assertEquals(error.status.toString(), "INSUFFICIENT_TX_FEE");
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenInfoIntegrationTest.java
@@ -87,7 +87,7 @@ class TokenInfoIntegrationTest {
     @DisplayName("Can query token with minimal properties")
     void canQueryTokenInfoWhenTokenIsCreatedWithMinimalProperties() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount(5);
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -117,8 +117,7 @@ class TokenInfoIntegrationTest {
             assertEquals(info.tokenType, TokenType.FUNGIBLE_COMMON);
             assertEquals(info.supplyType, TokenSupplyType.INFINITE);
 
-
-            // TODO: we lose this account
+            // we lose this IntegrationTestEnv throwaway account
             testEnv.client.close();
         });
     }
@@ -161,7 +160,7 @@ class TokenInfoIntegrationTest {
             assertEquals(info.decimals, 0);
             assertEquals(info.totalSupply, 10);
             assertEquals(testEnv.operatorId, info.treasuryAccountId);
-            assertNull(info.adminKey);
+            assertNotNull(info.adminKey);
             assertNull(info.freezeKey);
             assertNull(info.wipeKey);
             assertNull(info.kycKey);

--- a/sdk/src/integrationTest/java/TokenInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenInfoIntegrationTest.java
@@ -47,7 +47,6 @@ class TokenInfoIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             var info = new TokenInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .execute(testEnv.client);
 
@@ -91,7 +90,6 @@ class TokenInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -100,7 +98,6 @@ class TokenInfoIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             var info = new TokenInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .execute(testEnv.client);
 
@@ -134,7 +131,6 @@ class TokenInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)
@@ -148,7 +144,6 @@ class TokenInfoIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             var mintReceipt = new TokenMintTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMetadata(NftMetadataGenerator.generate((byte)10))
                 .execute(testEnv.client)
@@ -157,7 +152,6 @@ class TokenInfoIntegrationTest {
             assertEquals(mintReceipt.serials.size(), 10);
 
             var info = new TokenInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .execute(testEnv.client);
 
@@ -189,7 +183,6 @@ class TokenInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -199,7 +192,6 @@ class TokenInfoIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             var infoQuery = new TokenInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId);
 
             var cost = infoQuery.getCost(testEnv.client);
@@ -217,7 +209,6 @@ class TokenInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -227,7 +218,6 @@ class TokenInfoIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             var infoQuery = new TokenInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMaxQueryPayment(new Hbar(1000));
 
@@ -246,7 +236,6 @@ class TokenInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -256,7 +245,6 @@ class TokenInfoIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             var infoQuery = new TokenInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
@@ -279,7 +267,6 @@ class TokenInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -289,7 +276,6 @@ class TokenInfoIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             var infoQuery = new TokenInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMaxQueryPayment(new Hbar(1000));
 

--- a/sdk/src/integrationTest/java/TokenInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenInfoIntegrationTest.java
@@ -86,7 +86,7 @@ class TokenInfoIntegrationTest {
     @DisplayName("Can query token with minimal properties")
     void canQueryTokenInfoWhenTokenIsCreatedWithMinimalProperties() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount(new Hbar(5));
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount(new Hbar(10));
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")

--- a/sdk/src/integrationTest/java/TokenInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenInfoIntegrationTest.java
@@ -73,7 +73,14 @@ class TokenInfoIntegrationTest {
             assertEquals(info.tokenType, TokenType.FUNGIBLE_COMMON);
             assertEquals(info.supplyType, TokenSupplyType.INFINITE);
 
-            testEnv.client.close();
+            new TokenDeleteTransaction()
+                .setTokenId(tokenId)
+                .freezeWith(testEnv.client)
+                .sign(key1)
+                .execute(testEnv.client)
+                .getReceipt(testEnv.client);
+
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -113,6 +120,8 @@ class TokenInfoIntegrationTest {
             assertEquals(info.tokenType, TokenType.FUNGIBLE_COMMON);
             assertEquals(info.supplyType, TokenSupplyType.INFINITE);
 
+
+            // TODO: we lose this account
             testEnv.client.close();
         });
     }
@@ -132,6 +141,7 @@ class TokenInfoIntegrationTest {
                 .setSupplyType(TokenSupplyType.FINITE)
                 .setMaxSupply(5000)
                 .setTreasuryAccountId(testEnv.operatorId)
+                .setAdminKey(testEnv.operatorKey)
                 .setSupplyKey(testEnv.operatorKey)
                 .execute(testEnv.client);
 
@@ -168,7 +178,7 @@ class TokenInfoIntegrationTest {
             assertEquals(info.supplyType, TokenSupplyType.FINITE);
             assertEquals(info.maxSupply, 5000);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -183,6 +193,7 @@ class TokenInfoIntegrationTest {
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
+                .setAdminKey(testEnv.operatorKey)
                 .execute(testEnv.client);
 
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
@@ -195,7 +206,7 @@ class TokenInfoIntegrationTest {
 
             infoQuery.setQueryPayment(cost).execute(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -210,6 +221,7 @@ class TokenInfoIntegrationTest {
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
+                .setAdminKey(testEnv.operatorKey)
                 .execute(testEnv.client);
 
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
@@ -223,7 +235,7 @@ class TokenInfoIntegrationTest {
 
             infoQuery.setQueryPayment(cost).execute(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -238,6 +250,7 @@ class TokenInfoIntegrationTest {
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
+                .setAdminKey(testEnv.operatorKey)
                 .execute(testEnv.client);
 
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
@@ -255,7 +268,7 @@ class TokenInfoIntegrationTest {
 
             assertEquals(error.getMessage(), "com.hedera.hashgraph.sdk.MaxQueryPaymentExceededException: cost for TokenInfoQuery, of "+cost.toString()+", without explicit payment is greater than the maximum allowed payment of 1 tℏ");
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -270,6 +283,7 @@ class TokenInfoIntegrationTest {
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
+                .setAdminKey(testEnv.operatorKey)
                 .execute(testEnv.client);
 
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
@@ -287,7 +301,7 @@ class TokenInfoIntegrationTest {
 
             assertEquals(error.status.toString(), "INSUFFICIENT_TX_FEE");
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenInfoIntegrationTest.java
@@ -19,7 +19,7 @@ class TokenInfoIntegrationTest {
     @DisplayName("Can query token info when all keys are different")
     void canQueryTokenInfoWhenAllKeysAreDifferent() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key1 = PrivateKey.generate();
             var key2 = PrivateKey.generate();
@@ -28,7 +28,7 @@ class TokenInfoIntegrationTest {
             var key5 = PrivateKey.generate();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -47,7 +47,7 @@ class TokenInfoIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             var info = new TokenInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .execute(testEnv.client);
 
@@ -88,10 +88,10 @@ class TokenInfoIntegrationTest {
     @DisplayName("Can query token with minimal properties")
     void canQueryTokenInfoWhenTokenIsCreatedWithMinimalProperties() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -100,7 +100,7 @@ class TokenInfoIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             var info = new TokenInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .execute(testEnv.client);
 
@@ -131,10 +131,10 @@ class TokenInfoIntegrationTest {
     @DisplayName("Can query NFT")
     void canQueryNfts() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)
@@ -148,7 +148,7 @@ class TokenInfoIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             var mintReceipt = new TokenMintTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMetadata(NftMetadataGenerator.generate((byte)10))
                 .execute(testEnv.client)
@@ -157,7 +157,7 @@ class TokenInfoIntegrationTest {
             assertEquals(mintReceipt.serials.size(), 10);
 
             var info = new TokenInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .execute(testEnv.client);
 
@@ -186,10 +186,10 @@ class TokenInfoIntegrationTest {
     @DisplayName("Get cost of token info query")
     void getCostQueryTokenInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -199,7 +199,7 @@ class TokenInfoIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             var infoQuery = new TokenInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId);
 
             var cost = infoQuery.getCost(testEnv.client);
@@ -214,10 +214,10 @@ class TokenInfoIntegrationTest {
     @DisplayName("Get cost of token info query, with big max")
     void getCostBigMaxQueryTokenInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -227,7 +227,7 @@ class TokenInfoIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             var infoQuery = new TokenInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMaxQueryPayment(new Hbar(1000));
 
@@ -243,10 +243,10 @@ class TokenInfoIntegrationTest {
     @DisplayName("Can query token info when all keys are different")
     void getCostSmallMaxTokenInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -256,7 +256,7 @@ class TokenInfoIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             var infoQuery = new TokenInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
@@ -276,10 +276,10 @@ class TokenInfoIntegrationTest {
     @DisplayName("Throws insufficient transaction fee error")
     void getCostInsufficientTxFeeQueryTokenInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)
@@ -289,7 +289,7 @@ class TokenInfoIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             var infoQuery = new TokenInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMaxQueryPayment(new Hbar(1000));
 

--- a/sdk/src/integrationTest/java/TokenInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenInfoIntegrationTest.java
@@ -28,7 +28,6 @@ class TokenInfoIntegrationTest {
             var key5 = PrivateKey.generate();
 
             var response = new TokenCreateTransaction()
-                //setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)

--- a/sdk/src/integrationTest/java/TokenMintIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenMintIntegrationTest.java
@@ -17,16 +17,6 @@ class TokenMintIntegrationTest {
         assertDoesNotThrow(() -> {
             var testEnv = new IntegrationTestEnv();
 
-            var key = PrivateKey.generate();
-
-            var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setKey(key)
-                .setInitialBalance(new Hbar(1))
-                .execute(testEnv.client);
-
-            Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
-
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
                     .setNodeAccountIds(testEnv.nodeAccountIds)
@@ -55,7 +45,7 @@ class TokenMintIntegrationTest {
 
             assertEquals(receipt.totalSupply, 1000000 + 10);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -103,16 +93,6 @@ class TokenMintIntegrationTest {
         assertDoesNotThrow(() -> {
             var testEnv = new IntegrationTestEnv();
 
-            var key = PrivateKey.generate();
-
-            var response = new AccountCreateTransaction()
-                .setKey(key)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setInitialBalance(new Hbar(1))
-                .execute(testEnv.client);
-
-            Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
-
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenMintTransaction()
                     .setNodeAccountIds(testEnv.nodeAccountIds)
@@ -123,7 +103,7 @@ class TokenMintIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -132,16 +112,6 @@ class TokenMintIntegrationTest {
     void cannotMintTokensWhenAmountIsNotSet() {
         assertDoesNotThrow(() -> {
             var testEnv = new IntegrationTestEnv();
-
-            var key = PrivateKey.generate();
-
-            var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setKey(key)
-                .setInitialBalance(new Hbar(1))
-                .execute(testEnv.client);
-
-            Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
@@ -172,7 +142,7 @@ class TokenMintIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_MINT_AMOUNT.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -222,7 +192,7 @@ class TokenMintIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_SIGNATURE.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 
@@ -232,16 +202,6 @@ class TokenMintIntegrationTest {
     void canMintNfts() {
         assertDoesNotThrow(() -> {
             var testEnv = new IntegrationTestEnv();
-
-            var key = PrivateKey.generate();
-
-            var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setKey(key)
-                .setInitialBalance(new Hbar(1))
-                .execute(testEnv.client);
-
-            Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
@@ -270,7 +230,7 @@ class TokenMintIntegrationTest {
 
             assertEquals(receipt.serials.size(), 10);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenMintIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenMintIntegrationTest.java
@@ -52,11 +52,10 @@ class TokenMintIntegrationTest {
     @DisplayName("Cannot mint more tokens than max supply")
     void cannotMintMoreThanMaxSupply() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setSupplyType(TokenSupplyType.FINITE)
@@ -72,7 +71,6 @@ class TokenMintIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenMintTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .setAmount(6)
                     .execute(testEnv.client)
@@ -81,7 +79,7 @@ class TokenMintIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.TOKEN_MAX_SUPPLY_REACHED.toString()));
 
-            testEnv.client.close();
+            testEnv.close(tokenId);
         });
     }
 

--- a/sdk/src/integrationTest/java/TokenMintIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenMintIntegrationTest.java
@@ -15,11 +15,11 @@ class TokenMintIntegrationTest {
     @DisplayName("Can mint tokens")
     void canMintTokens() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -37,7 +37,7 @@ class TokenMintIntegrationTest {
             );
 
             var receipt = new TokenMintTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAmount(10)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
@@ -91,11 +91,11 @@ class TokenMintIntegrationTest {
     @DisplayName("Cannot mint tokens when token ID is not set")
     void cannotMintTokensWhenTokenIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenMintTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAmount(10)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -111,11 +111,11 @@ class TokenMintIntegrationTest {
     @DisplayName("Cannot mint tokens when amount is not set")
     void cannotMintTokensWhenAmountIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -134,7 +134,7 @@ class TokenMintIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenMintTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -150,12 +150,12 @@ class TokenMintIntegrationTest {
     @DisplayName("Cannot mint tokens when supply key does not sign transaction")
     void cannotMintTokensWhenSupplyKeyDoesNotSignTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -164,7 +164,7 @@ class TokenMintIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -183,7 +183,7 @@ class TokenMintIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenMintTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .setAmount(10)
                     .execute(testEnv.client)
@@ -201,11 +201,11 @@ class TokenMintIntegrationTest {
     @DisplayName("Can mint NFTs")
     void canMintNfts() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)
@@ -222,7 +222,7 @@ class TokenMintIntegrationTest {
             );
 
             var receipt = new TokenMintTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMetadata(NftMetadataGenerator.generate((byte)10))
                 .setTokenId(tokenId)
                 .execute(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenMintIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenMintIntegrationTest.java
@@ -15,7 +15,7 @@ class TokenMintIntegrationTest {
     @DisplayName("Can mint tokens")
     void canMintTokens() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
@@ -43,7 +43,7 @@ class TokenMintIntegrationTest {
 
             assertEquals(receipt.totalSupply, 1000000 + 10);
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -89,7 +89,7 @@ class TokenMintIntegrationTest {
     @DisplayName("Cannot mint tokens when token ID is not set")
     void cannotMintTokensWhenTokenIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenMintTransaction()
@@ -100,7 +100,7 @@ class TokenMintIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -108,7 +108,7 @@ class TokenMintIntegrationTest {
     @DisplayName("Cannot mint tokens when amount is not set")
     void cannotMintTokensWhenAmountIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
@@ -137,7 +137,7 @@ class TokenMintIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_MINT_AMOUNT.toString()));
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -145,7 +145,7 @@ class TokenMintIntegrationTest {
     @DisplayName("Cannot mint tokens when supply key does not sign transaction")
     void cannotMintTokensWhenSupplyKeyDoesNotSignTransaction() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -184,7 +184,7 @@ class TokenMintIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_SIGNATURE.toString()));
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 
@@ -193,7 +193,7 @@ class TokenMintIntegrationTest {
     @DisplayName("Can mint NFTs")
     void canMintNfts() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
@@ -220,7 +220,7 @@ class TokenMintIntegrationTest {
 
             assertEquals(receipt.serials.size(), 10);
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenMintIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenMintIntegrationTest.java
@@ -19,7 +19,6 @@ class TokenMintIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -37,7 +36,6 @@ class TokenMintIntegrationTest {
             );
 
             var receipt = new TokenMintTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAmount(10)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
@@ -95,7 +93,6 @@ class TokenMintIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenMintTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAmount(10)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -115,7 +112,6 @@ class TokenMintIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -134,7 +130,6 @@ class TokenMintIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenMintTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
@@ -155,7 +150,6 @@ class TokenMintIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -164,7 +158,6 @@ class TokenMintIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -183,7 +176,6 @@ class TokenMintIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenMintTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .setAmount(10)
                     .execute(testEnv.client)
@@ -205,7 +197,6 @@ class TokenMintIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)
@@ -222,7 +213,6 @@ class TokenMintIntegrationTest {
             );
 
             var receipt = new TokenMintTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMetadata(NftMetadataGenerator.generate((byte)10))
                 .setTokenId(tokenId)
                 .execute(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenNftInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenNftInfoIntegrationTest.java
@@ -20,7 +20,6 @@ class TokenNftInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var createReceipt = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)
@@ -39,7 +38,6 @@ class TokenNftInfoIntegrationTest {
             byte[] metadata = {50};
 
             var mintReceipt = new TokenMintTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .addMetadata(metadata)
                 .execute(testEnv.client)
@@ -48,7 +46,6 @@ class TokenNftInfoIntegrationTest {
             var nftId = tokenId.nft(mintReceipt.serials.get(0));
 
             var nftInfos = new TokenNftInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .byNftId(nftId)
                 .execute(testEnv.client);
 
@@ -68,7 +65,6 @@ class TokenNftInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var createReceipt = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)
@@ -87,14 +83,12 @@ class TokenNftInfoIntegrationTest {
             List<byte[]> metadatas = NftMetadataGenerator.generate((byte)10);
 
             var mintReceipt = new TokenMintTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMetadata(metadatas)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             var nftInfos = new TokenNftInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .byAccountId(testEnv.operatorId)
                 .setEnd(10)
                 .execute(testEnv.client);
@@ -120,7 +114,6 @@ class TokenNftInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var createReceipt = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)
@@ -139,14 +132,12 @@ class TokenNftInfoIntegrationTest {
             List<byte[]> metadatas = NftMetadataGenerator.generate((byte)10);
 
             var mintReceipt = new TokenMintTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMetadata(metadatas)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             var nftInfos = new TokenNftInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .byTokenId(tokenId)
                 .setEnd(10)
                 .execute(testEnv.client);

--- a/sdk/src/integrationTest/java/TokenNftInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenNftInfoIntegrationTest.java
@@ -17,10 +17,10 @@ class TokenNftInfoIntegrationTest {
     @DisplayName("Can query NFT info by NftId")
     void canQueryNftInfoByNftId() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var createReceipt = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)
@@ -39,7 +39,7 @@ class TokenNftInfoIntegrationTest {
             byte[] metadata = {50};
 
             var mintReceipt = new TokenMintTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .addMetadata(metadata)
                 .execute(testEnv.client)
@@ -48,7 +48,7 @@ class TokenNftInfoIntegrationTest {
             var nftId = tokenId.nft(mintReceipt.serials.get(0));
 
             var nftInfos = new TokenNftInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .byNftId(nftId)
                 .execute(testEnv.client);
 
@@ -65,10 +65,10 @@ class TokenNftInfoIntegrationTest {
     @DisplayName("Can query NFT info by AccountId")
     void canQueryNftInfoByAccountId() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var createReceipt = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)
@@ -87,14 +87,14 @@ class TokenNftInfoIntegrationTest {
             List<byte[]> metadatas = NftMetadataGenerator.generate((byte)10);
 
             var mintReceipt = new TokenMintTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMetadata(metadatas)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             var nftInfos = new TokenNftInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .byAccountId(testEnv.operatorId)
                 .setEnd(10)
                 .execute(testEnv.client);
@@ -117,10 +117,10 @@ class TokenNftInfoIntegrationTest {
     @DisplayName("Can query NFT info by TokenId")
     void canQueryNftInfoByTokenId() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var createReceipt = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)
@@ -139,14 +139,14 @@ class TokenNftInfoIntegrationTest {
             List<byte[]> metadatas = NftMetadataGenerator.generate((byte)10);
 
             var mintReceipt = new TokenMintTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMetadata(metadatas)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             var nftInfos = new TokenNftInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .byTokenId(tokenId)
                 .setEnd(10)
                 .execute(testEnv.client);

--- a/sdk/src/integrationTest/java/TokenNftInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenNftInfoIntegrationTest.java
@@ -17,7 +17,7 @@ class TokenNftInfoIntegrationTest {
     @DisplayName("Can query NFT info by NftId")
     void canQueryNftInfoByNftId() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var createReceipt = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -54,7 +54,7 @@ class TokenNftInfoIntegrationTest {
             assertEquals(nftInfos.get(0).accountId, testEnv.operatorId);
             assertEquals(nftInfos.get(0).metadata[0], 50);
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -62,7 +62,7 @@ class TokenNftInfoIntegrationTest {
     @DisplayName("Can query NFT info by AccountId")
     void canQueryNftInfoByAccountId() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var createReceipt = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -103,7 +103,7 @@ class TokenNftInfoIntegrationTest {
                 assertEquals(info.accountId, testEnv.operatorId);
             }
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -111,7 +111,7 @@ class TokenNftInfoIntegrationTest {
     @DisplayName("Can query NFT info by TokenId")
     void canQueryNftInfoByTokenId() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var createReceipt = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -152,7 +152,7 @@ class TokenNftInfoIntegrationTest {
                 assertEquals(info.accountId, testEnv.operatorId);
             }
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenNftInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenNftInfoIntegrationTest.java
@@ -35,7 +35,7 @@ class TokenNftInfoIntegrationTest {
                 .getReceipt(testEnv.client);
 
             var tokenId = Objects.requireNonNull(createReceipt.tokenId);
-            
+
             byte[] metadata = {50};
 
             var mintReceipt = new TokenMintTransaction()
@@ -51,13 +51,13 @@ class TokenNftInfoIntegrationTest {
                 .setNodeAccountIds(testEnv.nodeAccountIds)
                 .byNftId(nftId)
                 .execute(testEnv.client);
-                
+
             assertEquals(nftInfos.size(), 1);
             assertEquals(nftInfos.get(0).nftId, nftId);
             assertEquals(nftInfos.get(0).accountId, testEnv.operatorId);
             assertEquals(nftInfos.get(0).metadata[0], 50);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -85,7 +85,7 @@ class TokenNftInfoIntegrationTest {
             var tokenId = Objects.requireNonNull(createReceipt.tokenId);
 
             List<byte[]> metadatas = NftMetadataGenerator.generate((byte)10);
-            
+
             var mintReceipt = new TokenMintTransaction()
                 .setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
@@ -98,7 +98,7 @@ class TokenNftInfoIntegrationTest {
                 .byAccountId(testEnv.operatorId)
                 .setEnd(10)
                 .execute(testEnv.client);
-            
+
             assertEquals(nftInfos.size(), 10);
 
             var serials = new ArrayList<Long>(mintReceipt.serials);
@@ -109,7 +109,7 @@ class TokenNftInfoIntegrationTest {
                 assertEquals(info.accountId, testEnv.operatorId);
             }
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -137,7 +137,7 @@ class TokenNftInfoIntegrationTest {
             var tokenId = Objects.requireNonNull(createReceipt.tokenId);
 
             List<byte[]> metadatas = NftMetadataGenerator.generate((byte)10);
-            
+
             var mintReceipt = new TokenMintTransaction()
                 .setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
@@ -150,7 +150,7 @@ class TokenNftInfoIntegrationTest {
                 .byTokenId(tokenId)
                 .setEnd(10)
                 .execute(testEnv.client);
-            
+
             assertEquals(nftInfos.size(), 10);
 
             var serials = new ArrayList<Long>(mintReceipt.serials);
@@ -161,7 +161,7 @@ class TokenNftInfoIntegrationTest {
                 assertEquals(info.accountId, testEnv.operatorId);
             }
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenNftTransferIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenNftTransferIntegrationTest.java
@@ -18,7 +18,7 @@ class TokenNftTransferIntegrationTest {
     @Test
     void test() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -81,7 +81,7 @@ class TokenNftTransferIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenNftTransferIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenNftTransferIntegrationTest.java
@@ -23,7 +23,6 @@ class TokenNftTransferIntegrationTest {
             var key = PrivateKey.generate();
 
             TransactionResponse response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -32,7 +31,6 @@ class TokenNftTransferIntegrationTest {
             assertNotNull(accountId);
 
             response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)
@@ -49,14 +47,12 @@ class TokenNftTransferIntegrationTest {
             assertNotNull(tokenId);
 
             var mintReceipt = new TokenMintTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMetadata(NftMetadataGenerator.generate((byte)10))
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TokenAssociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -66,7 +62,6 @@ class TokenNftTransferIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenGrantKycTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
@@ -74,14 +69,12 @@ class TokenNftTransferIntegrationTest {
 
             var serialsToTransfer = new ArrayList<Long>(mintReceipt.serials.subList(0, 4));
             var transfer = new TransferTransaction();
-                //.setNodeAccountIds(testEnv.nodeAccountIds);
             for(var serial : serialsToTransfer) {
                 transfer.addNftTransfer(tokenId.nft(serial), testEnv.operatorId, accountId);
             }
             transfer.execute(testEnv.client).getReceipt(testEnv.client);
 
             new TokenWipeTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setAccountId(accountId)
                 .setSerials(serialsToTransfer)

--- a/sdk/src/integrationTest/java/TokenNftTransferIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenNftTransferIntegrationTest.java
@@ -18,12 +18,12 @@ class TokenNftTransferIntegrationTest {
     @Test
     void test() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             TransactionResponse response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -32,7 +32,7 @@ class TokenNftTransferIntegrationTest {
             assertNotNull(accountId);
 
             response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)
@@ -49,14 +49,14 @@ class TokenNftTransferIntegrationTest {
             assertNotNull(tokenId);
 
             var mintReceipt = new TokenMintTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMetadata(NftMetadataGenerator.generate((byte)10))
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TokenAssociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -66,22 +66,22 @@ class TokenNftTransferIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenGrantKycTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             var serialsToTransfer = new ArrayList<Long>(mintReceipt.serials.subList(0, 4));
-            var transfer = new TransferTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds);
+            var transfer = new TransferTransaction();
+                //.setNodeAccountIds(testEnv.nodeAccountIds);
             for(var serial : serialsToTransfer) {
                 transfer.addNftTransfer(tokenId.nft(serial), testEnv.operatorId, accountId);
             }
             transfer.execute(testEnv.client).getReceipt(testEnv.client);
 
             new TokenWipeTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setAccountId(accountId)
                 .setSerials(serialsToTransfer)

--- a/sdk/src/integrationTest/java/TokenRevokeKycIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenRevokeKycIntegrationTest.java
@@ -19,7 +19,6 @@ class TokenRevokeKycIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -28,7 +27,6 @@ class TokenRevokeKycIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -46,7 +44,6 @@ class TokenRevokeKycIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -55,7 +52,6 @@ class TokenRevokeKycIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenRevokeKycTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .freezeWith(testEnv.client)
@@ -76,7 +72,6 @@ class TokenRevokeKycIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -85,7 +80,6 @@ class TokenRevokeKycIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenRevokeKycTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .freezeWith(testEnv.client)
                     .sign(key)
@@ -108,7 +102,6 @@ class TokenRevokeKycIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -126,7 +119,6 @@ class TokenRevokeKycIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenRevokeKycTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .freezeWith(testEnv.client)
                     .sign(key)
@@ -149,7 +141,6 @@ class TokenRevokeKycIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -158,7 +149,6 @@ class TokenRevokeKycIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -177,7 +167,6 @@ class TokenRevokeKycIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenRevokeKycTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .setTokenId(tokenId)
                     .freezeWith(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenRevokeKycIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenRevokeKycIntegrationTest.java
@@ -14,7 +14,7 @@ class TokenRevokeKycIntegrationTest {
     @DisplayName("Can revoke kyc to account with token")
     void canRevokeKycAccountWithToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -59,7 +59,7 @@ class TokenRevokeKycIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 
@@ -67,7 +67,7 @@ class TokenRevokeKycIntegrationTest {
     @DisplayName("Cannot revoke kyc to account on token when token ID is not set")
     void cannotRevokeKycToAccountOnTokenWhenTokenIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -89,7 +89,7 @@ class TokenRevokeKycIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 
@@ -97,7 +97,7 @@ class TokenRevokeKycIntegrationTest {
     @DisplayName("Cannot revoke kyc to account on token when account ID is not set")
     void cannotRevokeKycToAccountOnTokenWhenAccountIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -128,7 +128,7 @@ class TokenRevokeKycIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -136,7 +136,7 @@ class TokenRevokeKycIntegrationTest {
     @DisplayName("Cannot revoke kyc to account on token when account was not associated with")
     void cannotRevokeKycToAccountOnTokenWhenAccountWasNotAssociatedWith() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -177,7 +177,7 @@ class TokenRevokeKycIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.toString()));
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenRevokeKycIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenRevokeKycIntegrationTest.java
@@ -63,7 +63,7 @@ class TokenRevokeKycIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 
@@ -95,7 +95,7 @@ class TokenRevokeKycIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 
@@ -136,7 +136,7 @@ class TokenRevokeKycIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -188,7 +188,7 @@ class TokenRevokeKycIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenRevokeKycIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenRevokeKycIntegrationTest.java
@@ -14,12 +14,12 @@ class TokenRevokeKycIntegrationTest {
     @DisplayName("Can revoke kyc to account with token")
     void canRevokeKycAccountWithToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -28,7 +28,7 @@ class TokenRevokeKycIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -46,7 +46,7 @@ class TokenRevokeKycIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -55,7 +55,7 @@ class TokenRevokeKycIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenRevokeKycTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .freezeWith(testEnv.client)
@@ -71,12 +71,12 @@ class TokenRevokeKycIntegrationTest {
     @DisplayName("Cannot revoke kyc to account on token when token ID is not set")
     void cannotRevokeKycToAccountOnTokenWhenTokenIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -85,7 +85,7 @@ class TokenRevokeKycIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenRevokeKycTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .freezeWith(testEnv.client)
                     .sign(key)
@@ -103,12 +103,12 @@ class TokenRevokeKycIntegrationTest {
     @DisplayName("Cannot revoke kyc to account on token when account ID is not set")
     void cannotRevokeKycToAccountOnTokenWhenAccountIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -126,7 +126,7 @@ class TokenRevokeKycIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenRevokeKycTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .freezeWith(testEnv.client)
                     .sign(key)
@@ -144,12 +144,12 @@ class TokenRevokeKycIntegrationTest {
     @DisplayName("Cannot revoke kyc to account on token when account was not associated with")
     void cannotRevokeKycToAccountOnTokenWhenAccountWasNotAssociatedWith() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -158,7 +158,7 @@ class TokenRevokeKycIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -177,7 +177,7 @@ class TokenRevokeKycIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenRevokeKycTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .setTokenId(tokenId)
                     .freezeWith(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenTransferIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenTransferIntegrationTest.java
@@ -16,7 +16,6 @@ class TokenTransferIntegrationTest {
             var key = PrivateKey.generate();
 
             TransactionResponse response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -25,7 +24,6 @@ class TokenTransferIntegrationTest {
             assertNotNull(accountId);
 
             response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -43,7 +41,6 @@ class TokenTransferIntegrationTest {
             assertNotNull(tokenId);
 
             new TokenAssociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -53,14 +50,12 @@ class TokenTransferIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenGrantKycTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TransferTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .addTokenTransfer(tokenId, testEnv.operatorId, -10)
                 .addTokenTransfer(tokenId, accountId, 10)
                 .execute(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenTransferIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenTransferIntegrationTest.java
@@ -11,12 +11,12 @@ class TokenTransferIntegrationTest {
     @DisplayName("Can transfer tokens")
     void tokenTransferTest() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             TransactionResponse response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -25,7 +25,7 @@ class TokenTransferIntegrationTest {
             assertNotNull(accountId);
 
             response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -43,7 +43,7 @@ class TokenTransferIntegrationTest {
             assertNotNull(tokenId);
 
             new TokenAssociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -53,14 +53,14 @@ class TokenTransferIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenGrantKycTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TransferTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .addTokenTransfer(tokenId, testEnv.operatorId, -10)
                 .addTokenTransfer(tokenId, accountId, 10)
                 .execute(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenTransferIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenTransferIntegrationTest.java
@@ -11,7 +11,7 @@ class TokenTransferIntegrationTest {
     @DisplayName("Can transfer tokens")
     void tokenTransferTest() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -61,7 +61,7 @@ class TokenTransferIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 

--- a/sdk/src/integrationTest/java/TokenUnfreezeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenUnfreezeIntegrationTest.java
@@ -14,12 +14,12 @@ class TokenUnfreezeIntegrationTest {
     @DisplayName("Can unfreeze account with token")
     void canUnfreezeAccountWithToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -28,7 +28,7 @@ class TokenUnfreezeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -46,7 +46,7 @@ class TokenUnfreezeIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -55,7 +55,7 @@ class TokenUnfreezeIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenUnfreezeTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .freezeWith(testEnv.client)
@@ -71,12 +71,12 @@ class TokenUnfreezeIntegrationTest {
     @DisplayName("Cannot unfreeze account on token when token ID is not set")
     void cannotUnfreezeAccountOnTokenWhenTokenIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -85,7 +85,7 @@ class TokenUnfreezeIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenUnfreezeTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .freezeWith(testEnv.client)
                     .sign(key)
@@ -103,12 +103,12 @@ class TokenUnfreezeIntegrationTest {
     @DisplayName("Cannot unfreeze account on token when account ID is not set")
     void cannotUnfreezeAccountOnTokenWhenAccountIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -126,7 +126,7 @@ class TokenUnfreezeIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenUnfreezeTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .freezeWith(testEnv.client)
                     .sign(key)
@@ -144,12 +144,12 @@ class TokenUnfreezeIntegrationTest {
     @DisplayName("Cannot unfreeze account on token when account was not associated with")
     void cannotUnfreezeAccountOnTokenWhenAccountWasNotAssociatedWith() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -158,7 +158,7 @@ class TokenUnfreezeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -177,7 +177,7 @@ class TokenUnfreezeIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenUnfreezeTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .setTokenId(tokenId)
                     .freezeWith(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenUnfreezeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenUnfreezeIntegrationTest.java
@@ -63,7 +63,7 @@ class TokenUnfreezeIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 
@@ -95,7 +95,7 @@ class TokenUnfreezeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 
@@ -136,7 +136,7 @@ class TokenUnfreezeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -188,7 +188,7 @@ class TokenUnfreezeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenUnfreezeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenUnfreezeIntegrationTest.java
@@ -19,7 +19,6 @@ class TokenUnfreezeIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -28,7 +27,6 @@ class TokenUnfreezeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -46,7 +44,6 @@ class TokenUnfreezeIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -55,7 +52,6 @@ class TokenUnfreezeIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenUnfreezeTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .freezeWith(testEnv.client)
@@ -76,7 +72,6 @@ class TokenUnfreezeIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -85,7 +80,6 @@ class TokenUnfreezeIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenUnfreezeTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .freezeWith(testEnv.client)
                     .sign(key)
@@ -108,7 +102,6 @@ class TokenUnfreezeIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -126,7 +119,6 @@ class TokenUnfreezeIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenUnfreezeTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .freezeWith(testEnv.client)
                     .sign(key)
@@ -149,7 +141,6 @@ class TokenUnfreezeIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -158,7 +149,6 @@ class TokenUnfreezeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -177,7 +167,6 @@ class TokenUnfreezeIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TokenUnfreezeTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .setTokenId(tokenId)
                     .freezeWith(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenUnfreezeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenUnfreezeIntegrationTest.java
@@ -14,7 +14,7 @@ class TokenUnfreezeIntegrationTest {
     @DisplayName("Can unfreeze account with token")
     void canUnfreezeAccountWithToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -59,7 +59,7 @@ class TokenUnfreezeIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 
@@ -67,7 +67,7 @@ class TokenUnfreezeIntegrationTest {
     @DisplayName("Cannot unfreeze account on token when token ID is not set")
     void cannotUnfreezeAccountOnTokenWhenTokenIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -89,7 +89,7 @@ class TokenUnfreezeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 
@@ -97,7 +97,7 @@ class TokenUnfreezeIntegrationTest {
     @DisplayName("Cannot unfreeze account on token when account ID is not set")
     void cannotUnfreezeAccountOnTokenWhenAccountIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -128,7 +128,7 @@ class TokenUnfreezeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -136,7 +136,7 @@ class TokenUnfreezeIntegrationTest {
     @DisplayName("Cannot unfreeze account on token when account was not associated with")
     void cannotUnfreezeAccountOnTokenWhenAccountWasNotAssociatedWith() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -177,7 +177,7 @@ class TokenUnfreezeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.toString()));
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenUpdateIntegrationTest.java
@@ -99,7 +99,7 @@ class TokenUpdateIntegrationTest {
     @DisplayName("Cannot update immutable token")
     void cannotUpdateImmutableToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount(5);
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -121,7 +121,7 @@ class TokenUpdateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.TOKEN_IS_IMMUTABLE.toString()));
 
-            // TODO: I think we're going to lose this account
+            // we lose this IntegrationTestEnv throwaway account
             testEnv.client.close();
         });
     }

--- a/sdk/src/integrationTest/java/TokenUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenUpdateIntegrationTest.java
@@ -18,10 +18,10 @@ class TokenUpdateIntegrationTest {
     @DisplayName("Can update token")
     void canUpdateToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -38,7 +38,7 @@ class TokenUpdateIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             @Var var info = new TokenInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .execute(testEnv.client);
 
@@ -52,11 +52,11 @@ class TokenUpdateIntegrationTest {
             assertNotNull(info.wipeKey);
             assertNotNull(info.kycKey);
             assertNotNull(info.supplyKey);
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.adminKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.freezeKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.wipeKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.kycKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.supplyKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.adminKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.freezeKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.wipeKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.kycKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.supplyKey.toString());
             assertNotNull(info.defaultFreezeStatus);
             assertFalse(info.defaultFreezeStatus);
             assertNotNull(info.defaultKycStatus);
@@ -70,7 +70,7 @@ class TokenUpdateIntegrationTest {
                 .getReceipt(testEnv.client);
 
             info = new TokenInfoQuery()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .execute(testEnv.client);
 
@@ -84,11 +84,11 @@ class TokenUpdateIntegrationTest {
             assertNotNull(info.wipeKey);
             assertNotNull(info.kycKey);
             assertNotNull(info.supplyKey);
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.adminKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.freezeKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.wipeKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.kycKey.toString());
-            assertEquals(testEnv.operatorKey.getPublicKey().toString(), info.supplyKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.adminKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.freezeKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.wipeKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.kycKey.toString());
+            assertEquals(testEnv.operatorKey.toString(), info.supplyKey.toString());
             assertNotNull(info.defaultFreezeStatus);
             assertFalse(info.defaultFreezeStatus);
             assertNotNull(info.defaultKycStatus);
@@ -102,10 +102,10 @@ class TokenUpdateIntegrationTest {
     @DisplayName("Cannot update immutable token")
     void cannotUpdateImmutableToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)

--- a/sdk/src/integrationTest/java/TokenUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenUpdateIntegrationTest.java
@@ -21,7 +21,6 @@ class TokenUpdateIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setDecimals(3)
@@ -38,7 +37,6 @@ class TokenUpdateIntegrationTest {
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
             @Var var info = new TokenInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .execute(testEnv.client);
 
@@ -70,7 +68,6 @@ class TokenUpdateIntegrationTest {
                 .getReceipt(testEnv.client);
 
             info = new TokenInfoQuery()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .execute(testEnv.client);
 
@@ -105,7 +102,6 @@ class TokenUpdateIntegrationTest {
             var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var response = new TokenCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenName("ffff")
                 .setTokenSymbol("F")
                 .setTreasuryAccountId(testEnv.operatorId)

--- a/sdk/src/integrationTest/java/TokenUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenUpdateIntegrationTest.java
@@ -18,7 +18,7 @@ class TokenUpdateIntegrationTest {
     @DisplayName("Can update token")
     void canUpdateToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")
@@ -91,7 +91,7 @@ class TokenUpdateIntegrationTest {
             assertNotNull(info.defaultKycStatus);
             assertFalse(info.defaultKycStatus);
 
-            testEnv.cleanUpAndClose(tokenId);
+            testEnv.close(tokenId);
         });
     }
 
@@ -99,7 +99,7 @@ class TokenUpdateIntegrationTest {
     @DisplayName("Cannot update immutable token")
     void cannotUpdateImmutableToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount(5);
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount(new Hbar(5));
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")

--- a/sdk/src/integrationTest/java/TokenUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenUpdateIntegrationTest.java
@@ -94,7 +94,7 @@ class TokenUpdateIntegrationTest {
             assertNotNull(info.defaultKycStatus);
             assertFalse(info.defaultKycStatus);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId);
         });
     }
 
@@ -125,6 +125,7 @@ class TokenUpdateIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.TOKEN_IS_IMMUTABLE.toString()));
 
+            // TODO: I think we're going to lose this account
             testEnv.client.close();
         });
     }

--- a/sdk/src/integrationTest/java/TokenUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenUpdateIntegrationTest.java
@@ -99,7 +99,7 @@ class TokenUpdateIntegrationTest {
     @DisplayName("Cannot update immutable token")
     void cannotUpdateImmutableToken() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount(new Hbar(5));
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount(new Hbar(10));
 
             var response = new TokenCreateTransaction()
                 .setTokenName("ffff")

--- a/sdk/src/integrationTest/java/TokenWipeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenWipeIntegrationTest.java
@@ -20,7 +20,6 @@ class TokenWipeIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -29,7 +28,6 @@ class TokenWipeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -47,7 +45,6 @@ class TokenWipeIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -56,21 +53,18 @@ class TokenWipeIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenGrantKycTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TransferTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .addTokenTransfer(tokenId, testEnv.operatorId, -10)
                 .addTokenTransfer(tokenId, accountId, 10)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TokenWipeTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setAccountId(accountId)
                 .setAmount(10)
@@ -91,7 +85,6 @@ class TokenWipeIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -100,7 +93,6 @@ class TokenWipeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)
@@ -117,14 +109,12 @@ class TokenWipeIntegrationTest {
             );
 
             var mintReceipt = new TokenMintTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMetadata(NftMetadataGenerator.generate((byte)10))
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TokenAssociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -133,7 +123,6 @@ class TokenWipeIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenGrantKycTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
@@ -141,14 +130,12 @@ class TokenWipeIntegrationTest {
 
             var serialsToTransfer = mintReceipt.serials.subList(0, 4);
             var transfer = new TransferTransaction();
-                //.setNodeAccountIds(testEnv.nodeAccountIds);
             for(var serial : serialsToTransfer) {
                 transfer.addNftTransfer(tokenId.nft(serial), testEnv.operatorId, accountId);
             }
             transfer.execute(testEnv.client).getReceipt(testEnv.client);
 
             new TokenWipeTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setAccountId(accountId)
                 .setSerials(serialsToTransfer)
@@ -168,7 +155,6 @@ class TokenWipeIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -177,7 +163,6 @@ class TokenWipeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -195,7 +180,6 @@ class TokenWipeIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -204,14 +188,12 @@ class TokenWipeIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenGrantKycTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TransferTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .addTokenTransfer(tokenId, testEnv.operatorId, -10)
                 .addTokenTransfer(tokenId, accountId, 10)
                 .execute(testEnv.client)
@@ -219,7 +201,6 @@ class TokenWipeIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenWipeTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .setAmount(10)
                     .execute(testEnv.client)
@@ -241,7 +222,6 @@ class TokenWipeIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -250,7 +230,6 @@ class TokenWipeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -268,7 +247,6 @@ class TokenWipeIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -277,14 +255,12 @@ class TokenWipeIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenGrantKycTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TransferTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .addTokenTransfer(tokenId, testEnv.operatorId, -10)
                 .addTokenTransfer(tokenId, accountId, 10)
                 .execute(testEnv.client)
@@ -292,7 +268,6 @@ class TokenWipeIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenWipeTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .setAmount(10)
                     .execute(testEnv.client)
@@ -314,7 +289,6 @@ class TokenWipeIntegrationTest {
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -323,7 +297,6 @@ class TokenWipeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -341,7 +314,6 @@ class TokenWipeIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -350,14 +322,12 @@ class TokenWipeIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenGrantKycTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TransferTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .addTokenTransfer(tokenId, testEnv.operatorId, -10)
                 .addTokenTransfer(tokenId, accountId, 10)
                 .execute(testEnv.client)
@@ -365,7 +335,6 @@ class TokenWipeIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenWipeTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .setAccountId(accountId)
                     .execute(testEnv.client)

--- a/sdk/src/integrationTest/java/TokenWipeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenWipeIntegrationTest.java
@@ -15,7 +15,7 @@ class TokenWipeIntegrationTest {
     @DisplayName("Can wipe accounts balance")
     void canWipeAccountsBalance() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -71,7 +71,7 @@ class TokenWipeIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 
@@ -80,7 +80,7 @@ class TokenWipeIntegrationTest {
     @DisplayName("Can wipe accounts NFTs")
     void canWipeAccountsNfts() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -142,7 +142,7 @@ class TokenWipeIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 
@@ -150,7 +150,7 @@ class TokenWipeIntegrationTest {
     @DisplayName("Cannot wipe accounts balance when account ID is not set")
     void cannotWipeAccountsBalanceWhenAccountIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -209,7 +209,7 @@ class TokenWipeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 
@@ -217,7 +217,7 @@ class TokenWipeIntegrationTest {
     @DisplayName("Cannot wipe accounts balance when token ID is not set")
     void cannotWipeAccountsBalanceWhenTokenIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -276,7 +276,7 @@ class TokenWipeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 
@@ -284,7 +284,7 @@ class TokenWipeIntegrationTest {
     @DisplayName("Cannot wipe accounts balance when amount is not set")
     void cannotWipeAccountsBalanceWhenAmountIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withThrowawayAccount();
+            var testEnv = new IntegrationTestEnv(1).useThrowawayAccount();
 
             var key = PrivateKey.generate();
 
@@ -343,7 +343,7 @@ class TokenWipeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_WIPING_AMOUNT.toString()));
 
-            testEnv.cleanUpAndClose(tokenId, accountId, key);
+            testEnv.close(tokenId, accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenWipeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenWipeIntegrationTest.java
@@ -77,7 +77,7 @@ class TokenWipeIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 
@@ -155,7 +155,7 @@ class TokenWipeIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 
@@ -228,7 +228,7 @@ class TokenWipeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_ACCOUNT_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 
@@ -301,7 +301,7 @@ class TokenWipeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOKEN_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 
@@ -374,7 +374,7 @@ class TokenWipeIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_WIPING_AMOUNT.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose(tokenId, accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TokenWipeIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TokenWipeIntegrationTest.java
@@ -15,12 +15,12 @@ class TokenWipeIntegrationTest {
     @DisplayName("Can wipe accounts balance")
     void canWipeAccountsBalance() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -29,7 +29,7 @@ class TokenWipeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -47,7 +47,7 @@ class TokenWipeIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -56,21 +56,21 @@ class TokenWipeIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenGrantKycTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TransferTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .addTokenTransfer(tokenId, testEnv.operatorId, -10)
                 .addTokenTransfer(tokenId, accountId, 10)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TokenWipeTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setAccountId(accountId)
                 .setAmount(10)
@@ -86,12 +86,12 @@ class TokenWipeIntegrationTest {
     @DisplayName("Can wipe accounts NFTs")
     void canWipeAccountsNfts() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -100,7 +100,7 @@ class TokenWipeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setTokenType(TokenType.NON_FUNGIBLE_UNIQUE)
@@ -117,14 +117,14 @@ class TokenWipeIntegrationTest {
             );
 
             var mintReceipt = new TokenMintTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setMetadata(NftMetadataGenerator.generate((byte)10))
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TokenAssociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -133,22 +133,22 @@ class TokenWipeIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenGrantKycTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             var serialsToTransfer = mintReceipt.serials.subList(0, 4);
-            var transfer = new TransferTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds);
+            var transfer = new TransferTransaction();
+                //.setNodeAccountIds(testEnv.nodeAccountIds);
             for(var serial : serialsToTransfer) {
                 transfer.addNftTransfer(tokenId.nft(serial), testEnv.operatorId, accountId);
             }
             transfer.execute(testEnv.client).getReceipt(testEnv.client);
 
             new TokenWipeTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTokenId(tokenId)
                 .setAccountId(accountId)
                 .setSerials(serialsToTransfer)
@@ -163,12 +163,12 @@ class TokenWipeIntegrationTest {
     @DisplayName("Cannot wipe accounts balance when account ID is not set")
     void cannotWipeAccountsBalanceWhenAccountIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -177,7 +177,7 @@ class TokenWipeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -195,7 +195,7 @@ class TokenWipeIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -204,14 +204,14 @@ class TokenWipeIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenGrantKycTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TransferTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .addTokenTransfer(tokenId, testEnv.operatorId, -10)
                 .addTokenTransfer(tokenId, accountId, 10)
                 .execute(testEnv.client)
@@ -219,7 +219,7 @@ class TokenWipeIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenWipeTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .setAmount(10)
                     .execute(testEnv.client)
@@ -236,12 +236,12 @@ class TokenWipeIntegrationTest {
     @DisplayName("Cannot wipe accounts balance when token ID is not set")
     void cannotWipeAccountsBalanceWhenTokenIDIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -250,7 +250,7 @@ class TokenWipeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -268,7 +268,7 @@ class TokenWipeIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -277,14 +277,14 @@ class TokenWipeIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenGrantKycTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TransferTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .addTokenTransfer(tokenId, testEnv.operatorId, -10)
                 .addTokenTransfer(tokenId, accountId, 10)
                 .execute(testEnv.client)
@@ -292,7 +292,7 @@ class TokenWipeIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenWipeTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setAccountId(accountId)
                     .setAmount(10)
                     .execute(testEnv.client)
@@ -309,12 +309,12 @@ class TokenWipeIntegrationTest {
     @DisplayName("Cannot wipe accounts balance when amount is not set")
     void cannotWipeAccountsBalanceWhenAmountIsNotSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withThrowawayAccount();
 
             var key = PrivateKey.generate();
 
             var response = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .setInitialBalance(new Hbar(1))
                 .execute(testEnv.client);
@@ -323,7 +323,7 @@ class TokenWipeIntegrationTest {
 
             var tokenId = Objects.requireNonNull(
                 new TokenCreateTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenName("ffff")
                     .setTokenSymbol("F")
                     .setDecimals(3)
@@ -341,7 +341,7 @@ class TokenWipeIntegrationTest {
             );
 
             new TokenAssociateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenIds(Collections.singletonList(tokenId))
                 .freezeWith(testEnv.client)
@@ -350,14 +350,14 @@ class TokenWipeIntegrationTest {
                 .getReceipt(testEnv.client);
 
             new TokenGrantKycTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTokenId(tokenId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
             new TransferTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .addTokenTransfer(tokenId, testEnv.operatorId, -10)
                 .addTokenTransfer(tokenId, accountId, 10)
                 .execute(testEnv.client)
@@ -365,7 +365,7 @@ class TokenWipeIntegrationTest {
 
             var error = assertThrows(PrecheckStatusException.class, () -> {
                 new TokenWipeTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .setTokenId(tokenId)
                     .setAccountId(accountId)
                     .execute(testEnv.client)

--- a/sdk/src/integrationTest/java/TopicCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicCreateIntegrationTest.java
@@ -12,7 +12,7 @@ public class TopicCreateIntegrationTest {
     @DisplayName("Can create topic")
     void canCreateTopic() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TopicCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
@@ -26,7 +26,7 @@ public class TopicCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -34,13 +34,13 @@ public class TopicCreateIntegrationTest {
     @DisplayName("Can create topic with no field set")
     void canCreateTopicWithNoFieldsSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TopicCreateTransaction()
                 .execute(testEnv.client);
             assertNotNull(response.getReceipt(testEnv.client).topicId);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/TopicCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicCreateIntegrationTest.java
@@ -12,10 +12,10 @@ public class TopicCreateIntegrationTest {
     @DisplayName("Can create topic")
     void canCreateTopic() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -35,10 +35,10 @@ public class TopicCreateIntegrationTest {
     @DisplayName("Can create topic with no field set")
     void canCreateTopicWithNoFieldsSet() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
             assertNotNull(response.getReceipt(testEnv.client).topicId);
 

--- a/sdk/src/integrationTest/java/TopicCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicCreateIntegrationTest.java
@@ -27,7 +27,7 @@ public class TopicCreateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -42,7 +42,7 @@ public class TopicCreateIntegrationTest {
                 .execute(testEnv.client);
             assertNotNull(response.getReceipt(testEnv.client).topicId);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/TopicCreateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicCreateIntegrationTest.java
@@ -15,7 +15,6 @@ public class TopicCreateIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -38,7 +37,6 @@ public class TopicCreateIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
             assertNotNull(response.getReceipt(testEnv.client).topicId);
 

--- a/sdk/src/integrationTest/java/TopicDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicDeleteIntegrationTest.java
@@ -28,7 +28,7 @@ public class TopicDeleteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -54,7 +54,7 @@ public class TopicDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.UNAUTHORIZED.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/TopicDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicDeleteIntegrationTest.java
@@ -13,10 +13,10 @@ public class TopicDeleteIntegrationTest {
     @DisplayName("Can delete topic")
     void canDeleteTopic() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -36,10 +36,10 @@ public class TopicDeleteIntegrationTest {
     @DisplayName("Cannot delete immutable topic")
     void cannotDeleteImmutableTopic() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             var topicId = Objects.requireNonNull(response.getReceipt(testEnv.client).topicId);
@@ -47,7 +47,7 @@ public class TopicDeleteIntegrationTest {
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TopicDeleteTransaction()
                     .setTopicId(topicId)
-                    .setNodeAccountIds(testEnv.nodeAccountIds)
+                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });

--- a/sdk/src/integrationTest/java/TopicDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicDeleteIntegrationTest.java
@@ -16,7 +16,6 @@ public class TopicDeleteIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -39,7 +38,6 @@ public class TopicDeleteIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             var topicId = Objects.requireNonNull(response.getReceipt(testEnv.client).topicId);
@@ -47,7 +45,6 @@ public class TopicDeleteIntegrationTest {
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TopicDeleteTransaction()
                     .setTopicId(topicId)
-                    //.setNodeAccountIds(testEnv.nodeAccountIds)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });

--- a/sdk/src/integrationTest/java/TopicDeleteIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicDeleteIntegrationTest.java
@@ -13,7 +13,7 @@ public class TopicDeleteIntegrationTest {
     @DisplayName("Can delete topic")
     void canDeleteTopic() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TopicCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
@@ -27,7 +27,7 @@ public class TopicDeleteIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -35,7 +35,7 @@ public class TopicDeleteIntegrationTest {
     @DisplayName("Cannot delete immutable topic")
     void cannotDeleteImmutableTopic() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TopicCreateTransaction()
                 .execute(testEnv.client);
@@ -51,7 +51,7 @@ public class TopicDeleteIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.UNAUTHORIZED.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/TopicInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicInfoIntegrationTest.java
@@ -15,7 +15,7 @@ public class TopicInfoIntegrationTest {
     @DisplayName("Can query topic info")
     void canQueryTopicInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TopicCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
@@ -35,7 +35,7 @@ public class TopicInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -43,7 +43,7 @@ public class TopicInfoIntegrationTest {
     @DisplayName("Can get cost for topic info query")
     void getCostQueryTopicInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TopicCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
@@ -68,7 +68,7 @@ public class TopicInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -76,7 +76,7 @@ public class TopicInfoIntegrationTest {
     @DisplayName("Can get cost for topic info query")
     void getCostBigMaxQueryTopicInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TopicCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
@@ -102,7 +102,7 @@ public class TopicInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -110,7 +110,7 @@ public class TopicInfoIntegrationTest {
     @DisplayName("Can get cost for topic info query")
     void getCostSmallMaxQueryTopicInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TopicCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
@@ -138,7 +138,7 @@ public class TopicInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -146,7 +146,7 @@ public class TopicInfoIntegrationTest {
     @DisplayName("Can get cost for topic info query")
     void getCostInsufficientTxFeeQueryTopicInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TopicCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
@@ -173,7 +173,7 @@ public class TopicInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 

--- a/sdk/src/integrationTest/java/TopicInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicInfoIntegrationTest.java
@@ -15,10 +15,10 @@ public class TopicInfoIntegrationTest {
     @DisplayName("Can query topic info")
     void canQueryTopicInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -27,13 +27,13 @@ public class TopicInfoIntegrationTest {
 
             var info = new TopicInfoQuery()
                 .setTopicId(topicId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.topicMemo, "[e2e::TopicCreateTransaction]");
 
             new TopicDeleteTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTopicId(topicId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
@@ -46,10 +46,10 @@ public class TopicInfoIntegrationTest {
     @DisplayName("Can get cost for topic info query")
     void getCostQueryTopicInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -57,8 +57,8 @@ public class TopicInfoIntegrationTest {
             var topicId = Objects.requireNonNull(response.getReceipt(testEnv.client).topicId);
 
             var infoQuery = new TopicInfoQuery()
-                .setTopicId(topicId)
-                .setNodeAccountIds(testEnv.nodeAccountIds);
+                .setTopicId(topicId);
+                //.setNodeAccountIds(testEnv.nodeAccountIds);
 
             var cost = infoQuery.getCost(testEnv.client);
 
@@ -69,7 +69,7 @@ public class TopicInfoIntegrationTest {
             assertEquals(info.topicMemo, "[e2e::TopicCreateTransaction]");
 
             new TopicDeleteTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTopicId(topicId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
@@ -82,10 +82,10 @@ public class TopicInfoIntegrationTest {
     @DisplayName("Can get cost for topic info query")
     void getCostBigMaxQueryTopicInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -94,7 +94,7 @@ public class TopicInfoIntegrationTest {
 
             var infoQuery = new TopicInfoQuery()
                 .setTopicId(topicId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(new Hbar(1000));
 
             var cost = infoQuery.getCost(testEnv.client);
@@ -106,7 +106,7 @@ public class TopicInfoIntegrationTest {
             assertEquals(info.topicMemo, "[e2e::TopicCreateTransaction]");
 
             new TopicDeleteTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTopicId(topicId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
@@ -119,10 +119,10 @@ public class TopicInfoIntegrationTest {
     @DisplayName("Can get cost for topic info query")
     void getCostSmallMaxQueryTopicInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -131,7 +131,7 @@ public class TopicInfoIntegrationTest {
 
             var infoQuery = new TopicInfoQuery()
                 .setTopicId(topicId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
             var cost = infoQuery.getCost(testEnv.client);
@@ -145,7 +145,7 @@ public class TopicInfoIntegrationTest {
             assertEquals(error.getMessage(), "com.hedera.hashgraph.sdk.MaxQueryPaymentExceededException: cost for TopicInfoQuery, of "+cost.toString()+", without explicit payment is greater than the maximum allowed payment of 1 tℏ");
 
             new TopicDeleteTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTopicId(topicId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
@@ -158,10 +158,10 @@ public class TopicInfoIntegrationTest {
     @DisplayName("Can get cost for topic info query")
     void getCostInsufficientTxFeeQueryTopicInfo() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -169,8 +169,8 @@ public class TopicInfoIntegrationTest {
             var topicId = Objects.requireNonNull(response.getReceipt(testEnv.client).topicId);
 
             var infoQuery = new TopicInfoQuery()
-                .setTopicId(topicId)
-                .setNodeAccountIds(testEnv.nodeAccountIds);
+                .setTopicId(topicId);
+                //.setNodeAccountIds(testEnv.nodeAccountIds);
 
             var cost = infoQuery.getCost(testEnv.client);
 
@@ -183,7 +183,7 @@ public class TopicInfoIntegrationTest {
             assertEquals(error.status.toString(), "INSUFFICIENT_TX_FEE");
 
             new TopicDeleteTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTopicId(topicId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);

--- a/sdk/src/integrationTest/java/TopicInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicInfoIntegrationTest.java
@@ -18,7 +18,6 @@ public class TopicInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -27,13 +26,11 @@ public class TopicInfoIntegrationTest {
 
             var info = new TopicInfoQuery()
                 .setTopicId(topicId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.topicMemo, "[e2e::TopicCreateTransaction]");
 
             new TopicDeleteTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTopicId(topicId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
@@ -49,7 +46,6 @@ public class TopicInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -58,7 +54,6 @@ public class TopicInfoIntegrationTest {
 
             var infoQuery = new TopicInfoQuery()
                 .setTopicId(topicId);
-                //.setNodeAccountIds(testEnv.nodeAccountIds);
 
             var cost = infoQuery.getCost(testEnv.client);
 
@@ -69,7 +64,6 @@ public class TopicInfoIntegrationTest {
             assertEquals(info.topicMemo, "[e2e::TopicCreateTransaction]");
 
             new TopicDeleteTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTopicId(topicId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
@@ -85,7 +79,6 @@ public class TopicInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -94,7 +87,6 @@ public class TopicInfoIntegrationTest {
 
             var infoQuery = new TopicInfoQuery()
                 .setTopicId(topicId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(new Hbar(1000));
 
             var cost = infoQuery.getCost(testEnv.client);
@@ -106,7 +98,6 @@ public class TopicInfoIntegrationTest {
             assertEquals(info.topicMemo, "[e2e::TopicCreateTransaction]");
 
             new TopicDeleteTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTopicId(topicId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
@@ -122,7 +113,6 @@ public class TopicInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -131,7 +121,6 @@ public class TopicInfoIntegrationTest {
 
             var infoQuery = new TopicInfoQuery()
                 .setTopicId(topicId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setMaxQueryPayment(Hbar.fromTinybars(1));
 
             var cost = infoQuery.getCost(testEnv.client);
@@ -145,7 +134,6 @@ public class TopicInfoIntegrationTest {
             assertEquals(error.getMessage(), "com.hedera.hashgraph.sdk.MaxQueryPaymentExceededException: cost for TopicInfoQuery, of "+cost.toString()+", without explicit payment is greater than the maximum allowed payment of 1 tℏ");
 
             new TopicDeleteTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTopicId(topicId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
@@ -161,7 +149,6 @@ public class TopicInfoIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -170,7 +157,6 @@ public class TopicInfoIntegrationTest {
 
             var infoQuery = new TopicInfoQuery()
                 .setTopicId(topicId);
-                //.setNodeAccountIds(testEnv.nodeAccountIds);
 
             var cost = infoQuery.getCost(testEnv.client);
 
@@ -183,7 +169,6 @@ public class TopicInfoIntegrationTest {
             assertEquals(error.status.toString(), "INSUFFICIENT_TX_FEE");
 
             new TopicDeleteTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTopicId(topicId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);

--- a/sdk/src/integrationTest/java/TopicInfoIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicInfoIntegrationTest.java
@@ -38,7 +38,7 @@ public class TopicInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -74,7 +74,7 @@ public class TopicInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -111,7 +111,7 @@ public class TopicInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -150,7 +150,7 @@ public class TopicInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -188,7 +188,7 @@ public class TopicInfoIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 

--- a/sdk/src/integrationTest/java/TopicMessageIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicMessageIntegrationTest.java
@@ -68,7 +68,7 @@ public class TopicMessageIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -128,7 +128,7 @@ public class TopicMessageIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/TopicMessageIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicMessageIntegrationTest.java
@@ -19,7 +19,6 @@ public class TopicMessageIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -28,7 +27,6 @@ public class TopicMessageIntegrationTest {
 
             @Var var info = new TopicInfoQuery()
                 .setTopicId(topicId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.topicId, topicId);
@@ -47,7 +45,6 @@ public class TopicMessageIntegrationTest {
                 });
 
             new TopicMessageSubmitTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTopicId(topicId)
                 .setMessage("Hello, from HCS!")
                 .execute(testEnv.client)
@@ -79,7 +76,6 @@ public class TopicMessageIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -88,7 +84,6 @@ public class TopicMessageIntegrationTest {
 
             @Var var info = new TopicInfoQuery()
                 .setTopicId(topicId)
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.topicId, topicId);
@@ -107,7 +102,6 @@ public class TopicMessageIntegrationTest {
                 });
 
             new TopicMessageSubmitTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTopicId(topicId)
                 .setMessage(Contents.BIG_CONTENTS)
                 .execute(testEnv.client)

--- a/sdk/src/integrationTest/java/TopicMessageIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicMessageIntegrationTest.java
@@ -16,10 +16,10 @@ public class TopicMessageIntegrationTest {
     @DisplayName("Can receive a topic message")
     void canReceiveATopicMessage() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -28,13 +28,13 @@ public class TopicMessageIntegrationTest {
 
             @Var var info = new TopicInfoQuery()
                 .setTopicId(topicId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.topicId, topicId);
             assertEquals(info.topicMemo, "[e2e::TopicCreateTransaction]");
             assertEquals(info.sequenceNumber, 0);
-            assertEquals(info.adminKey, testEnv.operatorKey.getPublicKey());
+            assertEquals(info.adminKey, testEnv.operatorKey);
 
             var receivedMessage = new boolean[]{false};
             var start = Instant.now();
@@ -47,7 +47,7 @@ public class TopicMessageIntegrationTest {
                 });
 
             new TopicMessageSubmitTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTopicId(topicId)
                 .setMessage("Hello, from HCS!")
                 .execute(testEnv.client)
@@ -76,10 +76,10 @@ public class TopicMessageIntegrationTest {
     @DisplayName("Can receive a large topic message")
     void canReceiveALargeTopicMessage() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -88,13 +88,13 @@ public class TopicMessageIntegrationTest {
 
             @Var var info = new TopicInfoQuery()
                 .setTopicId(topicId)
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .execute(testEnv.client);
 
             assertEquals(info.topicId, topicId);
             assertEquals(info.topicMemo, "[e2e::TopicCreateTransaction]");
             assertEquals(info.sequenceNumber, 0);
-            assertEquals(info.adminKey, testEnv.operatorKey.getPublicKey());
+            assertEquals(info.adminKey, testEnv.operatorKey);
 
             var receivedMessage = new boolean[]{false};
             var start = Instant.now();
@@ -107,7 +107,7 @@ public class TopicMessageIntegrationTest {
                 });
 
             new TopicMessageSubmitTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setTopicId(topicId)
                 .setMessage(Contents.BIG_CONTENTS)
                 .execute(testEnv.client)

--- a/sdk/src/integrationTest/java/TopicMessageIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicMessageIntegrationTest.java
@@ -16,7 +16,7 @@ public class TopicMessageIntegrationTest {
     @DisplayName("Can receive a topic message")
     void canReceiveATopicMessage() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TopicCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
@@ -65,7 +65,7 @@ public class TopicMessageIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -73,7 +73,7 @@ public class TopicMessageIntegrationTest {
     @DisplayName("Can receive a large topic message")
     void canReceiveALargeTopicMessage() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TopicCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
@@ -122,7 +122,7 @@ public class TopicMessageIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/TopicMessageSubmitIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicMessageSubmitIntegrationTest.java
@@ -16,7 +16,7 @@ public class TopicMessageSubmitIntegrationTest {
     @DisplayName("Can submit a topic message")
     void canSubmitATopicMessage() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TopicCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
@@ -54,7 +54,7 @@ public class TopicMessageSubmitIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -65,7 +65,7 @@ public class TopicMessageSubmitIntegrationTest {
         Assumptions.assumeTrue(!System.getProperty("HEDERA_NETWORK").equals("previewnet"));
 
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TopicCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
@@ -107,7 +107,7 @@ public class TopicMessageSubmitIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -118,7 +118,7 @@ public class TopicMessageSubmitIntegrationTest {
         Assumptions.assumeTrue(!System.getProperty("HEDERA_NETWORK").equals("previewnet"));
 
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TopicCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
@@ -142,7 +142,7 @@ public class TopicMessageSubmitIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOPIC_ID.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -153,7 +153,7 @@ public class TopicMessageSubmitIntegrationTest {
         Assumptions.assumeTrue(!System.getProperty("HEDERA_NETWORK").equals("previewnet"));
 
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TopicCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
@@ -176,7 +176,7 @@ public class TopicMessageSubmitIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOPIC_MESSAGE.toString()));
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/TopicMessageSubmitIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicMessageSubmitIntegrationTest.java
@@ -58,7 +58,7 @@ public class TopicMessageSubmitIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -116,7 +116,7 @@ public class TopicMessageSubmitIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -154,7 +154,7 @@ public class TopicMessageSubmitIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOPIC_ID.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -191,7 +191,7 @@ public class TopicMessageSubmitIntegrationTest {
 
             assertTrue(error.getMessage().contains(Status.INVALID_TOPIC_MESSAGE.toString()));
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/TopicMessageSubmitIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicMessageSubmitIntegrationTest.java
@@ -16,10 +16,10 @@ public class TopicMessageSubmitIntegrationTest {
     @DisplayName("Can submit a topic message")
     void canSubmitATopicMessage() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -28,16 +28,16 @@ public class TopicMessageSubmitIntegrationTest {
 
             @Var var info = new TopicInfoQuery()
                 .setTopicId(topicId)
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .execute(testEnv.client);
 
             assertEquals(info.topicId, topicId);
             assertEquals(info.topicMemo, "[e2e::TopicCreateTransaction]");
             assertEquals(info.sequenceNumber, 0);
-            assertEquals(info.adminKey, testEnv.operatorKey.getPublicKey());
+            assertEquals(info.adminKey, testEnv.operatorKey);
 
             new TopicMessageSubmitTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setTopicId(topicId)
                 .setMessage("Hello, from HCS!")
                 .execute(testEnv.client)
@@ -45,13 +45,13 @@ public class TopicMessageSubmitIntegrationTest {
 
             info = new TopicInfoQuery()
                 .setTopicId(topicId)
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .execute(testEnv.client);
 
             assertEquals(info.topicId, topicId);
             assertEquals(info.topicMemo, "[e2e::TopicCreateTransaction]");
             assertEquals(info.sequenceNumber, 1);
-            assertEquals(info.adminKey, testEnv.operatorKey.getPublicKey());
+            assertEquals(info.adminKey, testEnv.operatorKey);
 
             new TopicDeleteTransaction()
                 .setTopicId(topicId)
@@ -69,10 +69,10 @@ public class TopicMessageSubmitIntegrationTest {
         Assumptions.assumeTrue(!System.getProperty("HEDERA_NETWORK").equals("previewnet"));
 
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -81,16 +81,16 @@ public class TopicMessageSubmitIntegrationTest {
 
             @Var var info = new TopicInfoQuery()
                 .setTopicId(topicId)
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .execute(testEnv.client);
 
             assertEquals(info.topicId, topicId);
             assertEquals(info.topicMemo, "[e2e::TopicCreateTransaction]");
             assertEquals(info.sequenceNumber, 0);
-            assertEquals(info.adminKey, testEnv.operatorKey.getPublicKey());
+            assertEquals(info.adminKey, testEnv.operatorKey);
 
             var responses = new TopicMessageSubmitTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setTopicId(topicId)
                 .setMaxChunks(15)
                 .setMessage(Contents.BIG_CONTENTS)
@@ -102,16 +102,16 @@ public class TopicMessageSubmitIntegrationTest {
 
             info = new TopicInfoQuery()
                 .setTopicId(topicId)
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .execute(testEnv.client);
 
             assertEquals(info.topicId, topicId);
             assertEquals(info.topicMemo, "[e2e::TopicCreateTransaction]");
             assertEquals(info.sequenceNumber, 14);
-            assertEquals(info.adminKey, testEnv.operatorKey.getPublicKey());
+            assertEquals(info.adminKey, testEnv.operatorKey);
 
             new TopicDeleteTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setTopicId(topicId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
@@ -127,10 +127,10 @@ public class TopicMessageSubmitIntegrationTest {
         Assumptions.assumeTrue(!System.getProperty("HEDERA_NETWORK").equals("previewnet"));
 
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -139,7 +139,7 @@ public class TopicMessageSubmitIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TopicMessageSubmitTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                    //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                     .setMessage(Contents.BIG_CONTENTS)
                     .setMaxChunks(15)
                     .execute(testEnv.client)
@@ -147,7 +147,7 @@ public class TopicMessageSubmitIntegrationTest {
             });
 
             new TopicDeleteTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setTopicId(topicId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
@@ -165,10 +165,10 @@ public class TopicMessageSubmitIntegrationTest {
         Assumptions.assumeTrue(!System.getProperty("HEDERA_NETWORK").equals("previewnet"));
 
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -177,14 +177,14 @@ public class TopicMessageSubmitIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TopicMessageSubmitTransaction()
-                    .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                    //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                     .setTopicId(topicId)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });
 
             new TopicDeleteTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
+                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setTopicId(topicId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);

--- a/sdk/src/integrationTest/java/TopicMessageSubmitIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicMessageSubmitIntegrationTest.java
@@ -19,7 +19,6 @@ public class TopicMessageSubmitIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -28,7 +27,6 @@ public class TopicMessageSubmitIntegrationTest {
 
             @Var var info = new TopicInfoQuery()
                 .setTopicId(topicId)
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .execute(testEnv.client);
 
             assertEquals(info.topicId, topicId);
@@ -37,7 +35,6 @@ public class TopicMessageSubmitIntegrationTest {
             assertEquals(info.adminKey, testEnv.operatorKey);
 
             new TopicMessageSubmitTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setTopicId(topicId)
                 .setMessage("Hello, from HCS!")
                 .execute(testEnv.client)
@@ -45,7 +42,6 @@ public class TopicMessageSubmitIntegrationTest {
 
             info = new TopicInfoQuery()
                 .setTopicId(topicId)
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .execute(testEnv.client);
 
             assertEquals(info.topicId, topicId);
@@ -72,7 +68,6 @@ public class TopicMessageSubmitIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -81,7 +76,6 @@ public class TopicMessageSubmitIntegrationTest {
 
             @Var var info = new TopicInfoQuery()
                 .setTopicId(topicId)
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .execute(testEnv.client);
 
             assertEquals(info.topicId, topicId);
@@ -90,7 +84,6 @@ public class TopicMessageSubmitIntegrationTest {
             assertEquals(info.adminKey, testEnv.operatorKey);
 
             var responses = new TopicMessageSubmitTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setTopicId(topicId)
                 .setMaxChunks(15)
                 .setMessage(Contents.BIG_CONTENTS)
@@ -102,7 +95,6 @@ public class TopicMessageSubmitIntegrationTest {
 
             info = new TopicInfoQuery()
                 .setTopicId(topicId)
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .execute(testEnv.client);
 
             assertEquals(info.topicId, topicId);
@@ -111,7 +103,6 @@ public class TopicMessageSubmitIntegrationTest {
             assertEquals(info.adminKey, testEnv.operatorKey);
 
             new TopicDeleteTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setTopicId(topicId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
@@ -130,7 +121,6 @@ public class TopicMessageSubmitIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -139,7 +129,6 @@ public class TopicMessageSubmitIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TopicMessageSubmitTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                     .setMessage(Contents.BIG_CONTENTS)
                     .setMaxChunks(15)
                     .execute(testEnv.client)
@@ -147,7 +136,6 @@ public class TopicMessageSubmitIntegrationTest {
             });
 
             new TopicDeleteTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setTopicId(topicId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
@@ -168,7 +156,6 @@ public class TopicMessageSubmitIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setAdminKey(testEnv.operatorKey)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
                 .execute(testEnv.client);
@@ -177,14 +164,12 @@ public class TopicMessageSubmitIntegrationTest {
 
             var error = assertThrows(ReceiptStatusException.class, () -> {
                 new TopicMessageSubmitTransaction()
-                    //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                     .setTopicId(topicId)
                     .execute(testEnv.client)
                     .getReceipt(testEnv.client);
             });
 
             new TopicDeleteTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIdsForChunked)
                 .setTopicId(topicId)
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);

--- a/sdk/src/integrationTest/java/TopicUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicUpdateIntegrationTest.java
@@ -45,7 +45,7 @@ public class TopicUpdateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/TopicUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicUpdateIntegrationTest.java
@@ -14,10 +14,10 @@ public class TopicUpdateIntegrationTest {
     @DisplayName("Can update topic")
     void canUpdateTopic() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setAutoRenewAccountId(testEnv.operatorId)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
@@ -26,7 +26,7 @@ public class TopicUpdateIntegrationTest {
             var topicId = Objects.requireNonNull(response.getReceipt(testEnv.client).topicId);
 
             new TopicUpdateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .clearAutoRenewAccountId()
                 .setTopicMemo("hello")
                 .setTopicId(topicId)

--- a/sdk/src/integrationTest/java/TopicUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicUpdateIntegrationTest.java
@@ -14,7 +14,7 @@ public class TopicUpdateIntegrationTest {
     @DisplayName("Can update topic")
     void canUpdateTopic() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var response = new TopicCreateTransaction()
                 .setAdminKey(testEnv.operatorKey)
@@ -43,7 +43,7 @@ public class TopicUpdateIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/TopicUpdateIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TopicUpdateIntegrationTest.java
@@ -17,7 +17,6 @@ public class TopicUpdateIntegrationTest {
             var testEnv = IntegrationTestEnv.withOneNode();
 
             var response = new TopicCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAdminKey(testEnv.operatorKey)
                 .setAutoRenewAccountId(testEnv.operatorId)
                 .setTopicMemo("[e2e::TopicCreateTransaction]")
@@ -26,7 +25,6 @@ public class TopicUpdateIntegrationTest {
             var topicId = Objects.requireNonNull(response.getReceipt(testEnv.client).topicId);
 
             new TopicUpdateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .clearAutoRenewAccountId()
                 .setTopicMemo("hello")
                 .setTopicId(topicId)

--- a/sdk/src/integrationTest/java/TransactionIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TransactionIntegrationTest.java
@@ -35,14 +35,14 @@ public class TransactionIntegrationTest {
     @DisplayName("transaction hash in transaction record is equal to the derived transaction hash")
     void transactionHashInTransactionRecordIsEqualToTheDerivedTransactionHash() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
             var transaction = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
-                .setNodeAccountIds(Collections.singletonList(new AccountId(5)))
+                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .freezeWith(testEnv.client)
                 .signWithOperator(testEnv.client);
 
@@ -57,16 +57,7 @@ public class TransactionIntegrationTest {
             var accountId = record.receipt.accountId;
             assertNotNull(accountId);
 
-            new AccountDeleteTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setAccountId(accountId)
-                .setTransferAccountId(testEnv.operatorId)
-                .freezeWith(testEnv.client)
-                .sign(key)
-                .execute(testEnv.client)
-                .getReceipt(testEnv.client);
-
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 
@@ -74,12 +65,12 @@ public class TransactionIntegrationTest {
     @DisplayName("transaction can be serialized into bytes, deserialized, signature added and executed")
     void transactionFromToBytes() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
             var transaction = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .freezeWith(testEnv.client)
                 .signWithOperator(testEnv.client);
@@ -96,7 +87,7 @@ public class TransactionIntegrationTest {
             assertNotNull(accountId);
 
             var deleteTransaction = new AccountDeleteTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTransferAccountId(testEnv.operatorId)
                 .freezeWith(testEnv.client);
@@ -231,7 +222,7 @@ public class TransactionIntegrationTest {
 
             var tx = (TransferTransaction)Transaction.fromBytes(byts.toByteArray());
 
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             assertEquals(tx.getHbarTransfers().get(new AccountId(542348)).toTinybars(),-10);
             assertEquals(tx.getHbarTransfers().get(new AccountId(47439)).toTinybars(),10);

--- a/sdk/src/integrationTest/java/TransactionIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TransactionIntegrationTest.java
@@ -35,7 +35,7 @@ public class TransactionIntegrationTest {
     @DisplayName("transaction hash in transaction record is equal to the derived transaction hash")
     void transactionHashInTransactionRecordIsEqualToTheDerivedTransactionHash() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -55,7 +55,7 @@ public class TransactionIntegrationTest {
             var accountId = record.receipt.accountId;
             assertNotNull(accountId);
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 
@@ -63,7 +63,7 @@ public class TransactionIntegrationTest {
     @DisplayName("transaction can be serialized into bytes, deserialized, signature added and executed")
     void transactionFromToBytes() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -100,7 +100,7 @@ public class TransactionIntegrationTest {
 
             response.getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 
@@ -218,7 +218,7 @@ public class TransactionIntegrationTest {
 
             var tx = (TransferTransaction)Transaction.fromBytes(byts.toByteArray());
 
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             assertEquals(tx.getHbarTransfers().get(new AccountId(542348)).toTinybars(),-10);
             assertEquals(tx.getHbarTransfers().get(new AccountId(47439)).toTinybars(),10);
@@ -238,7 +238,7 @@ public class TransactionIntegrationTest {
 
             resp.getReceipt(testEnv.client);
 
-            testEnv.cleanUpAndClose();
+            testEnv.close();
         });
     }
 }

--- a/sdk/src/integrationTest/java/TransactionIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TransactionIntegrationTest.java
@@ -66,7 +66,7 @@ public class TransactionIntegrationTest {
                 .execute(testEnv.client)
                 .getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 
@@ -113,9 +113,13 @@ public class TransactionIntegrationTest {
 
             response.getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
+
+
+    // TODO: this test has a bunch of things hard-coded into it, which is kinda dumb, but it's a good idea for a test.
+    //       Any way to fix it and bring it back?
 
     @Disabled
     @Test
@@ -247,7 +251,7 @@ public class TransactionIntegrationTest {
 
             resp.getReceipt(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/TransactionIntegrationTest.java
+++ b/sdk/src/integrationTest/java/TransactionIntegrationTest.java
@@ -40,9 +40,7 @@ public class TransactionIntegrationTest {
             var key = PrivateKey.generate();
 
             var transaction = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
-                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .freezeWith(testEnv.client)
                 .signWithOperator(testEnv.client);
 
@@ -70,7 +68,6 @@ public class TransactionIntegrationTest {
             var key = PrivateKey.generate();
 
             var transaction = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
                 .freezeWith(testEnv.client)
                 .signWithOperator(testEnv.client);
@@ -87,7 +84,6 @@ public class TransactionIntegrationTest {
             assertNotNull(accountId);
 
             var deleteTransaction = new AccountDeleteTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setAccountId(accountId)
                 .setTransferAccountId(testEnv.operatorId)
                 .freezeWith(testEnv.client);

--- a/sdk/src/integrationTest/java/TransactionResponseTest.java
+++ b/sdk/src/integrationTest/java/TransactionResponseTest.java
@@ -42,7 +42,7 @@ public class TransactionResponseTest {
                 .sign(key)
                 .execute(testEnv.client);
 
-            testEnv.client.close();
+            testEnv.cleanUpAndClose();
         });
     }
 }

--- a/sdk/src/integrationTest/java/TransactionResponseTest.java
+++ b/sdk/src/integrationTest/java/TransactionResponseTest.java
@@ -21,9 +21,7 @@ public class TransactionResponseTest {
             var key = PrivateKey.generate();
 
             var transaction = new AccountCreateTransaction()
-                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
-                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .execute(testEnv.client);
 
             var record = transaction.getRecord(testEnv.client);

--- a/sdk/src/integrationTest/java/TransactionResponseTest.java
+++ b/sdk/src/integrationTest/java/TransactionResponseTest.java
@@ -16,14 +16,14 @@ public class TransactionResponseTest {
     @DisplayName("transaction hash in transaction record is equal to the transaction response transaction hash")
     void transactionHashInTransactionRecordIsEqualToTheTransactionResponseTransactionHash() {
         assertDoesNotThrow(() -> {
-            var testEnv = new IntegrationTestEnv();
+            var testEnv = IntegrationTestEnv.withOneNode();
 
             var key = PrivateKey.generate();
 
             var transaction = new AccountCreateTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
+                //.setNodeAccountIds(testEnv.nodeAccountIds)
                 .setKey(key)
-                .setNodeAccountIds(Collections.singletonList(new AccountId(5)))
+                //.setNodeAccountIds(Collections.singletonList(new AccountId(5)))
                 .execute(testEnv.client);
 
             var record = transaction.getRecord(testEnv.client);
@@ -33,16 +33,7 @@ public class TransactionResponseTest {
             var accountId = record.receipt.accountId;
             assertNotNull(accountId);
 
-            new AccountDeleteTransaction()
-                .setNodeAccountIds(testEnv.nodeAccountIds)
-                .setAccountId(accountId)
-                .setNodeAccountIds(Collections.singletonList(new AccountId(5)))
-                .setTransferAccountId(testEnv.operatorId)
-                .freezeWith(testEnv.client)
-                .sign(key)
-                .execute(testEnv.client);
-
-            testEnv.cleanUpAndClose();
+            testEnv.cleanUpAndClose(accountId, key);
         });
     }
 }

--- a/sdk/src/integrationTest/java/TransactionResponseTest.java
+++ b/sdk/src/integrationTest/java/TransactionResponseTest.java
@@ -16,7 +16,7 @@ public class TransactionResponseTest {
     @DisplayName("transaction hash in transaction record is equal to the transaction response transaction hash")
     void transactionHashInTransactionRecordIsEqualToTheTransactionResponseTransactionHash() {
         assertDoesNotThrow(() -> {
-            var testEnv = IntegrationTestEnv.withOneNode();
+            var testEnv = new IntegrationTestEnv(1);
 
             var key = PrivateKey.generate();
 
@@ -31,7 +31,7 @@ public class TransactionResponseTest {
             var accountId = record.receipt.accountId;
             assertNotNull(accountId);
 
-            testEnv.cleanUpAndClose(accountId, key);
+            testEnv.close(accountId, key);
         });
     }
 }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Network.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Network.java
@@ -56,6 +56,8 @@ class Network {
                 this.nodes.add(node);
             }
 
+            Collections.shuffle(nodes);
+
             lock.release();
             return;
         }
@@ -93,6 +95,8 @@ class Network {
                 networkNodes.put(entry.getKey(), node);
             }
         }
+
+        Collections.shuffle(nodes);
 
         lock.release();
     }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Node.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Node.java
@@ -1,13 +1,11 @@
 package com.hedera.hashgraph.sdk;
 
-import java.util.Random;
 import java.util.concurrent.ExecutorService;
 
 class Node extends ManagedNode implements Comparable<Node>{
     AccountId accountId;
     long delay;
     long delayUntil;
-    static Random random = new Random();
 
     Node(AccountId accountId, String address, ExecutorService executor) {
         super(address, executor);
@@ -58,7 +56,7 @@ class Node extends ManagedNode implements Comparable<Node>{
             } else if (this.lastUsed > node.lastUsed) {
                 return 1;
             } else {
-                return random.nextInt(3) - 1;
+                return 0;
             }
         }
     }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Node.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Node.java
@@ -1,11 +1,13 @@
 package com.hedera.hashgraph.sdk;
 
+import java.util.Random;
 import java.util.concurrent.ExecutorService;
 
 class Node extends ManagedNode implements Comparable<Node>{
     AccountId accountId;
     long delay;
     long delayUntil;
+    static Random random = new Random();
 
     Node(AccountId accountId, String address, ExecutorService executor) {
         super(address, executor);
@@ -56,7 +58,7 @@ class Node extends ManagedNode implements Comparable<Node>{
             } else if (this.lastUsed > node.lastUsed) {
                 return 1;
             } else {
-                return 0;
+                return random.nextInt(3) - 1;
             }
         }
     }


### PR DESCRIPTION
**Description**:

- Integration tests should now return Hbars to your account after tests complete instead of throwing away massive amounts of Hbar on each integration test.
- Node account IDs in a client network are now shuffled during client construction.

**Related issue(s)**:

Fixes #548

**Checklist**

- [X] Tested
