### PR TITLE
feat: use lombok for `AccountCreateTransaction`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 **NOTE**: v1 of the SDK is deprecated and support will be discontinued after October 2021. Please install the latest version 2.0.x or migrate from v1 to the latest 2.0.x version. You can reference the migration documentation [here](https://github.com/hashgraph/hedera-sdk-java/blob/master/MIGRATING_V1.md).
 
+**NOTE**: For users who want to clone this repository and use an IDE to jump around the project please install [Lombok)(https://projectlombok.org/) since we heavily use it throughout the project, and most IDEs do not support this out of the box.
+
 #### Gradle
 
 Select _one_ of the following depending on your target platform.

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id "maven"
     id "com.bmuschko.nexus" version "2.3.1"
     id "com.google.protobuf" version "0.8.14"
+    id "io.freefair.lombok" version "6.0.0-m2"
 }
 
 group = "com.hedera.hashgraph"

--- a/sdk/lombok.config
+++ b/sdk/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountCreateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountCreateTransaction.java
@@ -12,24 +12,29 @@ import lombok.experimental.Accessors;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
-import lombok.AccessLevel;
 
-import javax.annotation.Nullable;
 import java.util.LinkedHashMap;
-import java.util.Objects;
 
 /**
  * Create a new Hedera™ account.
  */
 @Accessors(chain = true)
 public final class AccountCreateTransaction extends Transaction<AccountCreateTransaction> {
-    private static final Hbar DEFAULT_RECORD_THRESHOLD = Hbar.fromTinybars(Long.MAX_VALUE);
 
+    /**
+     * The ID of the account to which this account is proxy staked.
+     */
     @NonNull
     @Getter
     @Setter
     private AccountId proxyAccountId;
 
+    /**
+     * The key for this account.
+     *
+     * <p>The key that must sign each transfer out of the account. If receiverSignatureRequired is
+     * true, then it must also sign any transfer into the account.
+     */
     @NonNull
     @Getter
     @Setter
@@ -40,15 +45,33 @@ public final class AccountCreateTransaction extends Transaction<AccountCreateTra
     @Setter
     private String accountMemo = "";
 
+    /**
+     * Set the initial amount to transfer into this account.
+     */
     @NonNull
     @Getter
     @Setter
     private Hbar initialBalance = new Hbar(0);
 
+    /**
+     * If set to true will require this account to sign any transfer of hbars to this account.
+     *
+     * <p>All transfers of hbars from this account must always be signed. This property only affects
+     * transfers to this account.
+     */
     @Getter
     @Setter
     private boolean receiverSignatureRequired = false;
 
+    /**
+     * The auto renew period for this account.
+     *
+     * <p>A Hedera™ account is charged to extend its expiration date every renew period. If it
+     * doesn't have enough balance, it extends as long as possible. If the balance is zero when it
+     * expires, then the account is deleted.
+     *
+     * <p>This is defaulted to 3 months by the SDK.
+     */
     @NonNull
     @Getter
     @Setter
@@ -89,10 +112,6 @@ public final class AccountCreateTransaction extends Transaction<AccountCreateTra
         builder.setAutoRenewPeriod(DurationConverter.toProtobuf(autoRenewPeriod));
         builder.setMemo(accountMemo);
 
-        if (autoRenewPeriod != null) {
-            builder.setAutoRenewPeriod(DurationConverter.toProtobuf(autoRenewPeriod));
-        }
-
         return builder;
     }
 
@@ -109,12 +128,15 @@ public final class AccountCreateTransaction extends Transaction<AccountCreateTra
         if (body.hasProxyAccountID()) {
             proxyAccountId = AccountId.fromProtobuf(body.getProxyAccountID());
         }
+        
         if(body.hasKey()) {
             key = Key.fromProtobufKey(body.getKey());
         }
+
         if(body.hasAutoRenewPeriod()) {
             autoRenewPeriod = DurationConverter.fromProtobuf(body.getAutoRenewPeriod());
         }
+
         initialBalance = Hbar.fromTinybars(body.getInitialBalance());
         accountMemo = body.getMemo();
         receiverSignatureRequired = body.getReceiverSigRequired();


### PR DESCRIPTION
**Description**:
This PR simply updates `AccountCreateTransaction` to use LomBok. Unlike the #586 I needed to use the `@Accessor` since need to make sure the setters chain. `Accessor` is an experimental API for Lombok which is worth mentioning.

**Related issue(s)**:

#586 

**Notes for reviewer**:
To really go through with converting all requests to use Lombok we need to implement the changes for #566 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
