### PR TITLE
Fix: execute can ignore timeout and block indefinitely 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - `TopicUpdateTransaction.[get|set]ExpirationTime()`
  - `CustomFee.[set|get]AllCollectorsAreExempt()`
 
+### Fixed
+ - Execute with a timeout can ignore timeout and block indefinitely in CI tests
+
 ## 2.17.4
 
 ### Added


### PR DESCRIPTION
**Description**:

This PR reverts some changes from #1091 in order to fix block when running tests in CI

**Related issue(s)**:

Fixes #1175

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
