### PR TITLE
Chore: change NftId.toString() format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+### Unreleased
+
+ * `NftId.[to|from]string()` now uses format `1.2.3/4` instead of `1.2.3@4`
+
+
 ### v2.0.13
 
 ### Added

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/NftId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/NftId.java
@@ -25,9 +25,9 @@ public class NftId {
 
     public static NftId fromString(String id) {
         @SuppressWarnings("StringSplitter")
-        var parts = id.split("@");
+        var parts = id.split("[/@]");
         if (parts.length != 2) {
-            throw new IllegalArgumentException("Expecting {shardNum}.{realmNum}.{idNum}-{checksum}@{serialNum}");
+            throw new IllegalArgumentException("Expecting {shardNum}.{realmNum}.{idNum}-{checksum}/{serialNum}");
         }
         return new NftId(TokenId.fromString(parts[0]), Long.parseLong(parts[1]));
     }
@@ -35,8 +35,7 @@ public class NftId {
     static NftId fromProtobuf(NftID nftId) {
         Objects.requireNonNull(nftId);
         var tokenId = nftId.getTokenID();
-        var returnNftId = new NftId(TokenId.fromProtobuf(tokenId), nftId.getSerialNumber());
-        return returnNftId;
+        return new NftId(TokenId.fromProtobuf(tokenId), nftId.getSerialNumber());
     }
 
     public static NftId fromBytes(byte[] bytes) throws InvalidProtocolBufferException {
@@ -56,11 +55,11 @@ public class NftId {
 
     @Override
     public String toString() {
-        return tokenId.toString() + "@" + serial;
+        return tokenId.toString() + "/" + serial;
     }
 
     public String toStringWithChecksum(Client client) {
-        return tokenId.toStringWithChecksum(client) + "@" + serial;
+        return tokenId.toStringWithChecksum(client) + "/" + serial;
     }
 
     @Override

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/NftIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/NftIdTest.java
@@ -38,7 +38,7 @@ class NftIdTest {
 
     @Test
     void fromStringWithChecksumOnMainnet() {
-        SnapshotMatcher.expect(NftId.fromString("0.0.123-vfmkw@7584").toStringWithChecksum(mainnetClient)).toMatchSnapshot();
+        SnapshotMatcher.expect(NftId.fromString("0.0.123-vfmkw/7584").toStringWithChecksum(mainnetClient)).toMatchSnapshot();
     }
 
     @Test
@@ -48,7 +48,7 @@ class NftIdTest {
 
     @Test
     void fromStringWithChecksumOnPreviewnet() {
-        SnapshotMatcher.expect(NftId.fromString("0.0.123-ntjly@487302").toStringWithChecksum(previewnetClient)).toMatchSnapshot();
+        SnapshotMatcher.expect(NftId.fromString("0.0.123-ntjly/487302").toStringWithChecksum(previewnetClient)).toMatchSnapshot();
     }
 
     @Test

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/NftIdTest.snap
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/NftIdTest.snap
@@ -1,25 +1,25 @@
 com.hedera.hashgraph.sdk.NftIdTest.fromBytes=[
-  "0.0.5005@574489"
+  "0.0.5005/574489"
 ]
 
 
 com.hedera.hashgraph.sdk.NftIdTest.fromString=[
-  "0.0.5005@1234"
+  "0.0.5005/1234"
 ]
 
 
 com.hedera.hashgraph.sdk.NftIdTest.fromStringWithChecksumOnMainnet=[
-  "0.0.123-vfmkw@7584"
+  "0.0.123-vfmkw/7584"
 ]
 
 
 com.hedera.hashgraph.sdk.NftIdTest.fromStringWithChecksumOnPreviewnet=[
-  "0.0.123-ntjly@487302"
+  "0.0.123-ntjly/487302"
 ]
 
 
 com.hedera.hashgraph.sdk.NftIdTest.fromStringWithChecksumOnTestnet=[
-  "0.0.123-rmkyk@584903"
+  "0.0.123-rmkyk/584903"
 ]
 
 


### PR DESCRIPTION
Signed-off-by: Sean Tedrow <sean.tedrow@launchbadge.com>

**Description**:

`NftId.[to|from]string()` now uses format `1.2.3/4` instead of `1.2.3@4`

**Checklist**

- [X] Tested (unit, integration, etc.)
