### PR TITLE
Fix TLS issues with mirror node

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ManagedNode.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ManagedNode.java
@@ -91,6 +91,10 @@ abstract class ManagedNode<N extends ManagedNode<N, KeyT>, KeyT> implements Comp
         this.useCount = node.useCount;
     }
 
+    protected String getAuthority() {
+        return "127.0.0.1";
+    }
+
     /**
      * Create an insecure version of this node
      *
@@ -231,7 +235,12 @@ abstract class ManagedNode<N extends ManagedNode<N, KeyT>, KeyT> implements Comp
         if (address.isInProcess()) {
             channelBuilder = InProcessChannelBuilder.forName(Objects.requireNonNull(address.getName()));
         } else if (address.isTransportSecurity()) {
-            channelBuilder = Grpc.newChannelBuilder(address.toString(), getChannelCredentials()).overrideAuthority("127.0.0.1");
+            channelBuilder = Grpc.newChannelBuilder(address.toString(), getChannelCredentials());
+
+            String authority = getAuthority();
+            if (authority != null) {
+                channelBuilder = channelBuilder.overrideAuthority(authority);
+            }
         } else {
             channelBuilder = ManagedChannelBuilder.forTarget(address.toString()).usePlaintext();
         }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ManagedNodeAddress.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ManagedNodeAddress.java
@@ -55,7 +55,7 @@ class ManagedNodeAddress {
     }
 
     public boolean isTransportSecurity() {
-        return port == 50212 || port == 433;
+        return port == 50212 || port == 443;
     }
 
     public ManagedNodeAddress toInsecure() {
@@ -65,7 +65,7 @@ class ManagedNodeAddress {
             case 50212:
                 port = 50211;
                 break;
-            case 433:
+            case 443:
                 port = 5600;
         }
 
@@ -80,7 +80,7 @@ class ManagedNodeAddress {
                 port = 50212;
                 break;
             case 5600:
-                port = 433;
+                port = 443;
         }
 
         return new ManagedNodeAddress(name, address, port);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ManagedNodeAddress.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ManagedNodeAddress.java
@@ -7,10 +7,10 @@ import java.util.regex.Pattern;
 class ManagedNodeAddress {
     private static final Pattern HOST_AND_PORT = Pattern.compile("^(\\S+):(\\d+)$");
     private static final Pattern IN_PROCESS = Pattern.compile("^in-process:(\\S+)$");
-    private static final int PORT_MIRROR_PLAIN = 5600;
-    private static final int PORT_MIRROR_TLS = 443;
-    private static final int PORT_NODE_PLAIN = 50211;
-    private static final int PORT_NODE_TLS = 50212;
+    static final int PORT_MIRROR_PLAIN = 5600;
+    static final int PORT_MIRROR_TLS = 443;
+    static final int PORT_NODE_PLAIN = 50211;
+    static final int PORT_NODE_TLS = 50212;
 
     // If address is `in-process:.*` this will contain the right side of the `:`
     @Nullable

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ManagedNodeAddress.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ManagedNodeAddress.java
@@ -7,6 +7,10 @@ import java.util.regex.Pattern;
 class ManagedNodeAddress {
     private static final Pattern HOST_AND_PORT = Pattern.compile("^(\\S+):(\\d+)$");
     private static final Pattern IN_PROCESS = Pattern.compile("^in-process:(\\S+)$");
+    private static final int PORT_MIRROR_PLAIN = 5600;
+    private static final int PORT_MIRROR_TLS = 443;
+    private static final int PORT_NODE_PLAIN = 50211;
+    private static final int PORT_NODE_TLS = 50212;
 
     // If address is `in-process:.*` this will contain the right side of the `:`
     @Nullable
@@ -55,18 +59,18 @@ class ManagedNodeAddress {
     }
 
     public boolean isTransportSecurity() {
-        return port == 50212 || port == 443;
+        return port == PORT_NODE_TLS || port == PORT_MIRROR_TLS;
     }
 
     public ManagedNodeAddress toInsecure() {
         var port = this.port;
 
         switch (this.port) {
-            case 50212:
-                port = 50211;
+            case PORT_NODE_TLS:
+                port = PORT_NODE_PLAIN;
                 break;
-            case 443:
-                port = 5600;
+            case PORT_MIRROR_TLS:
+                port = PORT_MIRROR_PLAIN;
         }
 
         return new ManagedNodeAddress(name, address, port);
@@ -76,11 +80,11 @@ class ManagedNodeAddress {
         var port = this.port;
 
         switch (this.port) {
-            case 50211:
-                port = 50212;
+            case PORT_NODE_PLAIN:
+                port = PORT_NODE_TLS;
                 break;
-            case 5600:
-                port = 443;
+            case PORT_MIRROR_PLAIN:
+                port = PORT_MIRROR_TLS;
         }
 
         return new ManagedNodeAddress(name, address, port);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/MirrorNode.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/MirrorNode.java
@@ -15,10 +15,17 @@ class MirrorNode extends ManagedNode<MirrorNode, ManagedNodeAddress> {
         super(node, address);
     }
 
+    @Override
+    protected String getAuthority() {
+        return null;
+    }
+
+    @Override
     MirrorNode toInsecure() {
         return new MirrorNode(this, address.toInsecure());
     }
 
+    @Override
     MirrorNode toSecure() {
         return new MirrorNode(this, address.toSecure());
     }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ManagedNodeAddressTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ManagedNodeAddressTest.java
@@ -71,8 +71,8 @@ public class ManagedNodeAddressTest {
         var mirrorNodeAddressSecure = mirrorNodeAddress.toSecure();
         Assertions.assertNull(mirrorNodeAddressSecure.getName());
         Assertions.assertEquals(mirrorNodeAddressSecure.getAddress(), "hcs.mainnet.mirrornode.hedera.com");
-        Assertions.assertEquals(mirrorNodeAddressSecure.getPort(), 433);
-        Assertions.assertEquals(mirrorNodeAddressSecure.toString(), "hcs.mainnet.mirrornode.hedera.com:433");
+        Assertions.assertEquals(mirrorNodeAddressSecure.getPort(), 443);
+        Assertions.assertEquals(mirrorNodeAddressSecure.toString(), "hcs.mainnet.mirrornode.hedera.com:443");
 
         var mirrorNodeAddressInsecure = mirrorNodeAddressSecure.toInsecure();
         Assertions.assertNull(mirrorNodeAddressInsecure.getName());
@@ -80,7 +80,7 @@ public class ManagedNodeAddressTest {
         Assertions.assertEquals(mirrorNodeAddressInsecure.getPort(), 5600);
         Assertions.assertEquals(mirrorNodeAddressInsecure.toString(), "hcs.mainnet.mirrornode.hedera.com:5600");
 
-        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> ManagedNodeAddress.fromString("this is a random string with spaces:433"));
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> ManagedNodeAddress.fromString("this is a random string with spaces:443"));
         assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> ManagedNodeAddress.fromString("hcs.mainnet.mirrornode.hedera.com:notarealport"));
     }
 }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ManagedNodeAddressTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ManagedNodeAddressTest.java
@@ -3,6 +3,7 @@ package com.hedera.hashgraph.sdk;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static com.hedera.hashgraph.sdk.ManagedNodeAddress.*;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ManagedNodeAddressTest {
@@ -11,37 +12,37 @@ public class ManagedNodeAddressTest {
         var ipAddress = ManagedNodeAddress.fromString("35.237.200.180:50211");
         Assertions.assertNull(ipAddress.getName());
         Assertions.assertEquals(ipAddress.getAddress(), "35.237.200.180");
-        Assertions.assertEquals(ipAddress.getPort(), 50211);
+        Assertions.assertEquals(ipAddress.getPort(), PORT_NODE_PLAIN);
         Assertions.assertEquals(ipAddress.toString(), "35.237.200.180:50211");
 
         var ipAddressSecure = ipAddress.toSecure();
         Assertions.assertNull(ipAddressSecure.getName());
         Assertions.assertEquals(ipAddressSecure.getAddress(), "35.237.200.180");
-        Assertions.assertEquals(ipAddressSecure.getPort(), 50212);
+        Assertions.assertEquals(ipAddressSecure.getPort(), PORT_NODE_TLS);
         Assertions.assertEquals(ipAddressSecure.toString(), "35.237.200.180:50212");
 
         var ipAddressInsecure = ipAddressSecure.toInsecure();
         Assertions.assertNull(ipAddressInsecure.getName());
         Assertions.assertEquals(ipAddressInsecure.getAddress(), "35.237.200.180");
-        Assertions.assertEquals(ipAddressInsecure.getPort(), 50211);
+        Assertions.assertEquals(ipAddressInsecure.getPort(), PORT_NODE_PLAIN);
         Assertions.assertEquals(ipAddressInsecure.toString(), "35.237.200.180:50211");
 
         var urlAddress = ManagedNodeAddress.fromString("0.testnet.hedera.com:50211");
         Assertions.assertNull(urlAddress.getName());
         Assertions.assertEquals(urlAddress.getAddress(), "0.testnet.hedera.com");
-        Assertions.assertEquals(urlAddress.getPort(), 50211);
+        Assertions.assertEquals(urlAddress.getPort(), PORT_NODE_PLAIN);
         Assertions.assertEquals(urlAddress.toString(), "0.testnet.hedera.com:50211");
 
         var urlAddressSecure = urlAddress.toSecure();
         Assertions.assertNull(urlAddressSecure.getName());
         Assertions.assertEquals(urlAddressSecure.getAddress(), "0.testnet.hedera.com");
-        Assertions.assertEquals(urlAddressSecure.getPort(), 50212);
+        Assertions.assertEquals(urlAddressSecure.getPort(), PORT_NODE_TLS);
         Assertions.assertEquals(urlAddressSecure.toString(), "0.testnet.hedera.com:50212");
 
         var urlAddressInsecure = urlAddressSecure.toInsecure();
         Assertions.assertNull(urlAddressInsecure.getName());
         Assertions.assertEquals(urlAddressInsecure.getAddress(), "0.testnet.hedera.com");
-        Assertions.assertEquals(urlAddressInsecure.getPort(), 50211);
+        Assertions.assertEquals(urlAddressInsecure.getPort(), PORT_NODE_PLAIN);
         Assertions.assertEquals(urlAddressInsecure.toString(), "0.testnet.hedera.com:50211");
 
         var processAddress = ManagedNodeAddress.fromString("in-process:testingProcess");
@@ -65,19 +66,19 @@ public class ManagedNodeAddressTest {
         var mirrorNodeAddress = ManagedNodeAddress.fromString("hcs.mainnet.mirrornode.hedera.com:5600");
         Assertions.assertNull(mirrorNodeAddress.getName());
         Assertions.assertEquals(mirrorNodeAddress.getAddress(), "hcs.mainnet.mirrornode.hedera.com");
-        Assertions.assertEquals(mirrorNodeAddress.getPort(), 5600);
+        Assertions.assertEquals(mirrorNodeAddress.getPort(), PORT_MIRROR_PLAIN);
         Assertions.assertEquals(mirrorNodeAddress.toString(), "hcs.mainnet.mirrornode.hedera.com:5600");
 
         var mirrorNodeAddressSecure = mirrorNodeAddress.toSecure();
         Assertions.assertNull(mirrorNodeAddressSecure.getName());
         Assertions.assertEquals(mirrorNodeAddressSecure.getAddress(), "hcs.mainnet.mirrornode.hedera.com");
-        Assertions.assertEquals(mirrorNodeAddressSecure.getPort(), 443);
+        Assertions.assertEquals(mirrorNodeAddressSecure.getPort(), PORT_MIRROR_TLS);
         Assertions.assertEquals(mirrorNodeAddressSecure.toString(), "hcs.mainnet.mirrornode.hedera.com:443");
 
         var mirrorNodeAddressInsecure = mirrorNodeAddressSecure.toInsecure();
         Assertions.assertNull(mirrorNodeAddressInsecure.getName());
         Assertions.assertEquals(mirrorNodeAddressInsecure.getAddress(), "hcs.mainnet.mirrornode.hedera.com");
-        Assertions.assertEquals(mirrorNodeAddressInsecure.getPort(), 5600);
+        Assertions.assertEquals(mirrorNodeAddressInsecure.getPort(), PORT_MIRROR_PLAIN);
         Assertions.assertEquals(mirrorNodeAddressInsecure.toString(), "hcs.mainnet.mirrornode.hedera.com:5600");
 
         assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> ManagedNodeAddress.fromString("this is a random string with spaces:443"));


### PR DESCRIPTION
**Description**:
* Fix incorrect port used for TLS detection
* Fix use of hard coded `overrideAuthority("127.0.0.1")` which doesn't work with the CA signed certificates the mirror node uses

**Related issue(s)**:

Fix #855

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
