### PR TITLE
fix: deprecate `ContractFunctionResult.stateChanges`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.17.0
+
+### Deprecated
+
+ - `ContractFunctionResult.stateChanges` - Use mirror node for contract traceability instead
+ - `ContractStateChanges`
+ - `StorageChange`
+
 ## v2.16.3
 
 ### Added

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractFunctionResult.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractFunctionResult.java
@@ -65,6 +65,10 @@ public final class ContractFunctionResult {
     @Deprecated
     public final List<ContractId> createdContractIds;
 
+    /**
+     * @deprecated - Use mirror node for contract traceability instead
+     */
+    @Deprecated
     public final List<ContractStateChange> stateChanges;
 
     public final long gas;

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractStateChange.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractStateChange.java
@@ -25,9 +25,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
+ * @deprecated - User mirror nodes for contract traceability instead
+ *
  * The storage changes to a smart contract's storage as a side effect of the function call.
  * See <a href="https://docs.hedera.com/guides/docs/hedera-api/smart-contracts/contractcalllocal#contractstatechange">Hedera Documentation</a>
  */
+@Deprecated
 public class ContractStateChange {
     public final ContractId contractId;
     public final List<StorageChange> storageChanges;

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/StorageChange.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/StorageChange.java
@@ -27,10 +27,12 @@ import javax.annotation.Nullable;
 import java.math.BigInteger;
 
 /**
- * A storage slot change description.
+ * @deprecated - User mirror nodes for contract traceability instead
  *
+ * A storage slot change description.
  * See <a href="https://docs.hedera.com/guides/docs/hedera-api/smart-contracts/contractcalllocal#storagechange">Hedera Documentation</a>
  */
+@Deprecated
 public class StorageChange {
     /**
      * The storage slot changed. Up to 32 bytes, big-endian, zero bytes left trimmed

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractInfoTest.snap
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractInfoTest.snap
@@ -1,10 +1,10 @@
 com.hedera.hashgraph.sdk.ContractInfoTest.fromBytes=[
-  "ContractInfo{contractId=0.0.1, accountId=0.0.2, contractAccountId=3, adminKey=null, expirationTime=1970-01-01T00:00:00.004Z, autoRenewPeriod=PT120H, storage=6, contractMemo=7, balance=8 tℏ, isDeleted=false, tokenRelationships={}, ledgerId=testnet, stakingInfo=null}"
+  "ContractInfo{contractId=0.0.1, accountId=0.0.2, contractAccountId=3, adminKey=null, expirationTime=1970-01-01T00:00:00.004Z, autoRenewPeriod=PT120H, autoRenewAccountId=null, storage=6, contractMemo=7, balance=8 tℏ, isDeleted=false, tokenRelationships={}, ledgerId=testnet, stakingInfo=null}"
 ]
 
 
 com.hedera.hashgraph.sdk.ContractInfoTest.fromProtobuf=[
-  "ContractInfo{contractId=0.0.1, accountId=0.0.2, contractAccountId=3, adminKey=null, expirationTime=1970-01-01T00:00:00.004Z, autoRenewPeriod=PT120H, storage=6, contractMemo=7, balance=8 tℏ, isDeleted=false, tokenRelationships={}, ledgerId=testnet, stakingInfo=null}"
+  "ContractInfo{contractId=0.0.1, accountId=0.0.2, contractAccountId=3, adminKey=null, expirationTime=1970-01-01T00:00:00.004Z, autoRenewPeriod=PT120H, autoRenewAccountId=null, storage=6, contractMemo=7, balance=8 tℏ, isDeleted=false, tokenRelationships={}, ledgerId=testnet, stakingInfo=null}"
 ]
 
 


### PR DESCRIPTION
Signed-off-by: Daniel Akhterov <akhterovd@gmail.com>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**
