### PR TITLE
Fix: Executable.execute to set gRPC deadline #1226

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  - `Client.close()` now tracks and automatically unsubscribes from Mirror Node Topic Queries
+ - `Executable.execute(Client client, Duration timeout)` now sets gRPC deadline to the underlying gRPC request
 
 ## 2.18.1
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -44,6 +44,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static com.hedera.hashgraph.sdk.BaseNodeAddress.PORT_NODE_PLAIN;
@@ -84,7 +85,7 @@ public final class Client implements AutoCloseable {
 
     private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
     private Duration closeTimeout = DEFAULT_CLOSE_TIMEOUT;
-    private volatile Duration grpcDeadline = DEFAULT_GRPC_DEADLINE;
+    private AtomicReference<Duration> grpcDeadline = new AtomicReference(DEFAULT_GRPC_DEADLINE);
 
     private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
 
@@ -1252,7 +1253,7 @@ public final class Client implements AutoCloseable {
         justification = "A Duration can't actually be mutated"
     )
     public Duration getGrpcDeadline() {
-        return grpcDeadline;
+        return grpcDeadline.get();
     }
 
     /**
@@ -1266,7 +1267,7 @@ public final class Client implements AutoCloseable {
         justification = "A Duration can't actually be mutated"
     )
     public Client setGrpcDeadline(Duration grpcDeadline) {
-        this.grpcDeadline = Objects.requireNonNull(grpcDeadline);
+        this.grpcDeadline.set(Objects.requireNonNull(grpcDeadline));
         return this;
     }
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -85,7 +85,7 @@ public final class Client implements AutoCloseable {
 
     private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
     private Duration closeTimeout = DEFAULT_CLOSE_TIMEOUT;
-    private AtomicReference<Duration> grpcDeadline = new AtomicReference(DEFAULT_GRPC_DEADLINE);
+    private final AtomicReference<Duration> grpcDeadline = new AtomicReference(DEFAULT_GRPC_DEADLINE);
 
     private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -60,6 +60,7 @@ public final class Client implements AutoCloseable {
     static final Duration DEFAULT_MIN_NODE_BACKOFF = Duration.ofSeconds(8L);
     static final Duration DEFAULT_CLOSE_TIMEOUT = Duration.ofSeconds(30L);
     static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofMinutes(2L);
+    static final Duration DEFAULT_GRPC_DEADLINE = Duration.ofSeconds(10L);
     static final Duration DEFAULT_NETWORK_UPDATE_PERIOD = Duration.ofHours(24);
     // Initial delay of 10 seconds before we update the network for the first time,
     // so that this doesn't happen in unit tests.
@@ -83,6 +84,7 @@ public final class Client implements AutoCloseable {
 
     private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
     private Duration closeTimeout = DEFAULT_CLOSE_TIMEOUT;
+    private Duration grpcDeadline = DEFAULT_GRPC_DEADLINE;
 
     private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
 
@@ -1237,6 +1239,34 @@ public final class Client implements AutoCloseable {
         this.closeTimeout = Objects.requireNonNull(closeTimeout);
         network.setCloseTimeout(closeTimeout);
         mirrorNetwork.setCloseTimeout(closeTimeout);
+        return this;
+    }
+
+    /**
+     * Maximum amount of time a gRPC request can run
+     *
+     * @return                          the gRPC deadline value
+     */
+    @SuppressFBWarnings(
+        value = "EI_EXPOSE_REP",
+        justification = "A Duration can't actually be mutated"
+    )
+    public synchronized Duration getGrpcDeadline() {
+        return grpcDeadline;
+    }
+
+    /**
+     * Set the maximum amount of time a gRPC request can run.
+     *
+     * @param grpcDeadline            the gRPC deadline value
+     * @return {@code this}
+     */
+    @SuppressFBWarnings(
+        value = "EI_EXPOSE_REP2",
+        justification = "A Duration can't actually be mutated"
+    )
+    public synchronized Client setGrpcDeadline(Duration grpcDeadline) {
+        this.grpcDeadline = Objects.requireNonNull(grpcDeadline);
         return this;
     }
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -84,7 +84,7 @@ public final class Client implements AutoCloseable {
 
     private Duration requestTimeout = DEFAULT_REQUEST_TIMEOUT;
     private Duration closeTimeout = DEFAULT_CLOSE_TIMEOUT;
-    private Duration grpcDeadline = DEFAULT_GRPC_DEADLINE;
+    private volatile Duration grpcDeadline = DEFAULT_GRPC_DEADLINE;
 
     private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
 
@@ -1251,7 +1251,7 @@ public final class Client implements AutoCloseable {
         value = "EI_EXPOSE_REP",
         justification = "A Duration can't actually be mutated"
     )
-    public synchronized Duration getGrpcDeadline() {
+    public Duration getGrpcDeadline() {
         return grpcDeadline;
     }
 
@@ -1265,7 +1265,7 @@ public final class Client implements AutoCloseable {
         value = "EI_EXPOSE_REP2",
         justification = "A Duration can't actually be mutated"
     )
-    public synchronized Client setGrpcDeadline(Duration grpcDeadline) {
+    public Client setGrpcDeadline(Duration grpcDeadline) {
         this.grpcDeadline = Objects.requireNonNull(grpcDeadline);
         return this;
     }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
@@ -355,12 +355,12 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
                 throw new MaxAttemptsExceededException(lastException);
             }
 
-            Duration deadline = Duration.between(Instant.now(), timeoutTime);
-            if (deadline.isNegative() || deadline.isZero()) {
+            Duration currentTimeout = Duration.between(Instant.now(), timeoutTime);
+            if (currentTimeout.isNegative() || currentTimeout.isZero()) {
                 throw new TimeoutException();
             }
 
-            GrpcRequest grpcRequest = new GrpcRequest(client.network, attempt, deadline);
+            GrpcRequest grpcRequest = new GrpcRequest(client.network, attempt, currentTimeout);
             Node node = grpcRequest.getNode();
             ResponseT response = null;
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
@@ -353,9 +353,12 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
                 throw new MaxAttemptsExceededException(lastException);
             }
 
-            if (Instant.now().isAfter(timeoutTime)) {
+            Duration deadline = Duration.between(Instant.now(), timeoutTime);
+            if (deadline.isNegative() || deadline.isZero()) {
                 throw new TimeoutException();
             }
+
+            this.setGrpcDeadline(deadline);
 
             GrpcRequest grpcRequest = new GrpcRequest(client.network, attempt);
             Node node = grpcRequest.getNode();


### PR DESCRIPTION
Signed-off-by: Nikola Genov <nikola.genov@limechain.tech>

**Description**:

* `Executable.execute(Client client, Duration timeout)` now sets gRPC deadline to the underlying gRPC request
* new executableShouldUseGrpcDeadline() added to ExecutableTest.java

* **Related issue(s)**:

Fixes #1226 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
