### PR TITLE
fix: fix Client.max[TransactionFee|QueryPayment]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Unreleased
 
- * Fixed bugs in `[to|from]Bytes()` in `TopicUpdateTransaction` and `TokenUpdateTransaction`
+ * Fixed bugs in [to|from]Bytes() in `TopicUpdateTransaction` and `TokenUpdateTransaction`
+ * Deprecated `Client.setMax[TransactionFee|QueryPayment]()`, added `Client.setDefaultMax[TransactionFee|QueryPayment]()` and `Client.getDefaultMax[TransactionFee|QueryPayment]()`
  * Added `FeeAssessmentMethod`.
  * Added `[get|set]AssessmentMethod()` to `CustomFractionalFee`
  * Added `CustomRoyaltyFee`

--- a/examples/src/main/java/CreateStatefulContractExample.java
+++ b/examples/src/main/java/CreateStatefulContractExample.java
@@ -1,10 +1,5 @@
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.Objects;
-import java.util.concurrent.TimeoutException;
-
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.Client;
 import com.hedera.hashgraph.sdk.ContractCallQuery;
@@ -17,15 +12,18 @@ import com.hedera.hashgraph.sdk.FileCreateTransaction;
 import com.hedera.hashgraph.sdk.FileId;
 import com.hedera.hashgraph.sdk.Hbar;
 import com.hedera.hashgraph.sdk.PrecheckStatusException;
-import com.hedera.hashgraph.sdk.ReceiptStatusException;
 import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.ReceiptStatusException;
 import com.hedera.hashgraph.sdk.TransactionReceipt;
 import com.hedera.hashgraph.sdk.TransactionResponse;
