### PR TITLE
fix: misleading logging when an unhealthy node is hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - `TRANSACTION_HAS_UNKNOWN_FIELDS` and `ACCOUNT_IS_IMMUTABLE` in `Status`
 
+### Fixed
+ - Misleading logging when an unhealthy node is hit
+
 ## 2.19.0
 
 ### Added

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
@@ -784,8 +784,8 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
 
         Throwable reactToConnectionFailure() {
             Objects.requireNonNull(network).increaseBackoff(node);
-            logger.warn("Retrying node {} in {} ms after channel connection failure during attempt #{}",
-                node.getAccountId(), node.getRemainingTimeForBackoff(), attempt);
+            logger.warn("Retrying in {} ms after channel connection failure with node {} during attempt #{}",
+                node.getRemainingTimeForBackoff(), node.getAccountId(), attempt);
             verboseLog(node);
             return new IllegalStateException("Failed to connect to node " + node.getAccountId());
         }
@@ -797,8 +797,8 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
 
             if (retry) {
                 Objects.requireNonNull(network).increaseBackoff(node);
-                logger.warn("Retrying node {} in {} ms after failure during attempt #{}: {}",
-                    node.getAccountId(), node.getRemainingTimeForBackoff(), attempt, e != null ? e.getMessage() : "NULL");
+                logger.warn("Retrying in {} ms after failure with node {} during attempt #{}: {}",
+                    node.getRemainingTimeForBackoff(), node.getAccountId(), attempt, e != null ? e.getMessage() : "NULL");
                 verboseLog(node);
             }
 
@@ -833,8 +833,8 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
             }
             switch (executionState) {
                 case Retry:
-                    logger.warn("Retrying node {} in {} ms after failure during attempt #{}: {}",
-                        node.getAccountId(), delay, attempt, responseStatus);
+                    logger.warn("Retrying in {} ms after failure with node {} during attempt #{}: {}",
+                        delay, node.getAccountId(), attempt, responseStatus);
                     verboseLog(node);
                     break;
                 case ServerError:


### PR DESCRIPTION
Signed-off-by: dikel <dikelito@tutamail.com>

**Description**:
Currently the logging when the SDK hit an unhealthy node is misleading. It says that it will retry with the same node but in reality a different node is used.

**Related issue(s)**:

Fixes #1288 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
