### PR TITLE
fix: TokenNftInfoQuery throws useful error when misconfigured

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenNftInfoQuery.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenNftInfoQuery.java
@@ -153,11 +153,8 @@ public class TokenNftInfoQuery extends com.hedera.hashgraph.sdk.Query<List<Token
 
     @Override
     CompletableFuture<Void> onExecuteAsync(Client client) {
-        int modesEnabled = (nftId != null ? 1 : 0) + (tokenId != null ? 1 : 0) + (accountId != null ? 1 : 0);
-        if (modesEnabled > 1) {
-            throw new IllegalStateException("TokenNftInfoQuery must be one of byNftId, byTokenId, or byAccountId, but multiple of these modes have been selected");
-        } else if (modesEnabled == 0) {
-            throw new IllegalStateException("TokenNftInfoQuery must be one of byNftId, byTokenId, or byAccountId, but none of these modes have been selected");
+        if (nftId == null) {
+            throw new IllegalStateException("TokenNftInfoQuery must be by NftId");
         }
         return super.onExecuteAsync(client);
     }


### PR DESCRIPTION
Signed-off-by: Sean Tedrow <sean.tedrow@launchbadge.com>

**Description**:

If you used `TokenNftInfoQuery.byAccountId()` or `byTokenId()`, and then executed, you'd get a null pointer exception instead of a useful error.  Now a more useful error will be thrown instead.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
