### PR TITLE
Fix: Remove streams

### DIFF
--- a/examples/src/main/java/TopicWithAdminKeyExample.java
+++ b/examples/src/main/java/TopicWithAdminKeyExample.java
@@ -12,7 +12,6 @@ import com.hedera.hashgraph.sdk.TopicUpdateTransaction;
 import com.hedera.hashgraph.sdk.Transaction;
 import com.hedera.hashgraph.sdk.TransactionResponse;
 import io.github.cdimascio.dotenv.Dotenv;
-import java8.util.J8Arrays;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -68,7 +67,9 @@ class TopicWithAdminKeyExample {
         // Generate the initial keys that are part of the adminKey's thresholdKey.
         // 3 ED25519 keys part of a 2-of-3 threshold key.
         initialAdminKeys = new PrivateKey[3];
-        J8Arrays.setAll(initialAdminKeys, i -> PrivateKey.generate());
+        for (int i = 0; i < 3; i++) {
+            initialAdminKeys[i] = PrivateKey.generate();
+        }
 
         KeyList thresholdKey = KeyList.withThreshold(2);
         Collections.addAll(thresholdKey, initialAdminKeys);
@@ -79,10 +80,11 @@ class TopicWithAdminKeyExample {
             .freezeWith(hapiClient);
 
         // Sign the transaction with 2 of 3 keys that are part of the adminKey threshold key.
-        J8Arrays.stream(initialAdminKeys, 0, 2).forEach(k -> {
+        for (int i = 0; i < 2; i++) {
+            PrivateKey k = initialAdminKeys[i];
             System.out.println("Signing ConsensusTopicCreateTransaction with key " + k);
             transaction.sign(k);
-        });
+        }
 
         TransactionResponse transactionResponse = transaction.execute(hapiClient);
 
@@ -95,7 +97,9 @@ class TopicWithAdminKeyExample {
         // Generate the new keys that are part of the adminKey's thresholdKey.
         // 4 ED25519 keys part of a 3-of-4 threshold key.
         PrivateKey[] newAdminKeys = new PrivateKey[4];
-        J8Arrays.setAll(newAdminKeys, i -> PrivateKey.generate());
+        for (int i = 0; i < 4; i++) {
+            newAdminKeys[i] = PrivateKey.generate();
+        }
 
         KeyList thresholdKey = KeyList.withThreshold(3);
         Collections.addAll(thresholdKey, newAdminKeys);
@@ -107,16 +111,18 @@ class TopicWithAdminKeyExample {
             .freezeWith(hapiClient);
 
         // Sign with the initial adminKey. 2 of the 3 keys already part of the topic's adminKey.
-        J8Arrays.stream(initialAdminKeys, 0, 2).forEach(k -> {
+        for (int i = 0; i < 2; i++) {
+            PrivateKey k = initialAdminKeys[i];
             System.out.println("Signing ConsensusTopicUpdateTransaction with initial admin key " + k);
             transaction.sign(k);
-        });
+        }
 
         // Sign with the new adminKey. 3 of 4 keys already part of the topic's adminKey.
-        J8Arrays.stream(newAdminKeys, 0, 3).forEach(k -> {
+        for (int i = 0; i < 3; i++) {
+            PrivateKey k = newAdminKeys[i];
             System.out.println("Signing ConsensusTopicUpdateTransaction with new admin key " + k);
             transaction.sign(k);
-        });
+        }
 
         TransactionResponse transactionResponse = transaction.execute(hapiClient);
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -54,10 +54,9 @@ dependencies {
 
 	// NOTE: This is to support Android API < 24. Once it becomes acceptable to require API 24+ we can drop this and
 	//       use CompletableFuture directly.
-	// https://github.com/stefan-zobel/streamsupport
+	// https://github.com/stefan-zobel/minifuture
 	// https://developer.android.com/about/dashboards/index.html
-	api "net.sourceforge.streamsupport:streamsupport:1.7.4"
-	api "net.sourceforge.streamsupport:streamsupport-cfuture:1.7.4"
+	api 'net.sourceforge.streamsupport:streamsupport-minifuture:1.7.4'
 
 	// NOTE: This is to support Android API < 26.
 	api "org.threeten:threetenbp:1.5.2"

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountInfo.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountInfo.java
@@ -3,12 +3,11 @@ package com.hedera.hashgraph.sdk;
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.hashgraph.sdk.proto.CryptoGetInfoResponse;
-import java8.util.J8Arrays;
-import java8.util.stream.Collectors;
 import org.threeten.bp.Duration;
 import org.threeten.bp.Instant;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -145,9 +144,10 @@ public final class AccountInfo {
             ? AccountId.fromProtobuf(accountInfo.getProxyAccountID())
             : null;
 
-        var liveHashes = J8Arrays.stream(accountInfo.getLiveHashesList().toArray())
-            .map((liveHash) -> LiveHash.fromProtobuf((com.hedera.hashgraph.sdk.proto.LiveHash) liveHash))
-            .collect(Collectors.toList());
+        List<LiveHash> liveHashes = new ArrayList<>();
+        for (var liveHash : accountInfo.getLiveHashesList()) {
+            liveHashes.add(LiveHash.fromProtobuf(liveHash));
+        }
 
         Map<TokenId, TokenRelationship> relationships = new HashMap<>();
 
@@ -182,9 +182,10 @@ public final class AccountInfo {
     }
 
     CryptoGetInfoResponse.AccountInfo toProtobuf() {
-        var hashes = J8Arrays.stream(liveHashes.toArray())
-            .map((liveHash) -> ((LiveHash) liveHash).toProtobuf())
-            .collect(Collectors.toList());
+        List<com.hedera.hashgraph.sdk.proto.LiveHash> hashes = new ArrayList<>();
+        for (var liveHash : liveHashes) {
+            hashes.add(liveHash.toProtobuf());
+        }
 
         var accountInfoBuilder = CryptoGetInfoResponse.AccountInfo.newBuilder()
             .setAccountID(accountId.toProtobuf())

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -4,7 +4,6 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
-import java8.util.Lists;
 import java8.util.concurrent.CompletableFuture;
 import java8.util.function.Consumer;
 import java8.util.function.Function;
@@ -242,13 +241,13 @@ public final class Client implements AutoCloseable, WithPing, WithPingAll {
                 String mirror = config.mirrorNetwork.getAsString();
                 switch (mirror) {
                     case "mainnet":
-                        client.setMirrorNetwork(Lists.of("hcs.mainnet.mirrornode.hedera.com:5600"));
+                        client.setMirrorNetwork(Collections.singletonList("hcs.mainnet.mirrornode.hedera.com:5600"));
                         break;
                     case "testnet":
-                        client.setMirrorNetwork(Lists.of("hcs.testnet.mirrornode.hedera.com:5600"));
+                        client.setMirrorNetwork(Collections.singletonList("hcs.testnet.mirrornode.hedera.com:5600"));
                         break;
                     case "previewnet":
-                        client.setMirrorNetwork(Lists.of("hcs.previewnet.mirrornode.hedera.com:5600"));
+                        client.setMirrorNetwork(Collections.singletonList("hcs.previewnet.mirrornode.hedera.com:5600"));
                         break;
                     default:
                         throw new JsonParseException("Illegal argument for mirrorNetwork.");

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractFunctionParameters.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractFunctionParameters.java
@@ -2,11 +2,6 @@ package com.hedera.hashgraph.sdk;
 
 import com.google.errorprone.annotations.Var;
 import com.google.protobuf.ByteString;
-import java8.util.J8Arrays;
-import java8.util.stream.Collectors;
-import java8.util.stream.IntStream;
-import java8.util.stream.IntStreams;
-import java8.util.stream.Stream;
 import org.bouncycastle.util.encoders.DecoderException;
 import org.bouncycastle.util.encoders.Hex;
 
@@ -16,6 +11,8 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+// TODO: remove streams
 
 // an implementation of function selector and parameter encoding as specified here:
 // https://solidity.readthedocs.io/en/v0.5.7/abi-spec.html#

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractFunctionParameters.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractFunctionParameters.java
@@ -76,9 +76,7 @@ public final class ContractFunctionParameters {
         return rightPad32(ByteString.copyFrom(bytes));
     }
 
-    private static ByteString encodeArray(Stream<ByteString> elements) {
-        List<ByteString> list = elements.collect(Collectors.toList());
-
+    private static ByteString encodeArray(List<ByteString> list) {
         return int256(list.size(), 32)
             .concat(ByteString.copyFrom(list));
     }
@@ -219,9 +217,10 @@ public final class ContractFunctionParameters {
      * @throws NullPointerException if any value in `strings` is null
      */
     public ContractFunctionParameters addStringArray(String[] strings) {
-        List<ByteString> byteStrings = J8Arrays.stream(strings)
-            .map(ContractFunctionParameters::encodeString)
-            .collect(Collectors.toList());
+        List<ByteString> byteStrings = new ArrayList<>();
+        for (var string : strings) {
+            byteStrings.add(encodeString(string));
+        }
 
         ByteString argBytes = encodeDynArr(byteStrings);
 
@@ -249,9 +248,10 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addBytesArray(byte[][] param) {
-        List<ByteString> byteArrays = J8Arrays.stream(param)
-            .map(ContractFunctionParameters::encodeBytes)
-            .collect(Collectors.toList());
+        List<ByteString> byteArrays = new ArrayList<>();
+        for (var p : param) {
+            byteArrays.add(encodeBytes(p));
+        }
 
         args.add(new Argument("bytes[]", encodeDynArr(byteArrays), true));
 
@@ -284,8 +284,10 @@ public final class ContractFunctionParameters {
      */
     public ContractFunctionParameters addBytes32Array(byte[][] param) {
         // array of fixed-size elements
-        Stream<ByteString> byteArrays = J8Arrays.stream(param)
-            .map(ContractFunctionParameters::encodeBytes32);
+        List<ByteString> byteArrays = new ArrayList<>();
+        for (var p : param) {
+            byteArrays.add(encodeBytes32(p));
+        }
 
         args.add(new Argument("bytes32[]", encodeArray(byteArrays), true));
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractFunctionParameters.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractFunctionParameters.java
@@ -217,7 +217,7 @@ public final class ContractFunctionParameters {
      * @throws NullPointerException if any value in `strings` is null
      */
     public ContractFunctionParameters addStringArray(String[] strings) {
-        List<ByteString> byteStrings = new ArrayList<>();
+        List<ByteString> byteStrings = new ArrayList<>(strings.length);
         for (var string : strings) {
             byteStrings.add(encodeString(string));
         }
@@ -248,7 +248,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addBytesArray(byte[][] param) {
-        List<ByteString> byteArrays = new ArrayList<>();
+        List<ByteString> byteArrays = new ArrayList<>(param.length);
         for (var p : param) {
             byteArrays.add(encodeBytes(p));
         }
@@ -284,7 +284,7 @@ public final class ContractFunctionParameters {
      */
     public ContractFunctionParameters addBytes32Array(byte[][] param) {
         // array of fixed-size elements
-        List<ByteString> byteArrays = new ArrayList<>();
+        List<ByteString> byteArrays = new ArrayList<>(param.length);
         for (var p : param) {
             byteArrays.add(encodeBytes32(p));
         }
@@ -362,13 +362,13 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt8Array(byte[] intArray) {
-        IntStream intStream = IntStreams.range(0, intArray.length).map(idx -> intArray[idx]);
+        List<ByteString> valList = new ArrayList<>(intArray.length);
+        for (byte val : intArray) {
+            valList.add(int256(val, 8));
+        }
 
-        @Var ByteString arrayBytes = ByteString.copyFrom(
-            intStream.mapToObj(i -> int256(i, 8))
-                .collect(Collectors.toList()));
-
-        arrayBytes = uint256(intArray.length, 32).concat(arrayBytes);
+        ByteString arrayBytes = uint256(intArray.length, 32)
+            .concat(ByteString.copyFrom(valList));
 
         args.add(new Argument("int8[]", arrayBytes, true));
 
@@ -382,11 +382,13 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt32Array(int[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
-            J8Arrays.stream(intArray).mapToObj(i -> int256(i, 32))
-                .collect(Collectors.toList()));
+        List<ByteString> valList = new ArrayList<>(intArray.length);
+        for (int val : intArray) {
+            valList.add(int256(val, 32));
+        }
 
-        arrayBytes = uint256(intArray.length, 32).concat(arrayBytes);
+        ByteString arrayBytes = uint256(intArray.length, 32)
+            .concat(ByteString.copyFrom(valList));
 
         args.add(new Argument("int32[]", arrayBytes, true));
 
@@ -400,11 +402,13 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt64Array(long[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
-            J8Arrays.stream(intArray).mapToObj(i -> int256(i, 64))
-                .collect(Collectors.toList()));
+        List<ByteString> valList = new ArrayList<>(intArray.length);
+        for (long val : intArray) {
+            valList.add(int256(val, 64));
+        }
 
-        arrayBytes = uint256(intArray.length, 64).concat(arrayBytes);
+        ByteString arrayBytes = uint256(intArray.length, 32)
+            .concat(ByteString.copyFrom(valList));
 
         args.add(new Argument("int64[]", arrayBytes, true));
 
@@ -420,11 +424,13 @@ public final class ContractFunctionParameters {
      *                                  (max range including the sign bit).
      */
     public ContractFunctionParameters addInt256Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
-            J8Arrays.stream(intArray).map(ContractFunctionParameters::int256)
-                .collect(Collectors.toList()));
+        List<ByteString> valList = new ArrayList<>(intArray.length);
+        for (BigInteger val : intArray) {
+            valList.add(int256(val));
+        }
 
-        arrayBytes = uint256(intArray.length, 256).concat(arrayBytes);
+        ByteString arrayBytes = uint256(intArray.length, 256)
+            .concat(ByteString.copyFrom(valList));
 
         args.add(new Argument("int256[]", arrayBytes, true));
 
@@ -503,13 +509,13 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addUint8Array(byte[] intArray) {
-        IntStream intStream = IntStreams.range(0, intArray.length).map(idx -> intArray[idx]);
+        List<ByteString> valList = new ArrayList<>(intArray.length);
+        for (byte val : intArray) {
+            valList.add(uint256(val, 8));
+        }
 
-        @Var ByteString arrayBytes = ByteString.copyFrom(
-            intStream.mapToObj(i -> uint256(i, 8))
-                .collect(Collectors.toList()));
-
-        arrayBytes = uint256(intArray.length, 32).concat(arrayBytes);
+        ByteString arrayBytes = uint256(intArray.length, 32)
+            .concat(ByteString.copyFrom(valList));
 
         args.add(new Argument("uint8[]", arrayBytes, true));
 
@@ -526,11 +532,13 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addUint32Array(int[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
-            J8Arrays.stream(intArray).mapToObj(i -> uint256(i, 32))
-                .collect(Collectors.toList()));
+        List<ByteString> valList = new ArrayList<>(intArray.length);
+        for (int val : intArray) {
+            valList.add(uint256(val, 32));
+        }
 
-        arrayBytes = uint256(intArray.length, 32).concat(arrayBytes);
+        ByteString arrayBytes = uint256(intArray.length, 32)
+            .concat(ByteString.copyFrom(valList));
 
         args.add(new Argument("uint32[]", arrayBytes, true));
 
@@ -547,11 +555,13 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addUint64Array(long[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
-            J8Arrays.stream(intArray).mapToObj(i -> uint256(i, 64))
-                .collect(Collectors.toList()));
+        List<ByteString> valList = new ArrayList<>(intArray.length);
+        for (long val : intArray) {
+            valList.add(uint256(val, 64));
+        }
 
-        arrayBytes = uint256(intArray.length, 64).concat(arrayBytes);
+        ByteString arrayBytes = uint256(intArray.length, 32)
+            .concat(ByteString.copyFrom(valList));
 
         args.add(new Argument("uint64[]", arrayBytes, true));
 
@@ -570,11 +580,13 @@ public final class ContractFunctionParameters {
      *                                  (max range including the sign bit) or is negative.
      */
     public ContractFunctionParameters addUint256Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
-            J8Arrays.stream(intArray).map(ContractFunctionParameters::uint256)
-                .collect(Collectors.toList()));
+        List<ByteString> valList = new ArrayList<>(intArray.length);
+        for (BigInteger val : intArray) {
+            valList.add(uint256(val));
+        }
 
-        arrayBytes = uint256(intArray.length, 256).concat(arrayBytes);
+        ByteString arrayBytes = uint256(intArray.length, 256)
+            .concat(ByteString.copyFrom(valList));
 
         args.add(new Argument("uint256[]", arrayBytes, true));
 
@@ -612,11 +624,11 @@ public final class ContractFunctionParameters {
      * @throws NullPointerException     if any value in the array is null.
      */
     public ContractFunctionParameters addAddressArray(String[] addresses) {
-        ByteString addressArray = encodeArray(
-            J8Arrays.stream(addresses).map(a -> {
-                byte[] address = decodeAddress(a);
-                return leftPad32(ByteString.copyFrom(address));
-            }));
+        List<ByteString> list = new ArrayList<>(addresses.length);
+        for (var address : addresses) {
+            list.add(leftPad32(ByteString.copyFrom(decodeAddress(address))));
+        }
+        ByteString addressArray = encodeArray(list);
 
         args.add(new Argument("address[]", addressArray, true));
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractFunctionResult.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractFunctionResult.java
@@ -3,8 +3,6 @@ package com.hedera.hashgraph.sdk;
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.ByteString;
 import com.hedera.hashgraph.sdk.proto.ContractFunctionResultOrBuilder;
-import java8.util.stream.Collectors;
-import java8.util.stream.StreamSupport;
 import org.bouncycastle.util.encoders.Hex;
 
 import javax.annotation.Nullable;
@@ -62,7 +60,10 @@ public final class ContractFunctionResult {
 
         gasUsed = inner.getGasUsed();
 
-        logs = StreamSupport.stream(inner.getLogInfoList()).map(ContractLogInfo::fromProtobuf).collect(Collectors.toList());
+        logs = new ArrayList<>();
+        for (var log : inner.getLogInfoList()) {
+            logs.add(ContractLogInfo.fromProtobuf(log));
+        }
     }
 
     /**

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/EntityIdHelper.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/EntityIdHelper.java
@@ -1,7 +1,6 @@
 package com.hedera.hashgraph.sdk;
 
 import com.google.errorprone.annotations.Var;
-import java8.lang.FunctionalInterface;
 import org.bouncycastle.util.encoders.DecoderException;
 import org.bouncycastle.util.encoders.Hex;
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Keystore.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Keystore.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.stream.JsonWriter;
-import java8.util.Optional;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.util.encoders.Hex;
 
@@ -39,7 +38,8 @@ final class Keystore {
                 .getAsJsonObject();
             return fromJson(jsonObject, passphrase);
         } catch (IllegalStateException e) {
-            throw new BadKeyException(Optional.ofNullable(e.getMessage()).orElse("failed to parse Keystore"));
+            var message = e.getMessage();
+            throw new BadKeyException(message != null ? message : "failed to parse Keystore");
         } catch (JsonIOException e) {
             // RFC (@abonander): I'm all for keeping this as an unchecked exception
             // but I want consistency with export() so this may involve creating our own exception

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ManagedNetwork.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ManagedNetwork.java
@@ -1,7 +1,6 @@
 package com.hedera.hashgraph.sdk;
 
 import com.google.errorprone.annotations.Var;
-import java8.util.Lists;
 import org.threeten.bp.Duration;
 import org.threeten.bp.Instant;
 
@@ -365,7 +364,7 @@ abstract class ManagedNetwork<
             }
         }
 
-        return Lists.copyOf(returnNodes.values());
+        return Collections.list(Collections.enumeration(returnNodes.values()));
     }
 
     /**

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ManagedNode.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ManagedNode.java
@@ -8,12 +8,12 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.TlsChannelCredentials;
 import io.grpc.inprocess.InProcessChannelBuilder;
-import java8.util.Objects;
 import org.threeten.bp.Duration;
 
 import javax.annotation.Nullable;
 import java8.util.concurrent.CompletableFuture;
 
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/MirrorNetwork.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/MirrorNetwork.java
@@ -1,7 +1,5 @@
 package com.hedera.hashgraph.sdk;
 
-import java8.util.Lists;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,15 +24,15 @@ class MirrorNetwork extends ManagedNetwork<MirrorNetwork, ManagedNodeAddress, Mi
     }
 
     static MirrorNetwork forMainnet(ExecutorService executor) {
-        return new MirrorNetwork(executor, Lists.of("hcs.mainnet.mirrornode.hedera.com:5600"));
+        return new MirrorNetwork(executor, Collections.singletonList("hcs.mainnet.mirrornode.hedera.com:5600"));
     }
 
     static MirrorNetwork forTestnet(ExecutorService executor) {
-        return new MirrorNetwork(executor, Lists.of("hcs.testnet.mirrornode.hedera.com:5600"));
+        return new MirrorNetwork(executor, Collections.singletonList("hcs.testnet.mirrornode.hedera.com:5600"));
     }
 
     static MirrorNetwork forPreviewnet(ExecutorService executor) {
-        return new MirrorNetwork(executor, Lists.of("hcs.previewnet.mirrornode.hedera.com:5600"));
+        return new MirrorNetwork(executor, Collections.singletonList("hcs.previewnet.mirrornode.hedera.com:5600"));
     }
 
     synchronized MirrorNetwork setNetwork(List<String> network) throws TimeoutException, InterruptedException {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Network.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Network.java
@@ -4,8 +4,6 @@ import com.google.common.collect.HashBiMap;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Resources;
 import com.google.protobuf.ByteString;
-import java8.util.stream.Collectors;
-import java8.util.stream.StreamSupport;
 
 import javax.annotation.Nullable;
 import java.io.IOException;

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
@@ -24,8 +24,7 @@ import java.util.HashMap;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-
-// TODO: Predicate is java8, remove it
+import java.util.function.Predicate;
 
 public final class TopicMessageQuery {
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
@@ -14,7 +14,6 @@ import io.grpc.stub.ClientCalls;
 import io.grpc.stub.StreamObserver;
 import java8.util.function.BiConsumer;
 import java8.util.function.Consumer;
-import java8.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.threeten.bp.Duration;
@@ -25,6 +24,8 @@ import java.util.HashMap;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+
+// TODO: Predicate is java8, remove it
 
 public final class TopicMessageQuery {
 

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractFunctionParametersTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractFunctionParametersTest.java
@@ -1,8 +1,8 @@
 package com.hedera.hashgraph.sdk;
 
 import com.google.protobuf.ByteString;
-import java8.util.Lists;
 import org.bouncycastle.util.encoders.Hex;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,44 +20,44 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class ContractFunctionParametersTest {
     @SuppressWarnings("unused")
     private static List<Arguments> int256Arguments() {
-        return Lists.of(
-            Arguments.of(0, "0000000000000000000000000000000000000000000000000000000000000000"),
-            Arguments.of(2, "0000000000000000000000000000000000000000000000000000000000000002"),
-            Arguments.of(255, "00000000000000000000000000000000000000000000000000000000000000ff"),
-            Arguments.of(4095, "0000000000000000000000000000000000000000000000000000000000000fff"),
-            Arguments.of(127 << 24, "000000000000000000000000000000000000000000000000000000007f000000"),
-            Arguments.of(2047 << 20, "000000000000000000000000000000000000000000000000000000007ff00000"),
-            // deadbeef as an integer literal is negative
-            Arguments.of(0xdeadbeefL, "00000000000000000000000000000000000000000000000000000000deadbeef"),
-            Arguments.of(-1, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
-            Arguments.of(-2, "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"),
-            Arguments.of(-256, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00"),
-            Arguments.of(-4096, "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000"),
-            Arguments.of(255 << 24, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000"),
-            Arguments.of(4095 << 20, "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000"),
-            Arguments.of(0xdeadbeef, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffdeadbeef")
-        );
+        List<Arguments> retval = new ArrayList<>();
+        retval.add(Arguments.of(0, "0000000000000000000000000000000000000000000000000000000000000000"));
+        retval.add(Arguments.of(2, "0000000000000000000000000000000000000000000000000000000000000002"));
+        retval.add(Arguments.of(255, "00000000000000000000000000000000000000000000000000000000000000ff"));
+        retval.add(Arguments.of(4095, "0000000000000000000000000000000000000000000000000000000000000fff"));
+        retval.add(Arguments.of(127 << 24, "000000000000000000000000000000000000000000000000000000007f000000"));
+        retval.add(Arguments.of(2047 << 20, "000000000000000000000000000000000000000000000000000000007ff00000"));
+        // deadbeef as an integer literal is negative
+        retval.add(Arguments.of(0xdeadbeefL, "00000000000000000000000000000000000000000000000000000000deadbeef"));
+        retval.add(Arguments.of(-1, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+        retval.add(Arguments.of(-2, "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"));
+        retval.add(Arguments.of(-256, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00"));
+        retval.add(Arguments.of(-4096, "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000"));
+        retval.add(Arguments.of(255 << 24, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000"));
+        retval.add(Arguments.of(4095 << 20, "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000"));
+        retval.add(Arguments.of(0xdeadbeef, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffdeadbeef"));
+        return retval;
     }
 
     @SuppressWarnings("unused")
     private static List<Arguments> uInt256Arguments() {
-        return Lists.of(
-            Arguments.of(0, "0000000000000000000000000000000000000000000000000000000000000000", 8),
-            Arguments.of(2, "0000000000000000000000000000000000000000000000000000000000000002", 8),
-            Arguments.of(255, "00000000000000000000000000000000000000000000000000000000000000ff", 8),
-            Arguments.of(4095, "0000000000000000000000000000000000000000000000000000000000000fff", 32),
-            Arguments.of(127 << 24, "000000000000000000000000000000000000000000000000000000007f000000", 32),
-            Arguments.of(2047 << 20, "000000000000000000000000000000000000000000000000000000007ff00000", 32),
-            // deadbeef as an integer literal is negative
-            Arguments.of(0xdeadbeef, "00000000000000000000000000000000000000000000000000000000deadbeef", 32),
-            Arguments.of(-1, "000000000000000000000000000000000000000000000000ffffffffffffffff", 64),
-            Arguments.of(-2, "000000000000000000000000000000000000000000000000fffffffffffffffe", 64),
-            Arguments.of(-256, "000000000000000000000000000000000000000000000000ffffffffffffff00", 64),
-            Arguments.of(-4096, "000000000000000000000000000000000000000000000000fffffffffffff000", 64),
-            Arguments.of(255 << 24, "000000000000000000000000000000000000000000000000ffffffffff000000", 64),
-            Arguments.of(4095 << 20, "000000000000000000000000000000000000000000000000fffffffffff00000", 64),
-            Arguments.of(0xdeadbeefL, "00000000000000000000000000000000000000000000000000000000deadbeef", 64)
-        );
+        List<Arguments> retval = new ArrayList<>();
+        retval.add(Arguments.of(0, "0000000000000000000000000000000000000000000000000000000000000000", 8));
+        retval.add(Arguments.of(2, "0000000000000000000000000000000000000000000000000000000000000002", 8));
+        retval.add(Arguments.of(255, "00000000000000000000000000000000000000000000000000000000000000ff", 8));
+        retval.add(Arguments.of(4095, "0000000000000000000000000000000000000000000000000000000000000fff", 32));
+        retval.add(Arguments.of(127 << 24, "000000000000000000000000000000000000000000000000000000007f000000", 32));
+        retval.add(Arguments.of(2047 << 20, "000000000000000000000000000000000000000000000000000000007ff00000", 32));
+        // deadbeef as an integer literal is negative
+        retval.add(Arguments.of(0xdeadbeef, "00000000000000000000000000000000000000000000000000000000deadbeef", 32));
+        retval.add(Arguments.of(-1, "000000000000000000000000000000000000000000000000ffffffffffffffff", 64));
+        retval.add(Arguments.of(-2, "000000000000000000000000000000000000000000000000fffffffffffffffe", 64));
+        retval.add(Arguments.of(-256, "000000000000000000000000000000000000000000000000ffffffffffffff00", 64));
+        retval.add(Arguments.of(-4096, "000000000000000000000000000000000000000000000000fffffffffffff000", 64));
+        retval.add(Arguments.of(255 << 24, "000000000000000000000000000000000000000000000000ffffffffff000000", 64));
+        retval.add(Arguments.of(4095 << 20, "000000000000000000000000000000000000000000000000fffffffffff00000", 64));
+        retval.add(Arguments.of(0xdeadbeefL, "00000000000000000000000000000000000000000000000000000000deadbeef", 64));
+        return retval;
     }
 
     @Test

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/Ed25519PrivateKeyTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/Ed25519PrivateKeyTest.java
@@ -3,8 +3,6 @@ package com.hedera.hashgraph.sdk;
 //import com.hedera.hashgraph.sdk.BadKeyException;
 //import com.hedera.hashgraph.sdk.Mnemonic;
 
-import java8.util.stream.RefStreams;
-import java8.util.stream.Stream;
 import org.bouncycastle.math.ec.rfc8032.Ed25519;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.DisplayName;
@@ -66,6 +64,7 @@ class Ed25519PrivateKeyTest {
     private static final byte[] MESSAGE_BYTES = MESSAGE_STR.getBytes(StandardCharsets.UTF_8);
     private static final String SIG_STR = "73bea53f31ca9c42a422ecb7516ec08d0bbd1a6bfd630ccf10ec1872454814d29f4a8011129cd007eab544af01a75f508285b591e5bed24b68f927751e49e30e";
 
+    /*
     @SuppressWarnings("unused")
     private static Stream<String> privKeyStrings() {
         return RefStreams.of(
@@ -76,7 +75,7 @@ class Ed25519PrivateKeyTest {
             // raw hex (just private key)
             TEST_KEY_STR_RAW
         );
-    }
+    }*/
 
     @Test
     @DisplayName("private key generates successfully")

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/HbarTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/HbarTest.java
@@ -1,13 +1,14 @@
 package com.hedera.hashgraph.sdk;
 
-import java8.util.stream.RefStreams;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -23,14 +24,14 @@ public class HbarTest {
     private final Hbar negativeFiftyHbar = new Hbar(-50);
 
     static Iterator<Arguments> getValueConversions() {
-        return RefStreams.of(
-            Arguments.arguments(new BigDecimal(50_000_000), HbarUnit.MICROBAR),
-            Arguments.arguments(new BigDecimal(50_000), HbarUnit.MILLIBAR),
-            Arguments.arguments(new BigDecimal(50), HbarUnit.HBAR),
-            Arguments.arguments(new BigDecimal("0.05"), HbarUnit.KILOBAR),
-            Arguments.arguments(new BigDecimal("0.00005"), HbarUnit.MEGABAR),
-            Arguments.arguments(new BigDecimal("0.00000005"), HbarUnit.GIGABAR)
-        ).iterator();
+        List<Arguments> retval = new ArrayList<>();
+        retval.add(Arguments.arguments(new BigDecimal(50_000_000), HbarUnit.MICROBAR));
+        retval.add(Arguments.arguments(new BigDecimal(50_000), HbarUnit.MILLIBAR));
+        retval.add(Arguments.arguments(new BigDecimal(50), HbarUnit.HBAR));
+        retval.add(Arguments.arguments(new BigDecimal("0.05"), HbarUnit.KILOBAR));
+        retval.add(Arguments.arguments(new BigDecimal("0.00005"), HbarUnit.MEGABAR));
+        retval.add(Arguments.arguments(new BigDecimal("0.00000005"), HbarUnit.GIGABAR));
+        return retval.iterator();
     }
 
     @Test


### PR DESCRIPTION
**Description**:

Aims to remove the use of streams from the SDK, which would allow us to remove a backport dependency and dramatically shrink the size of the SDK.

**Related issue(s)**:

Fixes #735

**Notes for reviewer**:

Unfortunately, we seem to have inadvertently exposed one of the backports publicly: `TopicMessageQuery.setRetryHandler()` takes a `Predicate`.  We are trying to target Java 7 for the sake of Android development, but `Predicate` is Java 8, so we were using a backport of `Predicate` here.  We need to decide what to do about this before going forward.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
