### PR TITLE
Fix error handling and logging in TopicMessageQuery

### DIFF
--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageQueryTest.java
@@ -356,13 +356,19 @@ class TopicMessageQueryTest {
 
     @Test
     @Timeout(5)
-    void noErrorWhenCallIsCancelled() {
+    void errorWhenCallIsCancelled() {
         consensusServiceStub.requests.add(request().build());
         consensusServiceStub.responses.add(Status.CANCELLED.asRuntimeException());
 
         subscribeToMirror(received::add);
 
-        assertThat(errors).isEmpty();
+        assertThat(errors)
+            .hasSize(1)
+            .first()
+            .isInstanceOf(StatusRuntimeException.class)
+            .extracting(t -> ((StatusRuntimeException)t).getStatus())
+            .isEqualTo(Status.CANCELLED);
+
         assertThat(received).isEmpty();
     }
 


### PR DESCRIPTION
Signed-off-by: Nikola Genov <nikola.genov@limechain.tech>

**Description**:

This PR modifies the onError logic in TopicMessageQuery to properly handle and log Cancelled status codes.

**Related issue(s)**:

Fixes #1278 

**Notes for reviewer**:
I couldn't find a clean solution to unit test the actual Logger Warn Message, currently the logger is a static field and it's not easy to mock it (LoggerFactory as well).

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
