### PR TITLE
feat: add get/setStakedNodeId to Account create/update transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## out of band
+
+### Added
+ * `setStakedNodeId` & `getStakedNodeId` to `AccountCreateTransaction` & `AccountUpdateTransaction`
+
 ## v2.15.0
 
 ### Added

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountCreateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountCreateTransaction.java
@@ -45,6 +45,9 @@ public final class AccountCreateTransaction extends Transaction<AccountCreateTra
     private boolean receiverSigRequired = false;
     private Duration autoRenewPeriod = DEFAULT_AUTO_RENEW_PERIOD;
     private int maxAutomaticTokenAssociations = 0;
+    @Nullable
+    private AccountId stakedAccountId = null;
+    private long stakedNodeId = -1;
 
     /**
      * Constructor.
@@ -237,6 +240,49 @@ public final class AccountCreateTransaction extends Transaction<AccountCreateTra
         Objects.requireNonNull(memo);
         requireNotFrozen();
         accountMemo = memo;
+        return this;
+    }
+
+    /**
+     * Extract the staked account id.
+     *
+     * @return                          the staked account id
+     */
+    public AccountId getStakedAccountId() {
+        return stakedAccountId;
+    }
+
+    /**
+     * Assign the staked node id.
+     *
+     * @param accountId                 the account id to stake to
+     * @return                          {@code this}
+     */
+    public AccountCreateTransaction setStakedAccountId(AccountId accountId) {
+        Objects.requireNonNull(accountId);
+        requireNotFrozen();
+        stakedAccountId = accountId;
+        return this;
+    }
+
+    /**
+     * Extract the staked node id.
+     *
+     * @return                          the staked node id
+     */
+    public long getStakedNodeId() {
+        return stakedNodeId;
+    }
+
+    /**
+     * Assign the staked node id.
+     *
+     * @param nodeId                    the node id to stake to
+     * @return                          {@code this}
+     */
+    public AccountCreateTransaction setStakedNodeId(long nodeId) {
+        requireNotFrozen();
+        stakedNodeId = nodeId;
         return this;
     }
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountUpdateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountUpdateTransaction.java
@@ -71,6 +71,9 @@ public final class AccountUpdateTransaction extends Transaction<AccountUpdateTra
     private Integer maxAutomaticTokenAssociations = null;
     @Nullable
     private Key aliasKey;
+    @Nullable
+    private AccountId stakedAccountId = null;
+    private long stakedNodeId = -1;
 
     /**
      * Constructor.
@@ -327,6 +330,49 @@ public final class AccountUpdateTransaction extends Transaction<AccountUpdateTra
     public AccountUpdateTransaction clearMemo() {
         requireNotFrozen();
         accountMemo = "";
+        return this;
+    }
+
+    /**
+     * Extract the staked account id.
+     *
+     * @return                          the staked account id
+     */
+    public AccountId getStakedAccountId() {
+        return stakedAccountId;
+    }
+
+    /**
+     * Assign the staked node id.
+     *
+     * @param accountId                 the account id to stake to
+     * @return                          {@code this}
+     */
+    public AccountUpdateTransaction setStakedAccountId(AccountId accountId) {
+        Objects.requireNonNull(accountId);
+        requireNotFrozen();
+        stakedAccountId = accountId;
+        return this;
+    }
+
+    /**
+     * Extract the staked node id.
+     *
+     * @return                          the staked node id
+     */
+    public long getStakedNodeId() {
+        return stakedNodeId;
+    }
+
+    /**
+     * Assign the staked node id.
+     *
+     * @param nodeId                    the node id to stake to
+     * @return                          {@code this}
+     */
+    public AccountUpdateTransaction setStakedNodeId(long nodeId) {
+        requireNotFrozen();
+        stakedNodeId = nodeId;
         return this;
     }
 


### PR DESCRIPTION
Signed-off-by: Ricky Rodriguez <ricky.rodriguez@launchbadge.com>

**Description**:
Add missing `setStakedNodeId` and `getStakedNodeId` to `AccountCreateTransaction` and `AccountUpdateTransaction`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
Need this to complete staking examples.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
