### PR TITLE
Fix: Executable listeners generate lots of logs even if trace is not enabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - main
+      - develop
       - release/*
   pull_request:
     branches:
       - main
+      - develop
       - release/*
 
 jobs:

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
@@ -89,11 +89,15 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
 
     Executable() {
         requestListener = request -> {
-            logger.trace("Sent protobuf {}", Hex.toHexString(request.toByteArray()));
+            if (logger.isTraceEnabled()) {
+                logger.trace("Sent protobuf {}", Hex.toHexString(request.toByteArray()));
+            }
             return request;
         };
         responseListener = response -> {
-            logger.trace("Received protobuf {}", Hex.toHexString(response.toByteArray()));
+            if (logger.isTraceEnabled()) {
+                logger.trace("Received protobuf {}", Hex.toHexString(response.toByteArray()));
+            }
             return response;
         };
     }


### PR DESCRIPTION
Signed-off-by: dikel <dikelito@tutamail.com>

**Description**:

Only evaluate the logger parameter in Executable listeners if trace logs are enabled

**Related issue(s)**:

Fixes #1181 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
