### PR TITLE
Chore: remove references for lazy account creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - `AccountId.fromEvmAddress()`
  - `AccountId.fromString()` now supports EVM address
  - `TransferTransaction.addHbarTransfer()` now supports EVM address
- - `LazyCreateTransferTransactionExample`
+ - `AutoCreateAccountTransferTransactionExample`
  - `TransferUsingEvmAddressExample`
  - `AccountCreationWaysExample`
 

--- a/examples/src/main/java/AccountAliasExample.java
+++ b/examples/src/main/java/AccountAliasExample.java
@@ -51,7 +51,7 @@ public class AccountAliasExample {
         client.setOperator(OPERATOR_ID, OPERATOR_KEY);
 
         /*
-         * Hedera supports a form of lazy account creation.
+         * Hedera supports a form of auto account creation.
          *
          * You can "create" an account by generating a private key, and then deriving the public key,
          * without any need to interact with the Hedera network.  The public key more or less acts as the user's

--- a/examples/src/main/java/AutoCreateAccountTransferTransactionExample.java
+++ b/examples/src/main/java/AutoCreateAccountTransferTransactionExample.java
@@ -2,12 +2,10 @@ import com.hedera.hashgraph.sdk.*;
 import io.github.cdimascio.dotenv.Dotenv;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 
-public class LazyCreateTransferTransactionExample {
+public class AutoCreateAccountTransferTransactionExample {
     // see `.env.sample` in the repository root for how to specify these values
     // or set environment variables with the same names
     private static final AccountId OPERATOR_ID = AccountId.fromString(Objects.requireNonNull(Dotenv.load().get("OPERATOR_ID")));
@@ -15,11 +13,11 @@ public class LazyCreateTransferTransactionExample {
     // HEDERA_NETWORK defaults to testnet if not specified in dotenv
     private static final String HEDERA_NETWORK = Dotenv.load().get("HEDERA_NETWORK", "testnet");
 
-    private LazyCreateTransferTransactionExample() {
+    private AutoCreateAccountTransferTransactionExample() {
     }
 
     /*
-    Lazy-create a new account using a public-address via a `TransferTransaction`.
+    Auto-create a new account using a public-address via a `TransferTransaction`.
     Reference: [HIP-583 Expand alias support in CryptoCreate & CryptoTransfer Transactions](https://hips.hedera.com/hip/hip-583)
     ## Example 2
     - Create an ECSDA private key


### PR DESCRIPTION
**Description**:
Removes references for lazy account creation and renames `LazyCreateTransferTransactionExample` to `AutoCreateAccountTransferTransactionExample`

**Related issue(s)**:

Fixes #1339 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
