### PR TITLE
fix: rename allowanceSpenderAccountId to spenderId in TokenNftInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Transaction sometimes being reported as duplicate when submitting large number of transactions
  - `RejectedExecutionException` under heavy load
  - `nodes` not clearing when reusing transaction
+ - Renamed allowanceSpenderAccountId to spenderId in TokenNftInfo
 
 ## 2.18.2
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenNftInfo.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenNftInfo.java
@@ -22,7 +22,6 @@ package com.hedera.hashgraph.sdk;
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.hedera.hashgraph.sdk.proto.TokenGetNftInfoResponse;
 import org.threeten.bp.Instant;
 
 import javax.annotation.Nullable;
@@ -63,7 +62,7 @@ public class TokenNftInfo {
      * If an allowance is granted for the NFT, its corresponding spender account
      */
     @Nullable
-    public final AccountId allowanceSpenderAccountId;
+    public final AccountId spenderId;
 
     /**
      * Constructor.
@@ -73,7 +72,7 @@ public class TokenNftInfo {
      * @param creationTime              the effective consensus time
      * @param metadata                  the unique metadata
      * @param ledgerId                  the ledger id of the response
-     * @param allowanceSpenderAccountId the spender of the allowance (null if not an allowance)
+     * @param spenderId the spender of the allowance (null if not an allowance)
      */
     TokenNftInfo(
         NftId nftId,
@@ -81,14 +80,14 @@ public class TokenNftInfo {
         Instant creationTime,
         byte[] metadata,
         LedgerId ledgerId,
-        @Nullable AccountId allowanceSpenderAccountId
+        @Nullable AccountId spenderId
     ) {
         this.nftId = nftId;
         this.accountId = accountId;
         this.creationTime = Objects.requireNonNull(creationTime);
         this.metadata = metadata;
         this.ledgerId = ledgerId;
-        this.allowanceSpenderAccountId = allowanceSpenderAccountId;
+        this.spenderId = spenderId;
     }
 
     /**
@@ -131,8 +130,8 @@ public class TokenNftInfo {
             .setCreationTime(InstantConverter.toProtobuf(creationTime))
             .setMetadata(ByteString.copyFrom(metadata))
             .setLedgerId(ledgerId.toByteString());
-        if (allowanceSpenderAccountId != null) {
-            builder.setSpenderId(allowanceSpenderAccountId.toProtobuf());
+        if (spenderId != null) {
+            builder.setSpenderId(spenderId.toProtobuf());
         }
         return builder.build();
     }
@@ -145,7 +144,7 @@ public class TokenNftInfo {
             .add("creationTime", creationTime)
             .add("metadata", metadata)
             .add("ledgerId", ledgerId)
-            .add("allowanceSpenderAccountId", allowanceSpenderAccountId)
+            .add("spenderId", spenderId)
             .toString();
     }
 

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenNftInfoTest.snap
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenNftInfoTest.snap
@@ -1,8 +1,8 @@
 com.hedera.hashgraph.sdk.TokenNftInfoTest.shouldSerialize=[
-  "TokenNftInfo{nftId=1.2.3/4, accountId=5.6.7, creationTime=2019-04-01T22:42:22Z, metadata=[-34, -83, -66, -17], ledgerId=mainnet, allowanceSpenderAccountId=8.9.10}"
+  "TokenNftInfo{nftId=1.2.3/4, accountId=5.6.7, creationTime=2019-04-01T22:42:22Z, metadata=[-34, -83, -66, -17], ledgerId=mainnet, spenderId=8.9.10}"
 ]
 
 
 com.hedera.hashgraph.sdk.TokenNftInfoTest.shouldSerializeNullSpender=[
-  "TokenNftInfo{nftId=1.2.3/4, accountId=5.6.7, creationTime=2019-04-01T22:42:22Z, metadata=[-34, -83, -66, -17], ledgerId=mainnet, allowanceSpenderAccountId=null}"
+  "TokenNftInfo{nftId=1.2.3/4, accountId=5.6.7, creationTime=2019-04-01T22:42:22Z, metadata=[-34, -83, -66, -17], ledgerId=mainnet, spenderId=null}"
 ]


### PR DESCRIPTION
Signed-off-by: dikel <dikelito@tutamail.com>

**Description**:
Renames allowanceSpenderAccountId to spenderId in TokenNftInfo to follow the protobuf specification.

**Related issue(s)**:

Fixes #1254 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
