### PR TITLE
Fix: bring getTokenIdDecimals() in line with reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  * `LedgerId`
  * `Client.[set|get]LedgerId()`
- * `TransferTransaction.addTokenTransferWithDecimals()`, `TransferTransaction.getDecimals()`.
+ * `TransferTransaction.addTokenTransferWithDecimals()`, `TransferTransaction.getTokenIdDecimals()`.
  * `ledgerId` fields in `AccountInfo`, `ContractInfo`, `FileInfo`, `ScheduleInfo`, `TokenInfo`, `TokenNftInfo`, and `TopicInfo`
  * `UNEXPECTED_TOKEN_DECIMALS` response code.
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TransferTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TransferTransaction.java
@@ -60,14 +60,18 @@ public class TransferTransaction extends Transaction<TransferTransaction> {
         initFromTransactionBody();
     }
 
-    @Nullable
-    public Integer getTokenIdDecimals(TokenId tokenId) {
-        var transferMap = tokenTransfers.get(tokenId);
-        if (transferMap == null) {
-            return null;
+    public Map<TokenId, Integer> getTokenIdDecimals() {
+        Map<TokenId, Integer> decimalsMap = new HashMap<>();
+        for (var tokenEntry : tokenTransfers.entrySet()) {
+            if (tokenEntry.getValue() == null) {
+                continue;
+            }
+            var decimals = tokenEntry.getValue().getExpectedDecimals();
+            if (decimals != null) {
+                decimalsMap.put(tokenEntry.getKey(), decimals.getValue());
+            }
         }
-        var decimals = transferMap.getExpectedDecimals();
-        return decimals == null ? null : decimals.getValue();
+        return decimalsMap;
     }
 
     private static void doAddTokenTransfer(Map<AccountId, Long> tokenTransferMap, AccountId accountId, long amount) {

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/CryptoTransferTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/CryptoTransferTransactionTest.java
@@ -76,10 +76,10 @@ public class CryptoTransferTransactionTest {
     @Test
     void canGetDecimals() {
         var tx = new TransferTransaction();
-        assertNull(tx.getTokenIdDecimals(TokenId.fromString("0.0.5")));
+        assertNull(tx.getTokenIdDecimals().get(TokenId.fromString("0.0.5")));
         tx.addTokenTransfer(TokenId.fromString("0.0.5"), AccountId.fromString("0.0.8"), 100);
-        assertNull(tx.getTokenIdDecimals(TokenId.fromString("0.0.5")));
+        assertNull(tx.getTokenIdDecimals().get(TokenId.fromString("0.0.5")));
         tx.addTokenTransferWithDecimals(TokenId.fromString("0.0.5"), AccountId.fromString("0.0.7"), -100, 5);
-        assertEquals(5, tx.getTokenIdDecimals(TokenId.fromString("0.0.5")));
+        assertEquals(5, tx.getTokenIdDecimals().get(TokenId.fromString("0.0.5")));
     }
 }


### PR DESCRIPTION
**Description**:
Bring `TransferTransaction.getTokenIdDecimals()` in line with [the SDK reference](https://github.com/hashgraph/hedera-sdk/blob/main/reference/cryptocurrency/TransferTransaction.md#gettokeniddecimals-map--tokenid-uint32-)

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
