### PR TITLE
fix: remove logging when unsubscribing from TopicMessageQuery

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
@@ -328,6 +328,12 @@ public final class TopicMessageQuery {
 
             @Override
             public void onError(Throwable t) {
+                // Return without logging an error if the call is cancelled
+                if (t instanceof StatusRuntimeException &&
+                    ((StatusRuntimeException)t).getStatus().getCode().equals(Status.Code.CANCELLED)) {
+                    return;
+                }
+
                 if (attempt >= maxAttempts || !retryHandler.test(t)) {
                     errorHandler.accept(t, null);
                     return;

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
@@ -329,7 +329,8 @@ public final class TopicMessageQuery {
             @Override
             public void onError(Throwable t) {
                 // Return without logging an error if the call is cancelled
-                if (((StatusRuntimeException) t).getStatus().getCode().equals(Status.Code.CANCELLED)) {
+                if (t instanceof StatusRuntimeException &&
+                    ((StatusRuntimeException) t).getStatus().getCode().equals(Status.Code.CANCELLED)) {
                     return;
                 }
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
@@ -329,8 +329,7 @@ public final class TopicMessageQuery {
             @Override
             public void onError(Throwable t) {
                 // Return without logging an error if the call is cancelled
-                if (t instanceof StatusRuntimeException &&
-                    ((StatusRuntimeException)t).getStatus().getCode().equals(Status.Code.CANCELLED)) {
+                if (((StatusRuntimeException) t).getStatus().getCode().equals(Status.Code.CANCELLED)) {
                     return;
                 }
 

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageQueryTest.java
@@ -354,6 +354,18 @@ class TopicMessageQueryTest {
             .isEqualTo(Status.RESOURCE_EXHAUSTED);
     }
 
+    @Test
+    @Timeout(5)
+    void noErrorWhenCallIsCancelled() {
+        consensusServiceStub.requests.add(request().build());
+        consensusServiceStub.responses.add(Status.CANCELLED.asRuntimeException());
+
+        subscribeToMirror(received::add);
+
+        assertThat(errors).hasSize(0);
+        assertThat(received).isEmpty();
+    }
+
     private void subscribeToMirror(Consumer<TopicMessage> onNext) {
         SubscriptionHandle subscriptionHandle = topicMessageQuery.subscribe(client, onNext);
         Stopwatch stopwatch = Stopwatch.createStarted();

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageQueryTest.java
@@ -362,7 +362,7 @@ class TopicMessageQueryTest {
 
         subscribeToMirror(received::add);
 
-        assertThat(errors).hasSize(0);
+        assertThat(errors).isEmpty();
         assertThat(received).isEmpty();
     }
 


### PR DESCRIPTION
Signed-off-by: dikel <dikelito@tutamail.com>

**Description**:

* Remove logging when unsubscribing from TopicMessageQuery

**Related issue(s)**:

Fixes #1174