### PR TITLE
Add minBackoff and maxBackoff to Client and Executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added `CustomRoyaltyFee`
  * Added `payerAccountIdList` to `AssessedCustomFee`
  * Added fields to `FreezeTransaction`
+ * Added `[min|max]Backoff` to `Client` and `Executable`
 
 ### v2.0.11
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -458,7 +458,7 @@ public final class Client implements AutoCloseable, WithPing, WithPingAll {
      */
     public Client setMinBackoff(Duration minBackoff) {
         if (minBackoff == null || minBackoff.toNanos() < 0) {
-            throw new IllegalArgumentException("maxBackoff must be a positive duration");
+            throw new IllegalArgumentException("minBackoff must be a positive duration");
         } else if (minBackoff.compareTo(maxBackoff) > 0) {
             throw new IllegalArgumentException("minBackoff must be less than or equal to maxBackoff");
         }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -32,7 +32,6 @@ import java.util.concurrent.TimeoutException;
  */
 public final class Client implements AutoCloseable, WithPing, WithPingAll {
     private static final Hbar DEFAULT_MAX_QUERY_PAYMENT = new Hbar(1);
-    private static final Hbar DEFAULT_MAX_TRANSACTION_FEE = new Hbar(1);
     static final int DEFAULT_MAX_ATTEMPTS = 10;
     static final Duration DEFAULT_MAX_BACKOFF = Duration.ofSeconds(8L);
     static final Duration DEFAULT_MIN_BACKOFF = Duration.ofMillis(250L);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -32,7 +32,9 @@ import java.util.concurrent.TimeoutException;
 public final class Client implements AutoCloseable, WithPing, WithPingAll {
     private static final Hbar DEFAULT_MAX_QUERY_PAYMENT = new Hbar(1);
     private static final Hbar DEFAULT_MAX_TRANSACTION_FEE = new Hbar(1);
-    static final Integer DEFAULT_MAX_ATTEMPTS = 10;
+    static final int DEFAULT_MAX_ATTEMPTS = 10;
+    static final Duration DEFAULT_MAX_BACKOFF = Duration.ofSeconds(8L);
+    static final Duration DEFAULT_MIN_BACKOFF = Duration.ofMillis(250L);
 
     Hbar maxTransactionFee = DEFAULT_MAX_QUERY_PAYMENT;
     Hbar maxQueryPayment = DEFAULT_MAX_TRANSACTION_FEE;
@@ -47,7 +49,11 @@ public final class Client implements AutoCloseable, WithPing, WithPingAll {
 
     private Duration requestTimeout = Duration.ofMinutes(2);
 
-    private Integer maxAttempts = null;
+    private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
+
+    private volatile Duration maxBackoff = DEFAULT_MAX_BACKOFF;
+
+    private volatile Duration minBackoff = DEFAULT_MIN_BACKOFF;
 
     private boolean autoValidateChecksums = false;
 
@@ -401,12 +407,63 @@ public final class Client implements AutoCloseable, WithPing, WithPingAll {
     }
 
     public synchronized Client setMaxAttempts(int maxAttempts) {
+        if (maxAttempts <= 0) {
+            throw new IllegalArgumentException("maxAttempts must be greater than zero");
+        }
         this.maxAttempts = maxAttempts;
         return this;
     }
 
     public synchronized int getMaxAttempts() {
-        return maxAttempts != null ? maxAttempts : DEFAULT_MAX_ATTEMPTS;
+        return maxAttempts;
+    }
+
+    /**
+     * @return maxBackoff The maximum amount of time to wait between retries
+     */
+    public Duration getMaxBackoff() {
+        return maxBackoff;
+    }
+
+    /**
+     * The maximum amount of time to wait between retries. Every retry attempt will increase the wait time exponentially
+     * until it reaches this time.
+     *
+     * @param maxBackoff The maximum amount of time to wait between retries
+     * @return {@code this}
+     */
+    public Client setMaxBackoff(Duration maxBackoff) {
+        if (maxBackoff == null || maxBackoff.toNanos() < 0) {
+            throw new IllegalArgumentException("maxBackoff must be a positive duration");
+        } else if (maxBackoff.compareTo(minBackoff) < 0) {
+            throw new IllegalArgumentException("maxBackoff must be greater than or equal to minBackoff");
+        }
+        this.maxBackoff = maxBackoff;
+        return this;
+    }
+
+    /**
+     * @return minBackoff The minimum amount of time to wait between retries
+     */
+    public Duration getMinBackoff() {
+        return minBackoff;
+    }
+
+    /**
+     * The minimum amount of time to wait between retries. When retrying, the delay will start at this time and increase
+     * exponentially until it reaches the maxBackoff.
+     *
+     * @param minBackoff The minimum amount of time to wait between retries
+     * @return {@code this}
+     */
+    public Client setMinBackoff(Duration minBackoff) {
+        if (minBackoff == null || minBackoff.toNanos() < 0) {
+            throw new IllegalArgumentException("maxBackoff must be a positive duration");
+        } else if (minBackoff.compareTo(maxBackoff) > 0) {
+            throw new IllegalArgumentException("minBackoff must be less than or equal to maxBackoff");
+        }
+        this.minBackoff = minBackoff;
+        return this;
     }
 
     public synchronized Client setMaxNodeAttempts(int maxNodeAttempts) {

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ClientTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ClientTest.java
@@ -4,6 +4,11 @@ import com.google.errorprone.annotations.Var;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.threeten.bp.Duration;
 
 import java.io.File;
 import java.io.InputStream;
@@ -30,6 +35,46 @@ class ClientTest {
             Client.forTestnet()
                 .setMaxQueryPayment(Hbar.MIN);
         });
+    }
+
+    @ValueSource(ints = {-1, 0})
+    @ParameterizedTest(name = "Invalid maxAttempts {0}")
+    void setMaxAttempts(int maxAttempts) {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Client.forNetwork(Map.of()).setMaxAttempts(maxAttempts);
+        });
+    }
+
+    @NullSource
+    @ValueSource(longs = {-1, 0, 249})
+    @ParameterizedTest(name = "Invalid maxBackoff {0}")
+    void setMaxBackoffInvalid(Long maxBackoffMillis) {
+        Duration maxBackoff = maxBackoffMillis != null ? Duration.ofMillis(maxBackoffMillis) : null;
+        assertThrows(IllegalArgumentException.class, () -> {
+            Client.forNetwork(Map.of()).setMaxBackoff(maxBackoff);
+        });
+    }
+
+    @ValueSource(longs = {250, 8000})
+    @ParameterizedTest(name = "Valid maxBackoff {0}")
+    void setMaxBackoffValid(long maxBackoff) {
+        Client.forNetwork(Map.of()).setMaxBackoff(Duration.ofMillis(maxBackoff));
+    }
+
+    @NullSource
+    @ValueSource(longs = {-1, 8001})
+    @ParameterizedTest(name = "Invalid minBackoff {0}")
+    void setMinBackoffInvalid(Long minBackoffMillis) {
+        Duration minBackoff = minBackoffMillis != null ? Duration.ofMillis(minBackoffMillis) : null;
+        assertThrows(IllegalArgumentException.class, () -> {
+            Client.forNetwork(Map.of()).setMinBackoff(minBackoff);
+        });
+    }
+
+    @ValueSource(longs = {0, 250, 8000})
+    @ParameterizedTest(name = "Valid minBackoff {0}")
+    void setMinBackoffValid(long minBackoff) {
+        Client.forNetwork(Map.of()).setMinBackoff(Duration.ofMillis(minBackoff));
     }
 
     @Test


### PR DESCRIPTION
**Description**:
- Add `minBackoff` option to `Client` with a default of 250ms
- Add `minBackoff` option to `Executable`
- Add `maxBackoff` option to `Client` with a default of 8s
- Add `maxBackoff` option to `Executable`
- Add validation that `maxAttempts` is greater than zero
- Fix `Executable` logs not showing concrete class name

**Related issue(s)**:

Fixes #614 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
