### PR TITLE
Bump protobuf-javalite to 3.21.9

### DIFF
--- a/sdk/protobuf-lite.gradle
+++ b/sdk/protobuf-lite.gradle
@@ -3,7 +3,7 @@ dependencies {
 
     // Protobuf Lite is used to maintain easy compatibility with Android
     // https://github.com/protocolbuffers/protobuf/blob/master/java/lite.md
-    api "com.google.protobuf:protobuf-javalite:3.21.1"
+    api "com.google.protobuf:protobuf-javalite:3.21.9"
 }
 
 protobuf {


### PR DESCRIPTION
**Description**:

Bump protobuf-javalite from 3.21.1 to 3.21.9 to fix https://nvd.nist.gov/vuln/detail/CVE-2022-3171

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
