### PR TITLE
Make TokenNftTransfer public

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenNftTransfer.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenNftTransfer.java
@@ -5,7 +5,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import javax.annotation.Nullable;
 import com.hedera.hashgraph.sdk.proto.NftTransfer;
 
-class TokenNftTransfer {
+public class TokenNftTransfer {
     public final AccountId sender;
     public final AccountId receiver;
     public final long serial;


### PR DESCRIPTION
**Description**:
`TransferTransaction.getTokenNftTransfers()` is a public method but the `TokenNftTransfer` class it returns is not public. It should also be public so this method can be utilized by clients. Also, the other transfer getters return all public information so it should have parity with those.

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
