### PR TITLE
fix: undeprecate `*ContractId.fromSolidityAddress()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - `TransactionRecord.[prngBytes|prngNumber|tokenNftTransfers]` now serializes/deserializes correctly
  - `[Account|Contract]UpdateTransaction.getDeclineStakingReward()` now returns `@Nullable Boolean` instead of `boolean`, and no longer throws a `NullPointerException`
  - `Client.setNodeMaxBackoff()`
+ - Undeprecate `*ContractId.fromSolidityAddress()`
 
 ## v2.17.1
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractId.java
@@ -104,10 +104,6 @@ public class ContractId extends Key implements Comparable<ContractId> {
         }
     }
 
-    /**
-     * @deprecated with no replacement
-     */
-    @Deprecated
     public static ContractId fromSolidityAddress(String address) {
         return EntityIdHelper.fromSolidityAddress(address, ContractId::new);
     }


### PR DESCRIPTION
**Related issue(s)**:

https://github.com/hashgraph/hedera-sdk-js/issues/1188

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