-
-
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 import io.github.cdimascio.dotenv.Dotenv;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.concurrent.TimeoutException;
 
 public final class CreateStatefulContractExample {
 
@@ -64,8 +62,8 @@ public final class CreateStatefulContractExample {
         client.setOperator(OPERATOR_ID, OPERATOR_KEY);
 
         // default max fee for all transactions executed by this client
-        client.setMaxTransactionFee(new Hbar(100));
-        client.setMaxQueryPayment(new Hbar(10));
+        client.setDefaultMaxTransactionFee(new Hbar(100));
+        client.setDefaultMaxQueryPayment(new Hbar(10));
 
         // create the contract's bytecode file
         TransactionResponse fileTransactionResponse = new FileCreateTransaction()

--- a/examples/src/main/java/UpdateAccountPublicKeyExample.java
+++ b/examples/src/main/java/UpdateAccountPublicKeyExample.java
@@ -33,7 +33,7 @@ public final class UpdateAccountPublicKeyExample {
         // by this account and be signed by this key
         client.setOperator(OPERATOR_ID, OPERATOR_KEY);
 
-        client.setMaxTransactionFee(new Hbar(10));
+        client.setDefaultMaxTransactionFee(new Hbar(10));
 
         // First, we create a new account so we don't affect our account
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ChunkedTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ChunkedTransaction.java
@@ -218,7 +218,7 @@ abstract class ChunkedTransaction<T extends ChunkedTransaction<T>> extends Trans
             throw new IllegalStateException("Cannot schedule a chunked transaction with length greater than " + CHUNK_SIZE);
         }
 
-        var bodyBuilder = spawnBodyBuilder();
+        var bodyBuilder = spawnBodyBuilder(null);
 
         onFreeze(bodyBuilder);
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
@@ -31,11 +32,11 @@ import java.util.concurrent.TimeoutException;
  */
 public final class Client implements AutoCloseable, WithPing, WithPingAll {
     private static final Hbar DEFAULT_MAX_QUERY_PAYMENT = new Hbar(1);
-    private static final Hbar DEFAULT_MAX_TRANSACTION_FEE = new Hbar(1);
     static final Integer DEFAULT_MAX_ATTEMPTS = 10;
 
-    Hbar maxTransactionFee = DEFAULT_MAX_QUERY_PAYMENT;
-    Hbar maxQueryPayment = DEFAULT_MAX_TRANSACTION_FEE;
+    @Nullable
+    Hbar defaultMaxTransactionFee = null;
+    Hbar defaultMaxQueryPayment = DEFAULT_MAX_QUERY_PAYMENT;
 
     Network network;
     MirrorNetwork mirrorNetwork;
@@ -476,16 +477,29 @@ public final class Client implements AutoCloseable, WithPing, WithPingAll {
      * {@link Transaction#setMaxTransactionFee(Hbar)} on every new transaction. The actual
      * fee assessed for a given transaction may be less than this value, but never greater.
      *
-     * @param maxTransactionFee The Hbar to be set
+     * @param defaultMaxTransactionFee The Hbar to be set
      * @return {@code this}
      */
-    public synchronized Client setMaxTransactionFee(Hbar maxTransactionFee) {
-        if (maxTransactionFee.toTinybars() < 0) {
+    public synchronized Client setDefaultMaxTransactionFee(Hbar defaultMaxTransactionFee) {
+        Objects.requireNonNull(defaultMaxTransactionFee);
+        if (defaultMaxTransactionFee.toTinybars() < 0) {
             throw new IllegalArgumentException("maxTransactionFee must be non-negative");
         }
 
-        this.maxTransactionFee = maxTransactionFee;
+        this.defaultMaxTransactionFee = defaultMaxTransactionFee;
         return this;
+    }
+
+    @Nullable
+    public synchronized Hbar getDefaultMaxTransactionFee() {
+        return defaultMaxTransactionFee;
+    }
+
+    /**
+     * @deprecated Use {@link #setDefaultMaxTransactionFee(Hbar)} instead.
+     */
+    public synchronized Client setMaxTransactionFee(Hbar maxTransactionFee) {
+        return setDefaultMaxTransactionFee(maxTransactionFee);
     }
 
     /**
@@ -503,16 +517,29 @@ public final class Client implements AutoCloseable, WithPing, WithPingAll {
      * <p>
      * Set to 0 to disable automatic implicit payments.
      *
-     * @param maxQueryPayment The Hbar to be set
+     * @param defaultMaxQueryPayment The Hbar to be set
      * @return {@code this}
      */
-    public synchronized Client setMaxQueryPayment(Hbar maxQueryPayment) {
-        if (maxQueryPayment.toTinybars() < 0) {
-            throw new IllegalArgumentException("maxQueryPayment must be non-negative");
+    public synchronized Client setDefaultMaxQueryPayment(Hbar defaultMaxQueryPayment) {
+        Objects.requireNonNull(defaultMaxQueryPayment);
+        if (defaultMaxQueryPayment.toTinybars() < 0) {
+            throw new IllegalArgumentException("defaultMaxQueryPayment must be non-negative");
         }
 
-        this.maxQueryPayment = maxQueryPayment;
+        this.defaultMaxQueryPayment = defaultMaxQueryPayment;
         return this;
+    }
+
+    public synchronized Hbar getDefaultMaxQueryPayment() {
+        return defaultMaxQueryPayment;
+    }
+
+    /**
+     * @deprecated Use {@link #setDefaultMaxQueryPayment(Hbar)} instead.
+     */
+    @Deprecated
+    public synchronized Client setMaxQueryPayment(Hbar maxQueryPayment) {
+        return setDefaultMaxQueryPayment(maxQueryPayment);
     }
 
     public synchronized Client setRequestTimeout(Duration requestTimeout) {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractCreateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractCreateTransaction.java
@@ -75,7 +75,7 @@ public final class ContractCreateTransaction extends Transaction<ContractCreateT
 
     public ContractCreateTransaction() {
         setAutoRenewPeriod(DEFAULT_AUTO_RENEW_PERIOD);
-        setMaxTransactionFee(new Hbar(20));
+        defaultMaxTransactionFee = new Hbar(20);
     }
 
     ContractCreateTransaction(LinkedHashMap<TransactionId, LinkedHashMap<AccountId, com.hedera.hashgraph.sdk.proto.Transaction>> txs) throws InvalidProtocolBufferException {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/FileAppendTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/FileAppendTransaction.java
@@ -28,7 +28,7 @@ public final class FileAppendTransaction extends ChunkedTransaction<FileAppendTr
     public FileAppendTransaction() {
         super();
 
-        setMaxTransactionFee(new Hbar(5));
+        defaultMaxTransactionFee = new Hbar(5);
     }
 
     FileAppendTransaction(LinkedHashMap<TransactionId, LinkedHashMap<AccountId, com.hedera.hashgraph.sdk.proto.Transaction>> txs) throws InvalidProtocolBufferException {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/FileCreateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/FileCreateTransaction.java
@@ -30,7 +30,7 @@ public final class FileCreateTransaction extends Transaction<FileCreateTransacti
 
     public FileCreateTransaction() {
         setExpirationTime(Instant.now().plus(DEFAULT_AUTO_RENEW_PERIOD));
-        setMaxTransactionFee(new Hbar(5));
+        defaultMaxTransactionFee = new Hbar(5);
     }
 
     FileCreateTransaction(LinkedHashMap<TransactionId, LinkedHashMap<AccountId, com.hedera.hashgraph.sdk.proto.Transaction>> txs) throws InvalidProtocolBufferException {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Query.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Query.java
@@ -150,7 +150,7 @@ public abstract class Query<O, T extends Query<O, T>> extends Executable<T, com.
 
                 return getCostAsync(client).thenCompose(cost -> {
                     // Check if this is below our configured maximum query payment
-                    var maxCost = MoreObjects.firstNonNull(maxQueryPayment, client.maxQueryPayment);
+                    var maxCost = MoreObjects.firstNonNull(maxQueryPayment, client.defaultMaxQueryPayment);
 
                     if (cost.compareTo(maxCost) > 0) {
                         return CompletableFuture.failedFuture(new MaxQueryPaymentExceededException(

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ScheduleCreateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ScheduleCreateTransaction.java
@@ -22,7 +22,7 @@ public final class ScheduleCreateTransaction extends Transaction<ScheduleCreateT
     private String scheduleMemo = "";
 
     public ScheduleCreateTransaction() {
-        setMaxTransactionFee(new Hbar(5));
+        defaultMaxTransactionFee = new Hbar(5);
     }
 
     ScheduleCreateTransaction(LinkedHashMap<TransactionId, LinkedHashMap<AccountId, com.hedera.hashgraph.sdk.proto.Transaction>> txs) throws InvalidProtocolBufferException {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ScheduleDeleteTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ScheduleDeleteTransaction.java
@@ -18,7 +18,7 @@ public final class ScheduleDeleteTransaction extends Transaction<ScheduleDeleteT
     private ScheduleId scheduleId = null;
 
     public ScheduleDeleteTransaction() {
-        setMaxTransactionFee(new Hbar(5));
+        defaultMaxTransactionFee = new Hbar(5);
     }
 
     ScheduleDeleteTransaction(LinkedHashMap<TransactionId, LinkedHashMap<AccountId, com.hedera.hashgraph.sdk.proto.Transaction>> txs) throws InvalidProtocolBufferException {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ScheduleSignTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ScheduleSignTransaction.java
@@ -1,15 +1,15 @@
 package com.hedera.hashgraph.sdk;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.hedera.hashgraph.sdk.proto.ScheduleSignTransactionBody;
-import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.SchedulableTransactionBody;
 import com.hedera.hashgraph.sdk.proto.ScheduleServiceGrpc;
+import com.hedera.hashgraph.sdk.proto.ScheduleSignTransactionBody;
+import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
 import io.grpc.MethodDescriptor;
 
-import java.util.LinkedHashMap;
 import javax.annotation.Nullable;
+import java.util.LinkedHashMap;
 import java.util.Objects;
 
 public final class ScheduleSignTransaction extends Transaction<ScheduleSignTransaction> {
@@ -18,7 +18,7 @@ public final class ScheduleSignTransaction extends Transaction<ScheduleSignTrans
     private ScheduleId scheduleId = null;
 
     public ScheduleSignTransaction() {
-        setMaxTransactionFee(new Hbar(5));
+        defaultMaxTransactionFee = new Hbar(5);
     }
 
     ScheduleSignTransaction(LinkedHashMap<TransactionId, LinkedHashMap<AccountId, com.hedera.hashgraph.sdk.proto.Transaction>> txs) throws InvalidProtocolBufferException {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenAssociateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenAssociateTransaction.java
@@ -1,17 +1,17 @@
 package com.hedera.hashgraph.sdk;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.hedera.hashgraph.sdk.proto.TokenAssociateTransactionBody;
-import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.SchedulableTransactionBody;
+import com.hedera.hashgraph.sdk.proto.TokenAssociateTransactionBody;
 import com.hedera.hashgraph.sdk.proto.TokenServiceGrpc;
+import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
 import io.grpc.MethodDescriptor;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
-import javax.annotation.Nullable;
 import java.util.Objects;
 
 public class TokenAssociateTransaction extends Transaction<TokenAssociateTransaction> {
@@ -20,7 +20,7 @@ public class TokenAssociateTransaction extends Transaction<TokenAssociateTransac
     private List<TokenId> tokenIds = new ArrayList<>();
 
     public TokenAssociateTransaction() {
-        setMaxTransactionFee(new Hbar(5));
+        defaultMaxTransactionFee = new Hbar(5);
     }
 
     TokenAssociateTransaction(LinkedHashMap<TransactionId, LinkedHashMap<AccountId, com.hedera.hashgraph.sdk.proto.Transaction>> txs) throws InvalidProtocolBufferException {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenCreateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenCreateTransaction.java
@@ -48,7 +48,7 @@ public class TokenCreateTransaction extends Transaction<TokenCreateTransaction> 
 
     public TokenCreateTransaction() {
         setAutoRenewPeriod(DEFAULT_AUTO_RENEW_PERIOD);
-        setMaxTransactionFee(new Hbar(30));
+        defaultMaxTransactionFee = new Hbar(30);
     }
 
     TokenCreateTransaction(LinkedHashMap<TransactionId, LinkedHashMap<AccountId, com.hedera.hashgraph.sdk.proto.Transaction>> txs) throws InvalidProtocolBufferException {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenDissociateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenDissociateTransaction.java
@@ -20,7 +20,7 @@ public class TokenDissociateTransaction extends com.hedera.hashgraph.sdk.Transac
     private List<TokenId> tokenIds = new ArrayList<>();
 
     public TokenDissociateTransaction() {
-        setMaxTransactionFee(new Hbar(5));
+        defaultMaxTransactionFee = new Hbar(5);
     }
 
     TokenDissociateTransaction(LinkedHashMap<TransactionId, LinkedHashMap<AccountId, com.hedera.hashgraph.sdk.proto.Transaction>> txs) throws InvalidProtocolBufferException {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TransferTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TransferTransaction.java
@@ -24,7 +24,7 @@ public class TransferTransaction extends Transaction<TransferTransaction> {
     private final Map<AccountId, Hbar> hbarTransfers = new HashMap<>();
 
     public TransferTransaction() {
-        setMaxTransactionFee(new Hbar(1));
+        defaultMaxTransactionFee = new Hbar(1);
     }
 
     TransferTransaction(LinkedHashMap<TransactionId, LinkedHashMap<AccountId, com.hedera.hashgraph.sdk.proto.Transaction>> txs) throws InvalidProtocolBufferException {

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ClientTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ClientTest.java
@@ -37,7 +37,7 @@ class ClientTest {
     void setMaxTransactionFeeNegative() {
         assertThrows(IllegalArgumentException.class, () -> {
             Client.forTestnet()
-                .setMaxTransactionFee(Hbar.MIN);
+                .setDefaultMaxTransactionFee(Hbar.MIN);
         });
     }
 


### PR DESCRIPTION
Signed-off-by: Sean Tedrow <sean.tedrow@launchbadge.com>

Deprecates `Client.setMax[TransactionFee|QueryPayment]()`

Adds `Client.setDefaultMax[TransactionFee|QueryPayment]()` and `Client.getDefaultMax[TransactionFee|QueryPayment]()`

**Related issue(s)**:

Fixes #612

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
