### PR TITLE
Fix/reported duplicate transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+ - `Executable.execute(Client client, Duration timeout)` now sets gRPC deadline to the underlying gRPC request
+ - Transaction sometimes being reported as duplicate when submitting large number of transactions
+
 ## 2.18.2
 
 ### Fixed
  - `Client.close()` now tracks and automatically unsubscribes from Mirror Node Topic Queries
- - `Executable.execute(Client client, Duration timeout)` now sets gRPC deadline to the underlying gRPC request
 
 ## 2.18.1
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNode.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNode.java
@@ -298,6 +298,7 @@ abstract class BaseNode<N extends BaseNode<N, KeyT>, KeyT> {
             .keepAliveTimeout(10, TimeUnit.SECONDS)
             .userAgent(getUserAgent())
             .executor(executor)
+            .disableRetry()
             .build();
 
         return channel;


### PR DESCRIPTION
Signed-off-by: dikel <dikelito@tutamail.com>

**Description**:
Fixes transaction sometimes being reported as duplicate when submitting large number of transactions.

**Related issue(s)**: 

Fixes #1088 

**Notes for reviewer**:
From the grpc documentation

> `disableRetry()`: Disables the retry and hedging subsystem provided by the gRPC library. This is designed for the case when users have their own retry implementation and want to avoid their own retry taking place simultaneously with the gRPC library layer retry.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
