### PR TITLE
fix: Replace double-checked locking in getSpecificWordList()

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Mnemonic.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Mnemonic.java
@@ -218,22 +218,17 @@ public final class Mnemonic {
         }
     }
 
-    private static List<String> getSpecificWordList(
+    private static synchronized List<String> getSpecificWordList(
         Supplier<SoftReference<List<String>>> getCurrentWordList,
         Supplier<List<String>> getNewWordList,
         Consumer<SoftReference<List<String>>> setCurrentWordList
     ) {
         var localWordList = getCurrentWordList.get();
         if (localWordList == null || localWordList.get() == null) {
-            synchronized (Mnemonic.class) {
-                localWordList = getCurrentWordList.get();
-                if (localWordList == null || localWordList.get() == null) {
-                    List<String> words = getNewWordList.get();
-                    setCurrentWordList.accept(new SoftReference<>(words));
-                    // immediately return the strong reference
-                    return words;
-                }
-            }
+            List<String> words = getNewWordList.get();
+            setCurrentWordList.accept(new SoftReference<>(words));
+            // immediately return the strong reference
+            return words;
         }
 
         return localWordList.get();


### PR DESCRIPTION
…ked locking

**Description**:
Makes `Mnemonic.getSpecificWordList()` synchronized and removes the double-checked locking idiom

**Related issue(s)**:

Fixes #1334 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
