### PR TITLE
Minimize delays when picking node for request (#803)

### DIFF
--- a/sdk/src/integrationTest/java/AccountBalanceIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountBalanceIntegrationTest.java
@@ -119,7 +119,7 @@ class AccountBalanceIntegrationTest {
     void shouldIgnoreUnresponsiveNodes() throws Exception {
         var network = new HashMap<String, AccountId>();
         network.put("35.237.200.180:50211", new AccountId(3));
-        network.put("35.242.233.154:50211", new AccountId(10));
+        network.put("35.242.233.155:50211", new AccountId(10));
 
         var client = Client.forNetwork(network);
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
@@ -1,5 +1,6 @@
 package com.hedera.hashgraph.sdk;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.MethodDescriptor;
@@ -17,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import static com.hedera.hashgraph.sdk.FutureConverter.toCompletableFuture;
@@ -36,8 +38,14 @@ abstract class Executable<SdkRequestT, ProtoRequestT, ResponseT, O> implements W
     protected Duration minBackoff = null;
 
     protected int nextNodeIndex = 0;
+
     protected List<AccountId> nodeAccountIds = Collections.emptyList();
     protected List<Node> nodes = new ArrayList<>();
+
+    // Lambda responsible for executing synchronous gRPC requests. Pluggable for unit testing.
+    @VisibleForTesting
+    Function<GrpcRequest, ResponseT> blockingUnaryCall =
+        (grpcRequest) -> ClientCalls.blockingUnaryCall(grpcRequest.createCall(), grpcRequest.getRequest());
 
     Executable() {
     }
@@ -202,43 +210,45 @@ abstract class Executable<SdkRequestT, ProtoRequestT, ResponseT, O> implements W
             }
 
             GrpcRequest grpcRequest = new GrpcRequest(attempt);
+            Node node = grpcRequest.getNode();
+            ResponseT response = null;
 
-            // Sleeping if a node is not healthy should not increment attempt as we didn't really make an attempt
-            if (!grpcRequest.getNode().isHealthy()) {
-                delay(grpcRequest.getNode().getRemainingTimeForBackoff());
-            }
+            // If we get an unhealthy node here, we've cycled through all the "good" nodes that have failed
+            // and have no choice but to try a bad one.
+            if (!node.isHealthy())
+                delay(node.getRemainingTimeForBackoff());
 
-            if (grpcRequest.getNode().channelFailedToConnect()) {
+            if (node.channelFailedToConnect()) {
+                logger.trace("Failed to connect channel for node {} for request #{}", node.getAccountId(), attempt);
                 lastException = grpcRequest.reactToConnectionFailure();
-                delay(grpcRequest.getDelay());
                 continue;
             }
 
-            ResponseT response = null;
-
             try {
-                response = ClientCalls.blockingUnaryCall(grpcRequest.createCall(), grpcRequest.getRequest());
+                response = blockingUnaryCall.apply(grpcRequest);
             } catch (Throwable e) {
                 lastException = e;
             }
 
             if (response == null) {
                 if(grpcRequest.shouldRetryExceptionally(lastException)) {
-                    delay(grpcRequest.getDelay());
                     continue;
                 } else {
                     throw grpcRequest.mapStatusException();
                 }
             }
 
-            switch (grpcRequest.shouldRetry(response)) {
-                case Retry:
+            switch (grpcRequest.getStatus(response)) {
+                case ServerError:
                     lastException = grpcRequest.mapStatusException();
+                    continue;
+                case Retry:
+                    // Response is not ready yet from server, need to wait.
                     delay(grpcRequest.getDelay());
                     continue;
-                case Error:
+                case RequestError:
                     throw grpcRequest.mapStatusException();
-                case Finished:
+                case Success:
                 default:
                     return grpcRequest.mapResponse();
             }
@@ -258,7 +268,8 @@ abstract class Executable<SdkRequestT, ProtoRequestT, ResponseT, O> implements W
         });
     }
 
-    private void setNodesFromNodeAccountIds(Client client) {
+    @VisibleForTesting
+    void setNodesFromNodeAccountIds(Client client) {
         for (var accountId : nodeAccountIds) {
             @Nullable
             var node = client.network.getNode(accountId);
@@ -269,15 +280,49 @@ abstract class Executable<SdkRequestT, ProtoRequestT, ResponseT, O> implements W
         }
     }
 
-    private Node getNodeForExecute(int attempt) {
-        var node = nodes.get(nextNodeIndex);
+    /**
+     * Return the next node for execution. Will select the first node that is deemed healthy.
+     * If we cannot find such a node and have tried n nodes (n being the size of the node list), we will
+     * select the node with the smallest remaining delay. All delays MUST be executed in calling layer
+     * as this method will be called for sync + async scenarios.
+     */
+    @VisibleForTesting
+    Node getNodeForExecute(int attempt) {
+        Node node = null;
+        Node candidate = null;
+        long smallestDelay = Long.MAX_VALUE;
 
-        logger.trace("Sending request #{} to node {}: {}", attempt, node.getAccountId(), this);
+        for (int i = 0; i < nodes.size(); i++) {
+            node = nodes.get(nextNodeIndex);
 
-        var nodeIsHealthy = node.isHealthy();
-        if (!node.isHealthy()) {
-            logger.warn("Using unhealthy node {}. Delaying attempt #{} for {} ms", node.getAccountId(), attempt, node.getRemainingTimeForBackoff());
+            if (!node.isHealthy()) {
+                // Keep track of the node with the smallest delay seen thus far. If we go through the entire list
+                // (meaning all nodes are unhealthy) then we will select the node with the smallest delay.
+                long backoff = node.getRemainingTimeForBackoff();
+                if (backoff < smallestDelay) {
+                    candidate = node;
+                    smallestDelay = backoff;
+                }
+
+                node = null;
+                advanceRequest();
+            } else {
+                break; // got a good node, use it
+            }
         }
+
+        if (node == null) {
+            node = candidate;
+
+            // If we've tried all nodes, index will be +1 too far. Index increment happens outside
+            // this method so try to be consistent with happy path.
+            nextNodeIndex = Math.max(0, nextNodeIndex - 1);
+        }
+
+        // node won't be null at this point because execute() validates before this method is called.
+        // Add null check here to work around sonar NPE detection.
+        if (node != null)
+            logger.trace("Using node {} for request #{}: {}", node.getAccountId(), attempt, this);
 
         return node;
     }
@@ -309,8 +354,7 @@ abstract class Executable<SdkRequestT, ProtoRequestT, ResponseT, O> implements W
         return grpcRequest.getNode().channelFailedToConnectAsync().thenCompose(connectionFailed -> {
             if (connectionFailed) {
                 var connectionException = grpcRequest.reactToConnectionFailure();
-                return Delayer.delayFor(grpcRequest.getDelay(), client.executor)
-                    .thenCompose((v) -> executeAsync(client, attempt + 1, connectionException));
+                return executeAsync(client, attempt + 1, connectionException);
             }
 
             return toCompletableFuture(ClientCalls.futureUnaryCall(grpcRequest.createCall(), grpcRequest.getRequest())).handle((response, error) -> {
@@ -324,13 +368,15 @@ abstract class Executable<SdkRequestT, ProtoRequestT, ResponseT, O> implements W
                     return CompletableFuture.<O>failedFuture(error);
                 }
 
-                switch (grpcRequest.shouldRetry(response)) {
+                switch (grpcRequest.getStatus(response)) {
+                    case ServerError:
+                        return executeAsync(client, attempt + 1, grpcRequest.mapStatusException());
                     case Retry:
                         return Delayer.delayFor(grpcRequest.getDelay(), client.executor)
                             .thenCompose((v) -> executeAsync(client, attempt + 1, grpcRequest.mapStatusException()));
-                    case Error:
+                    case RequestError:
                         return CompletableFuture.<O>failedFuture(grpcRequest.mapStatusException());
-                    case Finished:
+                    case Success:
                     default:
                         return CompletableFuture.completedFuture(grpcRequest.mapResponse());
                 }
@@ -377,22 +423,25 @@ abstract class Executable<SdkRequestT, ProtoRequestT, ResponseT, O> implements W
     }
 
     /**
-     * Called just after receiving the query response from Hedera. By default it triggers a retry
-     * when the pre-check status is {@code BUSY}.
+     * Default implementation, may be overridden in subclasses (especially for query case). Called just
+     * after receiving the query response from Hedera. By default it triggers a retry when the pre-check
+     * status is {@code BUSY}.
      */
     ExecutionState shouldRetry(Status status, ResponseT response) {
         switch (status) {
             case PLATFORM_TRANSACTION_NOT_CREATED:
+            case PLATFORM_NOT_ACTIVE:
             case BUSY:
-                return ExecutionState.Retry;
+                return ExecutionState.ServerError;
             case OK:
-                return ExecutionState.Finished;
+                return ExecutionState.Success;
             default:
-                return ExecutionState.Error;
+                return ExecutionState.RequestError;     // user error
         }
     }
 
-    private class GrpcRequest {
+    @VisibleForTesting
+    class GrpcRequest {
         private final Node node;
         private final int attempt;
         //private final ClientCall<ProtoRequestT, ResponseT> call;
@@ -406,8 +455,8 @@ abstract class Executable<SdkRequestT, ProtoRequestT, ResponseT, O> implements W
 
         GrpcRequest(int attempt) {
             this.attempt = attempt;
-            this.node = Executable.this.getNodeForExecute(attempt);
-            this.request = Executable.this.getRequestForExecute();
+            this.node = getNodeForExecute(attempt);
+            this.request = getRequestForExecute();
             this.startAt = System.nanoTime();
 
             // Exponential back-off for Delayer: 250ms, 500ms, 1s, 2s, 4s, 8s, ... 8s
@@ -461,7 +510,7 @@ abstract class Executable<SdkRequestT, ProtoRequestT, ResponseT, O> implements W
             return Executable.this.mapResponse(response, node.getAccountId(), request);
         }
 
-        ExecutionState shouldRetry(ResponseT response) {
+        ExecutionState getStatus(ResponseT response) {
             node.decreaseDelay();
 
             this.response = response;
@@ -470,14 +519,18 @@ abstract class Executable<SdkRequestT, ProtoRequestT, ResponseT, O> implements W
             logger.trace("Received {} response in {} s from node {} during attempt #{}: {}",
                 responseStatus, latency, node.getAccountId(), attempt, response);
 
+            // Delegate interpretation of response status to subclass. Queries will initiate retries
+            // differently from transaction submissions.
             var executionState = Executable.this.shouldRetry(responseStatus, response);
-
             switch (executionState) {
                 case Retry:
-                    // the response has been identified as failing or otherwise
-                    // needing a retry let's do this again after a delay
                     logger.warn("Retrying node {} in {} ms after failure during attempt #{}: {}",
                         node.getAccountId(), delay, attempt, responseStatus);
+                    break;
+                case ServerError:
+                    logger.warn("Problem submitting request to node {} for attempt #{}, retry with new node: {}",
+                        node.getAccountId(), attempt, responseStatus);
+                    break;
                 default:
                     // Do nothing
             }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ExecutionState.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ExecutionState.java
@@ -1,7 +1,8 @@
 package com.hedera.hashgraph.sdk;
 
 public enum ExecutionState {
-    Retry,
-    Finished,
-    Error,
+    Success,
+    Retry,          // call successful but operation not complete, retry with same/new node
+    ServerError,    // bad node, retry with new node
+    RequestError    // user error
 }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TransactionReceiptQuery.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TransactionReceiptQuery.java
@@ -107,7 +107,7 @@ public final class TransactionReceiptQuery
                 break;
 
             default:
-                return ExecutionState.Error;
+                return ExecutionState.RequestError;
         }
 
         var receiptStatus =
@@ -122,7 +122,7 @@ public final class TransactionReceiptQuery
                 return ExecutionState.Retry;
 
             default:
-                return ExecutionState.Finished;
+                return ExecutionState.Success;
         }
     }
 }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TransactionRecordQuery.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TransactionRecordQuery.java
@@ -85,7 +85,7 @@ public final class TransactionRecordQuery extends Query<TransactionRecord, Trans
     @Override
     ExecutionState shouldRetry(Status status, Response response) {
         var retry = super.shouldRetry(status, response);
-        if (retry != ExecutionState.Finished) {
+        if (retry != ExecutionState.Success) {
             return retry;
         }
 
@@ -98,12 +98,12 @@ public final class TransactionRecordQuery extends Query<TransactionRecord, Trans
             case OK:
                 // When fetching payment an `OK` in there query header means the cost is in the response
                 if (paymentTransactions == null || paymentTransactions.isEmpty()) {
-                    return ExecutionState.Finished;
+                    return ExecutionState.Success;
                 } else {
                     break;
                 }
             default:
-                return ExecutionState.Error;
+                return ExecutionState.RequestError;
         }
 
         var receiptStatus =
@@ -118,7 +118,7 @@ public final class TransactionRecordQuery extends Query<TransactionRecord, Trans
                 return ExecutionState.Retry;
 
             default:
-                return ExecutionState.Finished;
+                return ExecutionState.Success;
         }
     }
 }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ExecutableTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ExecutableTest.java
@@ -1,0 +1,502 @@
+package com.hedera.hashgraph.sdk;
+
+import com.hedera.hashgraph.sdk.proto.QueryHeader;
+import com.hedera.hashgraph.sdk.proto.Response;
+import com.hedera.hashgraph.sdk.proto.ResponseCodeEnum;
+import com.hedera.hashgraph.sdk.proto.ResponseHeader;
+import io.grpc.MethodDescriptor;
+import io.grpc.StatusRuntimeException;
+import java8.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
+import org.threeten.bp.Duration;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ExecutableTest {
+    Client client;
+    Network network;
+    Node node3, node4, node5;
+    List<AccountId> nodeAccountIds;
+
+    @BeforeEach
+    void setup() {
+        client = Client.forMainnet();
+        network = mock(Network.class);
+        client.network = network;
+
+        node3 = mock(Node.class);
+        node4 = mock(Node.class);
+        node5 = mock(Node.class);
+
+        when(node3.getAccountId()).thenReturn(new AccountId(3));
+        when(node4.getAccountId()).thenReturn(new AccountId(4));
+        when(node5.getAccountId()).thenReturn(new AccountId(5));
+        when(network.getNode(new AccountId(3))).thenReturn(node3);
+        when(network.getNode(new AccountId(4))).thenReturn(node4);
+        when(network.getNode(new AccountId(5))).thenReturn(node5);
+
+        nodeAccountIds = new ArrayList<AccountId>() {{
+            add(new AccountId(3));
+            add(new AccountId(4));
+            add(new AccountId(5));
+        }};
+    }
+
+    @Test
+    void firstNodeHealthy() {
+        when(node3.isHealthy()).thenReturn(true);
+
+        var tx = new DummyTransaction();
+        tx.setNodeAccountIds(nodeAccountIds);
+        tx.setNodesFromNodeAccountIds(client);
+        tx.setMinBackoff(Duration.ofMillis(10));
+        tx.setMaxBackoff(Duration.ofMillis(1000));
+
+        var node = tx.getNodeForExecute(1);
+        assertEquals(node3, node);
+    }
+
+    @Test
+    void multipleNodesUnhealthy() {
+        when(node3.isHealthy()).thenReturn(false);
+        when(node4.isHealthy()).thenReturn(true);
+
+        when(node3.getRemainingTimeForBackoff()).thenReturn(1000L);
+
+        var tx = new DummyTransaction();
+        tx.setNodeAccountIds(nodeAccountIds);
+        tx.setNodesFromNodeAccountIds(client);
+        tx.setMinBackoff(Duration.ofMillis(10));
+        tx.setMaxBackoff(Duration.ofMillis(1000));
+
+        var node = tx.getNodeForExecute(1);
+        assertEquals(node4, node);
+    }
+
+    @Test
+    void allNodesUnhealthy() {
+        when(node3.isHealthy()).thenReturn(false);
+        when(node4.isHealthy()).thenReturn(false);
+        when(node5.isHealthy()).thenReturn(false);
+
+        when(node3.getRemainingTimeForBackoff()).thenReturn(4000L);
+        when(node4.getRemainingTimeForBackoff()).thenReturn(3000L);
+        when(node5.getRemainingTimeForBackoff()).thenReturn(5000L);
+
+        var tx = new DummyTransaction();
+        tx.setNodeAccountIds(nodeAccountIds);
+        tx.setNodesFromNodeAccountIds(client);
+        tx.setMinBackoff(Duration.ofMillis(10));
+        tx.setMaxBackoff(Duration.ofMillis(1000));
+        tx.nextNodeIndex = 1;
+
+        var node = tx.getNodeForExecute(1);
+        assertEquals(node4, node);
+    }
+
+    @Test
+    void multipleRequestsWithSingleHealthyNode() {
+        when(node3.isHealthy()).thenReturn(true);
+        when(node4.isHealthy()).thenReturn(false);
+        when(node5.isHealthy()).thenReturn(false);
+
+        when(node4.getRemainingTimeForBackoff()).thenReturn(4000L);
+        when(node5.getRemainingTimeForBackoff()).thenReturn(3000L);
+
+        var tx = new DummyTransaction();
+        tx.setNodeAccountIds(nodeAccountIds);
+        tx.setNodesFromNodeAccountIds(client);
+        tx.setMinBackoff(Duration.ofMillis(10));
+        tx.setMaxBackoff(Duration.ofMillis(1000));
+
+        var node = tx.getNodeForExecute(1);
+        assertEquals(node3, node);
+        tx.nextNodeIndex++;
+
+        node = tx.getNodeForExecute(2);
+        assertEquals(node3, node);
+        verify(node4).getRemainingTimeForBackoff();
+        verify(node5).getRemainingTimeForBackoff();
+    }
+
+    @Test
+    void multipleRequestsWithNoHealthyNodes() {
+        AtomicInteger i = new AtomicInteger();
+
+        when(node3.isHealthy()).thenReturn(false);
+        when(node4.isHealthy()).thenReturn(false);
+        when(node5.isHealthy()).thenReturn(false);
+
+        long[] node3Times = {4000, 3000, 1000};
+        long[] node4Times = {3000, 1000, 4000};
+        long[] node5Times = {1000, 3000, 4000};
+
+        when(node3.getRemainingTimeForBackoff()).thenAnswer((Answer<Long>) invocation -> node3Times[i.get()]);
+        when(node4.getRemainingTimeForBackoff()).thenAnswer((Answer<Long>) invocation -> node4Times[i.get()]);
+        when(node5.getRemainingTimeForBackoff()).thenAnswer((Answer<Long>) invocation -> node5Times[i.get()]);
+
+        var tx = new DummyTransaction();
+        tx.setNodeAccountIds(nodeAccountIds);
+        tx.setNodesFromNodeAccountIds(client);
+        tx.setMinBackoff(Duration.ofMillis(10));
+        tx.setMaxBackoff(Duration.ofMillis(1000));
+
+        var node = tx.getNodeForExecute(1);
+        assertEquals(node5, node);
+        i.incrementAndGet();
+
+        node = tx.getNodeForExecute(2);
+        assertEquals(node4, node);
+        i.incrementAndGet();
+
+        node = tx.getNodeForExecute(3);
+        assertEquals(node3, node);
+    }
+
+    @Test
+    void successfulExecute() throws PrecheckStatusException, TimeoutException {
+        var now = org.threeten.bp.Instant.now();
+        var tx = new DummyTransaction() {
+            @Nullable
+            @Override
+            TransactionResponse mapResponse(com.hedera.hashgraph.sdk.proto.TransactionResponse response, AccountId nodeId, com.hedera.hashgraph.sdk.proto.Transaction request) {
+                return new TransactionResponse(
+                    new AccountId(3),
+                    TransactionId.withValidStart(new AccountId(3), now),
+                    null,
+                    null);
+            }
+        };
+
+        var nodeAccountIds = new ArrayList<AccountId>(){{
+            add(new AccountId(3));
+            add(new AccountId(4));
+            add(new AccountId(5));
+        }};
+        tx.setNodeAccountIds(nodeAccountIds);
+
+        var txResp =
+            com.hedera.hashgraph.sdk.proto.TransactionResponse
+                .newBuilder()
+                .setNodeTransactionPrecheckCode(ResponseCodeEnum.OK)
+                .build();
+
+        tx.blockingUnaryCall = (grpcRequest) -> txResp;
+        com.hedera.hashgraph.sdk.TransactionResponse resp = (com.hedera.hashgraph.sdk.TransactionResponse) tx.execute(client);
+
+        assertEquals(new AccountId(3), resp.nodeId);
+    }
+
+    @Test
+    void executeWithChannelFailure() throws PrecheckStatusException, TimeoutException {
+        when(node3.isHealthy()).thenReturn(true);
+        when(node4.isHealthy()).thenReturn(true);
+
+        when(node3.channelFailedToConnect()).thenReturn(true);
+        when(node4.channelFailedToConnect()).thenReturn(false);
+
+        var now = org.threeten.bp.Instant.now();
+        var tx = new DummyTransaction() {
+            @Nullable
+            @Override
+            TransactionResponse mapResponse(com.hedera.hashgraph.sdk.proto.TransactionResponse response, AccountId nodeId, com.hedera.hashgraph.sdk.proto.Transaction request) {
+                return new TransactionResponse(
+                    new AccountId(4),
+                    TransactionId.withValidStart(new AccountId(4), now),
+                    null,
+                    null);
+            }
+        };
+
+        var nodeAccountIds = new ArrayList<AccountId>(){{
+            add(new AccountId(3));
+            add(new AccountId(4));
+            add(new AccountId(5));
+        }};
+        tx.setNodeAccountIds(nodeAccountIds);
+
+        var txResp =
+            com.hedera.hashgraph.sdk.proto.TransactionResponse
+                .newBuilder()
+                .setNodeTransactionPrecheckCode(ResponseCodeEnum.OK)
+                .build();
+
+        tx.blockingUnaryCall = (grpcRequest) -> txResp;
+        com.hedera.hashgraph.sdk.TransactionResponse resp = (com.hedera.hashgraph.sdk.TransactionResponse) tx.execute(client);
+
+        verify(node3).channelFailedToConnect();
+        verify(node4).channelFailedToConnect();
+        assertEquals(new AccountId(4), resp.nodeId);
+    }
+
+    @Test
+    void executeWithAllUnhealthyNodes() throws PrecheckStatusException, TimeoutException {
+        AtomicInteger i = new AtomicInteger();
+
+        // 1st round, pick node3, fail channel connect
+        // 2nd round, pick node4, fail channel connect
+        // 3rd round, pick node5, fail channel connect
+        // 4th round, pick node 3, wait for delay, channel connect ok
+        when(node3.isHealthy()).thenAnswer((Answer<Boolean>) inv -> i.get() == 0);
+        when(node4.isHealthy()).thenAnswer((Answer<Boolean>) inv -> i.get() == 0);
+        when(node5.isHealthy()).thenAnswer((Answer<Boolean>) inv -> i.get() == 0);
+
+        when(node3.channelFailedToConnect()).thenAnswer((Answer<Boolean>) inv -> i.get() == 0);
+        when(node4.channelFailedToConnect()).thenAnswer((Answer<Boolean>) inv -> i.get() == 0);
+        when(node5.channelFailedToConnect()).thenAnswer((Answer<Boolean>) inv -> i.getAndIncrement() == 0);
+
+        when(node3.getRemainingTimeForBackoff()).thenReturn(500L);
+        when(node4.getRemainingTimeForBackoff()).thenReturn(600L);
+        when(node5.getRemainingTimeForBackoff()).thenReturn(700L);
+
+        var now = org.threeten.bp.Instant.now();
+        var tx = new DummyTransaction() {
+            @Nullable
+            @Override
+            TransactionResponse mapResponse(com.hedera.hashgraph.sdk.proto.TransactionResponse response, AccountId nodeId, com.hedera.hashgraph.sdk.proto.Transaction request) {
+                return new TransactionResponse(
+                    new AccountId(3),
+                    TransactionId.withValidStart(new AccountId(3), now),
+                    null,
+                    null);
+            }
+        };
+
+        var nodeAccountIds = new ArrayList<AccountId>(){{
+            add(new AccountId(3));
+            add(new AccountId(4));
+            add(new AccountId(5));
+        }};
+        tx.setNodeAccountIds(nodeAccountIds);
+
+        var txResp =
+            com.hedera.hashgraph.sdk.proto.TransactionResponse
+                .newBuilder()
+                .setNodeTransactionPrecheckCode(ResponseCodeEnum.OK)
+                .build();
+
+        tx.blockingUnaryCall = (grpcRequest) -> txResp;
+        com.hedera.hashgraph.sdk.TransactionResponse resp = (com.hedera.hashgraph.sdk.TransactionResponse) tx.execute(client);
+
+        verify(node3, times(2)).channelFailedToConnect();
+        verify(node4).channelFailedToConnect();
+        verify(node5).channelFailedToConnect();
+        assertEquals(new AccountId(3), resp.nodeId);
+    }
+
+    @Test
+    void executeExhaustRetries() {
+        AtomicInteger i = new AtomicInteger();
+
+        when(node3.isHealthy()).thenReturn(true);
+        when(node4.isHealthy()).thenReturn(true);
+        when(node5.isHealthy()).thenReturn(true);
+
+        when(node3.channelFailedToConnect()).thenReturn(true);
+        when(node4.channelFailedToConnect()).thenReturn(true);
+        when(node5.channelFailedToConnect()).thenReturn(true);
+
+        var tx = new DummyTransaction();
+        var nodeAccountIds = new ArrayList<AccountId>(){{
+            add(new AccountId(3));
+            add(new AccountId(4));
+            add(new AccountId(5));
+        }};
+        tx.setNodeAccountIds(nodeAccountIds);
+        assertThrows(MaxAttemptsExceededException.class, () -> tx.execute(client));
+    }
+
+    @Test
+    void executeRetriableErrorDuringCall() {
+        AtomicInteger i = new AtomicInteger();
+
+        when(node3.isHealthy()).thenReturn(true);
+        when(node4.isHealthy()).thenReturn(true);
+
+        when(node3.channelFailedToConnect()).thenReturn(false);
+        when(node4.channelFailedToConnect()).thenReturn(false);
+
+        var tx = new DummyTransaction();
+        var nodeAccountIds = new ArrayList<AccountId>(){{
+            add(new AccountId(3));
+            add(new AccountId(4));
+            add(new AccountId(5));
+        }};
+        tx.setNodeAccountIds(nodeAccountIds);
+
+        var txResp =
+            com.hedera.hashgraph.sdk.proto.TransactionResponse
+                .newBuilder()
+                .setNodeTransactionPrecheckCode(ResponseCodeEnum.OK)
+                .build();
+
+        tx.blockingUnaryCall = (grpcRequest) -> {
+            if (i.getAndIncrement() == 0)
+                throw new StatusRuntimeException(io.grpc.Status.UNAVAILABLE);
+            else
+                throw new StatusRuntimeException(io.grpc.Status.ABORTED);
+        };
+
+        assertThrows(PrecheckStatusException.class, () ->  tx.execute(client));
+
+        verify(node3).channelFailedToConnect();
+        verify(node4).channelFailedToConnect();
+    }
+
+    @Test
+    void executeQueryDelay() throws PrecheckStatusException, TimeoutException {
+        when(node3.isHealthy()).thenReturn(true);
+        when(node4.isHealthy()).thenReturn(true);
+
+        when(node3.channelFailedToConnect()).thenReturn(false);
+        when(node4.channelFailedToConnect()).thenReturn(false);
+
+        AtomicInteger i = new AtomicInteger();
+        var tx = new DummyQuery() {
+            @Override
+            Status mapResponseStatus(com.hedera.hashgraph.sdk.proto.Response response) {
+                return Status.RECEIPT_NOT_FOUND;
+            }
+
+            @Override
+            ExecutionState shouldRetry(Status status, Response response) {
+                return i.getAndIncrement() == 0 ? ExecutionState.Retry : ExecutionState.Success;
+            }
+        };
+        var nodeAccountIds = new ArrayList<AccountId>(){{
+            add(new AccountId(3));
+            add(new AccountId(4));
+            add(new AccountId(5));
+        }};
+        tx.setNodeAccountIds(nodeAccountIds);
+
+        var receipt = com.hedera.hashgraph.sdk.proto.TransactionReceipt.newBuilder()
+            .setStatus(ResponseCodeEnum.OK)
+            .build();
+        var receiptResp = com.hedera.hashgraph.sdk.proto.TransactionGetReceiptResponse.newBuilder()
+            .setReceipt(receipt)
+            .build();
+
+        var resp = Response.newBuilder().setTransactionGetReceipt(receiptResp).build();
+        tx.blockingUnaryCall = (grpcRequest) -> resp;
+        TransactionReceipt rcp = (TransactionReceipt) tx.execute(client);
+
+        verify(node3).channelFailedToConnect();
+        verify(node4).channelFailedToConnect();
+    }
+
+
+    @Test
+    void executeUserError() throws PrecheckStatusException, TimeoutException {
+        when(node3.isHealthy()).thenReturn(true);
+        when(node3.channelFailedToConnect()).thenReturn(false);
+
+        var tx = new DummyTransaction() {
+            @Override
+            Status mapResponseStatus(com.hedera.hashgraph.sdk.proto.TransactionResponse response) { return Status.ACCOUNT_DELETED; }
+        };
+        var nodeAccountIds = new ArrayList<AccountId>(){{
+            add(new AccountId(3));
+            add(new AccountId(4));
+            add(new AccountId(5));
+        }};
+        tx.setNodeAccountIds(nodeAccountIds);
+
+        var txResp =
+            com.hedera.hashgraph.sdk.proto.TransactionResponse
+                .newBuilder()
+                .setNodeTransactionPrecheckCode(ResponseCodeEnum.ACCOUNT_DELETED)
+                .build();
+
+        tx.blockingUnaryCall = (grpcRequest) -> txResp;
+        assertThrows(PrecheckStatusException.class, () ->  tx.execute(client));
+
+        verify(node3).channelFailedToConnect();
+    }
+
+    @Test
+    void shouldRetryReturnsCorrectStates() {
+        var tx = new DummyTransaction();
+
+        assertEquals(ExecutionState.ServerError, tx.shouldRetry(Status.PLATFORM_TRANSACTION_NOT_CREATED, null));
+        assertEquals(ExecutionState.ServerError, tx.shouldRetry(Status.PLATFORM_NOT_ACTIVE, null));
+        assertEquals(ExecutionState.ServerError, tx.shouldRetry(Status.BUSY, null));
+        assertEquals(ExecutionState.Success, tx.shouldRetry(Status.OK, null));
+        assertEquals(ExecutionState.RequestError, tx.shouldRetry(Status.ACCOUNT_DELETED, null));
+    }
+
+    static class DummyTransaction<T extends Transaction<T>>
+        extends Executable<T, com.hedera.hashgraph.sdk.proto.Transaction, com.hedera.hashgraph.sdk.proto.TransactionResponse, com.hedera.hashgraph.sdk.TransactionResponse> {
+
+        @Override
+        void onExecute(Client client) { }
+
+        @Nullable
+        @Override
+        CompletableFuture<Void> onExecuteAsync(Client client) { return null; }
+
+        @Nullable
+        @Override
+        com.hedera.hashgraph.sdk.proto.Transaction makeRequest() { return null; }
+
+        @Nullable
+        @Override
+        TransactionResponse mapResponse(com.hedera.hashgraph.sdk.proto.TransactionResponse response, AccountId nodeId, com.hedera.hashgraph.sdk.proto.Transaction request) {
+            return null;
+        }
+
+        @Override
+        Status mapResponseStatus(com.hedera.hashgraph.sdk.proto.TransactionResponse response) { return Status.OK; }
+
+        @Nullable
+        @Override
+        MethodDescriptor<com.hedera.hashgraph.sdk.proto.Transaction, com.hedera.hashgraph.sdk.proto.TransactionResponse> getMethodDescriptor() {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        TransactionId getTransactionId() { return null; }
+    }
+
+    static class DummyQuery extends Query<TransactionReceipt, TransactionReceiptQuery> {
+        @Override
+        void onExecute(Client client) { }
+
+        @Override
+        TransactionReceipt mapResponse(Response response, AccountId nodeId, com.hedera.hashgraph.sdk.proto.Query request) {
+            return null;
+        }
+
+        @Override
+        Status mapResponseStatus(com.hedera.hashgraph.sdk.proto.Response response) { return Status.OK; }
+
+        @Override
+        MethodDescriptor<com.hedera.hashgraph.sdk.proto.Query, Response> getMethodDescriptor() { return null; }
+
+        @Override
+        void onMakeRequest(com.hedera.hashgraph.sdk.proto.Query.Builder queryBuilder, QueryHeader header) { }
+
+        @Override
+        ResponseHeader mapResponseHeader(Response response) { return null; }
+
+        @Override
+        QueryHeader mapRequestHeader(com.hedera.hashgraph.sdk.proto.Query request) { return null; }
+
+        @Override
+        void validateChecksums(Client client) { }
+    }
+}

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/HederaTrustManagerTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/HederaTrustManagerTest.java
@@ -1,7 +1,6 @@
 package com.hedera.hashgraph.sdk;
 
 import com.google.protobuf.ByteString;
-import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -9,7 +8,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.Base64;
 import java.util.Map;
 import java.util.Objects;
 

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenPauseTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenPauseTransactionTest.java
@@ -1,7 +1,6 @@
 package com.hedera.hashgraph.sdk;
 
 import io.github.jsonSnapshot.SnapshotMatcher;
-import net.bytebuddy.description.ByteCodeElement;
 import org.junit.AfterClass;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Signed-off-by: Albert Tam <albert.tam@hedera.com>

**Description**:
Change the retry scheme to move onto the next healthy node without delay. If all the nodes are deemed unhealthy then select the node with the shortest delay remaining. Also remove the delay whenever an error is encountered, choosing to retry the request with another node immediately.

**Related issue(s)**:

Fixes #803

**Notes for reviewer**:
Had to make GrpcRequest package protected to enable it to be unit-tested.

No change made to the API so no impact to user experience, internal improvement only.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
