### PR TITLE
BIP39 - mnemonic passphrase normalize to NFKD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Transaction sometimes being reported as duplicate when submitting large number of transactions
  - `RejectedExecutionException` under heavy load
  - `nodes` not clearing when reusing transaction
+ - BIP-39 - unicode mnemonic passphrases are normalized to NFKD
 
 ## 2.18.2
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Mnemonic.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Mnemonic.java
@@ -35,6 +35,7 @@ import java.lang.ref.SoftReference;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
+import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -418,7 +419,7 @@ public final class Mnemonic {
      * @return the byte array
      */
     byte[] toSeed(String passphrase) {
-        String salt = "mnemonic" + passphrase;
+        String salt = Normalizer.normalize("mnemonic" + passphrase, Normalizer.Form.NFKD);
 
         // BIP-39 seed generation
         PKCS5S2ParametersGenerator pbkdf2 = new PKCS5S2ParametersGenerator(new SHA512Digest());

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/MnemonicTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/MnemonicTest.java
@@ -321,4 +321,18 @@ public class MnemonicTest {
         PrivateKey key = mnemonic.toPrivateKey();
         assertThat(key.toString()).isEqualTo(MNEMONIC_PRIVATE_KEY);
     }
+
+    @Test
+    @DisplayName("Mnemonic passphrase test")
+    void mnemonicPassphraseTest() throws Exception {
+        // Test if mnemonic passphrase is BIP-39 compliant which requires unicode phrases to be NFKD normalized.
+        // Use unicode string as a passphrase. If it is properly normalized to NFKD,
+        // it should generate the expectedPrivateKey bellow:
+        String passphrase = "\u03B4\u03BF\u03BA\u03B9\u03BC\u03AE";
+        String expectedPrivateKey = "302e020100300506032b6570042204203fefe1000db9485372851d542453b07e7970de4e2ecede7187d733ac037f4d2c";
+
+        Mnemonic mnemonic = Mnemonic.fromString(MNEMONIC_STRING);
+        PrivateKey key = mnemonic.toPrivateKey(passphrase);
+        assertThat(key.toString()).isEqualTo(expectedPrivateKey);
+    }
 }


### PR DESCRIPTION
Signed-off-by: Nikola Genov <nikola.genov@limechain.tech>

**Description**:

This PR modifies Mnemonic seed generation when a passphrase is used. In order to support BIP-39 the passphrase is normalized to NFKD.

**Related issue(s)**:

Fixes #1240 

**Notes for reviewer**:
Should we normalize the whole mnemonic and not just the passphrase?

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
