### PR TITLE
Fix: remove the insecure port of mirror nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+ - Remove the insecure port of mirror nodes
+
 ## 2.21.0
 
 ### Added

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNetwork.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNetwork.java
@@ -20,7 +20,6 @@
 package com.hedera.hashgraph.sdk;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.errorprone.annotations.Var;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.threeten.bp.Duration;
 import org.threeten.bp.Instant;

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNetwork.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNetwork.java
@@ -271,36 +271,6 @@ abstract class BaseNetwork<
     }
 
     /**
-     * Enable or disable transport security (TLS).
-     *
-     * @param transportSecurity         should transport security be enabled
-     * @return {@code this}
-     * @throws InterruptedException     when a thread is interrupted while it's waiting, sleeping, or otherwise occupied
-     */
-    synchronized BaseNetworkT setTransportSecurity(boolean transportSecurity) throws InterruptedException {
-        if (this.transportSecurity != transportSecurity) {
-            network.clear();
-
-            for (int i = 0; i < nodes.size(); i++) {
-                @Var var node = nodes.get(i);
-                node.close(closeTimeout);
-
-                node = transportSecurity ? node.toSecure() : node.toInsecure();
-
-                nodes.set(i, node);
-                getNodesForKey(node.getKey()).add(node);
-            }
-        }
-
-        healthyNodes = new ArrayList<>(nodes);
-
-        this.transportSecurity = transportSecurity;
-
-        // noinspection unchecked
-        return (BaseNetworkT) this;
-    }
-
-    /**
      * Extract the close timeout.
      *
      * @return                          the close timeout
@@ -445,16 +415,6 @@ abstract class BaseNetwork<
         nodesForKey.remove(node);
         if (nodesForKey.isEmpty()) {
             this.network.remove(node.getKey());
-        }
-    }
-
-    private List<BaseNodeT> getNodesForKey(KeyT key) {
-        if (network.containsKey(key)) {
-            return network.get(key);
-        } else {
-            var newList = new ArrayList<BaseNodeT>();
-            network.put(key, newList);
-            return newList;
         }
     }
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNode.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNode.java
@@ -125,20 +125,6 @@ abstract class BaseNode<N extends BaseNode<N, KeyT>, KeyT> {
     }
 
     /**
-     * Create an insecure version of this node
-     *
-     * @return                          the insecure version of the node
-     */
-    abstract N toInsecure();
-
-    /**
-     * Create a secure version of this node
-     *
-     * @return                          the secure version of the node
-     */
-    abstract N toSecure();
-
-    /**
      * Extract the key list
      *
      * @return                          the key list

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNodeAddress.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNodeAddress.java
@@ -127,8 +127,8 @@ class BaseNodeAddress {
      * @return                          the insecure managed node address
      */
     public BaseNodeAddress toInsecure() {
-        var port = (this.port == PORT_NODE_TLS) ? PORT_NODE_PLAIN : this.port;
-        return new BaseNodeAddress(name, address, port);
+        var newPort = (this.port == PORT_NODE_TLS) ? PORT_NODE_PLAIN : this.port;
+        return new BaseNodeAddress(name, address, newPort);
     }
 
     /**
@@ -137,8 +137,8 @@ class BaseNodeAddress {
      * @return                          the secure managed node address
      */
     public BaseNodeAddress toSecure() {
-        var port = (this.port == PORT_NODE_PLAIN) ? PORT_NODE_TLS : this.port;
-        return new BaseNodeAddress(name, address, port);
+        var newPort = (this.port == PORT_NODE_PLAIN) ? PORT_NODE_TLS : this.port;
+        return new BaseNodeAddress(name, address, newPort);
     }
 
     @Override

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNodeAddress.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNodeAddress.java
@@ -29,7 +29,6 @@ import java.util.regex.Pattern;
 class BaseNodeAddress {
     private static final Pattern HOST_AND_PORT = Pattern.compile("^(\\S+):(\\d+)$");
     private static final Pattern IN_PROCESS = Pattern.compile("^in-process:(\\S+)$");
-    static final int PORT_MIRROR_PLAIN = 5600;
     static final int PORT_MIRROR_TLS = 443;
     static final int PORT_NODE_PLAIN = 50211;
     static final int PORT_NODE_TLS = 50212;
@@ -128,12 +127,7 @@ class BaseNodeAddress {
      * @return                          the insecure managed node address
      */
     public BaseNodeAddress toInsecure() {
-        var port = switch (this.port) {
-            case PORT_NODE_TLS -> PORT_NODE_PLAIN;
-            case PORT_MIRROR_TLS -> PORT_MIRROR_PLAIN;
-            default -> this.port;
-        };
-
+        var port = (this.port == PORT_NODE_TLS) ? PORT_NODE_PLAIN : this.port;
         return new BaseNodeAddress(name, address, port);
     }
 
@@ -143,12 +137,7 @@ class BaseNodeAddress {
      * @return                          the secure managed node address
      */
     public BaseNodeAddress toSecure() {
-        var port = switch (this.port) {
-            case PORT_NODE_PLAIN -> PORT_NODE_TLS;
-            case PORT_MIRROR_PLAIN -> PORT_MIRROR_TLS;
-            default -> this.port;
-        };
-
+        var port = (this.port == PORT_NODE_PLAIN) ? PORT_NODE_TLS : this.port;
         return new BaseNodeAddress(name, address, port);
     }
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -467,16 +467,17 @@ public final class Client implements AutoCloseable {
     }
 
     /**
+     *
      * Set if transport security should be used to connect to mirror nodes.
      * <br>
      * If transport security is enabled all connections to mirror nodes will use TLS.
      *
+     * @deprecated Mirror nodes can only be accessed using TLS
      * @param transportSecurity - enable or disable transport security for mirror nodes
      * @return {@code this} for fluent API usage.
-     * @throws InterruptedException     when a thread is interrupted while it's waiting, sleeping, or otherwise occupied
      */
-    public Client setMirrorTransportSecurity(boolean transportSecurity) throws InterruptedException {
-        mirrorNetwork.setTransportSecurity(transportSecurity);
+    @Deprecated
+    public Client setMirrorTransportSecurity(boolean transportSecurity) {
         return this;
     }
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/MirrorNetwork.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/MirrorNetwork.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeoutException;
 class MirrorNetwork extends BaseNetwork<MirrorNetwork, BaseNodeAddress, MirrorNode> {
     private MirrorNetwork(ExecutorService executor, List<String> addresses) {
         super(executor);
-
+        this.transportSecurity = true;
         try {
             setNetwork(addresses);
         } catch (InterruptedException | TimeoutException e) {
@@ -60,13 +60,7 @@ class MirrorNetwork extends BaseNetwork<MirrorNetwork, BaseNodeAddress, MirrorNo
      * @return                          the new mirror network for mainnet
      */
     static MirrorNetwork forMainnet(ExecutorService executor) {
-        try {
-            return new MirrorNetwork(executor, Lists.of("mainnet-public.mirrornode.hedera.com:443"))
-                .setTransportSecurity(true);
-        } catch (InterruptedException e) {
-            // should never happen
-            throw new RuntimeException(e);
-        }
+        return new MirrorNetwork(executor, Lists.of("mainnet-public.mirrornode.hedera.com:443"));
     }
 
     /**

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/MirrorNode.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/MirrorNode.java
@@ -61,16 +61,6 @@ class MirrorNode extends BaseNode<MirrorNode, BaseNodeAddress> {
     }
 
     @Override
-    MirrorNode toInsecure() {
-        return new MirrorNode(this, address.toInsecure());
-    }
-
-    @Override
-    MirrorNode toSecure() {
-        return new MirrorNode(this, address.toSecure());
-    }
-
-    @Override
     BaseNodeAddress getKey() {
         return address;
     }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/MirrorNode.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/MirrorNode.java
@@ -45,16 +45,6 @@ class MirrorNode extends BaseNode<MirrorNode, BaseNodeAddress> {
         this(BaseNodeAddress.fromString(address), executor);
     }
 
-    /**
-     * Constructor.
-     *
-     * @param node                      the mirror node
-     * @param address                   the address as a managed node address
-     */
-    private MirrorNode(MirrorNode node, BaseNodeAddress address) {
-        super(node, address);
-    }
-
     @Override
     protected String getAuthority() {
         return null;

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Node.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Node.java
@@ -75,12 +75,20 @@ class Node extends BaseNode<Node, AccountId> {
         this.addressBookEntry = node.addressBookEntry;
     }
 
-    @Override
+    /**
+     * Create an insecure version of this node
+     *
+     * @return                          the insecure version of the node
+     */
     Node toInsecure() {
         return new Node(this, address.toInsecure());
     }
 
-    @Override
+    /**
+     * Create a secure version of this node
+     *
+     * @return                          the secure version of the node
+     */
     Node toSecure() {
         return new Node(this, address.toSecure());
     }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/BaseNodeAddressTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/BaseNodeAddressTest.java
@@ -34,67 +34,67 @@ public class BaseNodeAddressTest {
         assertThat(ipAddress.getName()).isNull();
         assertThat(ipAddress.getAddress()).isEqualTo("35.237.200.180");
         assertThat(ipAddress.getPort()).isEqualTo(PORT_NODE_PLAIN);
-        assertThat(ipAddress.toString()).isEqualTo("35.237.200.180:50211");
+        assertThat(ipAddress).hasToString("35.237.200.180:50211");
 
         var ipAddressSecure = ipAddress.toSecure();
         assertThat(ipAddressSecure.getName()).isNull();
         assertThat(ipAddressSecure.getAddress()).isEqualTo("35.237.200.180");
         assertThat(ipAddressSecure.getPort()).isEqualTo(PORT_NODE_TLS);
-        assertThat(ipAddressSecure.toString()).isEqualTo("35.237.200.180:50212");
+        assertThat(ipAddressSecure).hasToString("35.237.200.180:50212");
 
         var ipAddressInsecure = ipAddressSecure.toInsecure();
         assertThat(ipAddressInsecure.getName()).isNull();
         assertThat(ipAddressInsecure.getAddress()).isEqualTo("35.237.200.180");
         assertThat(ipAddressInsecure.getPort()).isEqualTo(PORT_NODE_PLAIN);
-        assertThat(ipAddressInsecure.toString()).isEqualTo("35.237.200.180:50211");
+        assertThat(ipAddressInsecure).hasToString("35.237.200.180:50211");
 
         var urlAddress = BaseNodeAddress.fromString("0.testnet.hedera.com:50211");
         assertThat(urlAddress.getName()).isNull();
         assertThat(urlAddress.getAddress()).isEqualTo("0.testnet.hedera.com");
         assertThat(urlAddress.getPort()).isEqualTo(PORT_NODE_PLAIN);
-        assertThat(urlAddress.toString()).isEqualTo("0.testnet.hedera.com:50211");
+        assertThat(urlAddress).hasToString("0.testnet.hedera.com:50211");
 
         var urlAddressSecure = urlAddress.toSecure();
         assertThat(urlAddressSecure.getName()).isNull();
         assertThat(urlAddressSecure.getAddress()).isEqualTo("0.testnet.hedera.com");
         assertThat(urlAddressSecure.getPort()).isEqualTo(PORT_NODE_TLS);
-        assertThat(urlAddressSecure.toString()).isEqualTo("0.testnet.hedera.com:50212");
+        assertThat(urlAddressSecure).hasToString("0.testnet.hedera.com:50212");
 
         var urlAddressInsecure = urlAddressSecure.toInsecure();
         assertThat(urlAddressInsecure.getName()).isNull();
         assertThat(urlAddressInsecure.getAddress()).isEqualTo("0.testnet.hedera.com");
         assertThat(urlAddressInsecure.getPort()).isEqualTo(PORT_NODE_PLAIN);
-        assertThat(urlAddressInsecure.toString()).isEqualTo("0.testnet.hedera.com:50211");
+        assertThat(urlAddressInsecure).hasToString("0.testnet.hedera.com:50211");
 
         var processAddress = BaseNodeAddress.fromString("in-process:testingProcess");
         assertThat(processAddress.getName()).isEqualTo("testingProcess");
         assertThat(processAddress.getAddress()).isNull();
         assertThat(processAddress.getPort()).isEqualTo(0);
-        assertThat(processAddress.toString()).isEqualTo("testingProcess");
+        assertThat(processAddress).hasToString("testingProcess");
 
         var processAddressSecure = processAddress.toSecure();
         assertThat(processAddressSecure.getName()).isEqualTo("testingProcess");
         assertThat(processAddressSecure.getAddress()).isNull();
         assertThat(processAddressSecure.getPort()).isEqualTo(0);
-        assertThat(processAddressSecure.toString()).isEqualTo("testingProcess");
+        assertThat(processAddressSecure).hasToString("testingProcess");
 
         var processAddressInsecure = processAddressSecure.toInsecure();
         assertThat(processAddressInsecure.getName()).isEqualTo("testingProcess");
         assertThat(processAddressInsecure.getAddress()).isNull();
         assertThat(processAddressInsecure.getPort()).isEqualTo(0);
-        assertThat(processAddressInsecure.toString()).isEqualTo("testingProcess");
+        assertThat(processAddressInsecure).hasToString("testingProcess");
 
         var mirrorNodeAddress = BaseNodeAddress.fromString("mainnet-public.mirrornode.hedera.com:443");
         assertThat(mirrorNodeAddress.getName()).isNull();
         assertThat(mirrorNodeAddress.getAddress()).isEqualTo("mainnet-public.mirrornode.hedera.com");
         assertThat(mirrorNodeAddress.getPort()).isEqualTo(PORT_MIRROR_TLS);
-        assertThat(mirrorNodeAddress.toString()).isEqualTo("mainnet-public.mirrornode.hedera.com:443");
+        assertThat(mirrorNodeAddress).hasToString("mainnet-public.mirrornode.hedera.com:443");
 
         var mirrorNodeAddressSecure = mirrorNodeAddress.toSecure();
         assertThat(mirrorNodeAddressSecure.getName()).isNull();
         assertThat(mirrorNodeAddressSecure.getAddress()).isEqualTo("mainnet-public.mirrornode.hedera.com");
         assertThat(mirrorNodeAddressSecure.getPort()).isEqualTo(PORT_MIRROR_TLS);
-        assertThat(mirrorNodeAddressSecure.toString()).isEqualTo("mainnet-public.mirrornode.hedera.com:443");
+        assertThat(mirrorNodeAddressSecure).hasToString("mainnet-public.mirrornode.hedera.com:443");
 
         assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> BaseNodeAddress.fromString("this is a random string with spaces:443"));
         assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> BaseNodeAddress.fromString("mainnet-public.mirrornode.hedera.com:notarealport"));

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/BaseNodeAddressTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/BaseNodeAddressTest.java
@@ -21,7 +21,6 @@ package com.hedera.hashgraph.sdk;
 
 import org.junit.jupiter.api.Test;
 
-import static com.hedera.hashgraph.sdk.BaseNodeAddress.PORT_MIRROR_PLAIN;
 import static com.hedera.hashgraph.sdk.BaseNodeAddress.PORT_MIRROR_TLS;
 import static com.hedera.hashgraph.sdk.BaseNodeAddress.PORT_NODE_PLAIN;
 import static com.hedera.hashgraph.sdk.BaseNodeAddress.PORT_NODE_TLS;
@@ -85,23 +84,17 @@ public class BaseNodeAddressTest {
         assertThat(processAddressInsecure.getPort()).isEqualTo(0);
         assertThat(processAddressInsecure.toString()).isEqualTo("testingProcess");
 
-        var mirrorNodeAddress = BaseNodeAddress.fromString("mainnet-public.mirrornode.hedera.com:5600");
+        var mirrorNodeAddress = BaseNodeAddress.fromString("mainnet-public.mirrornode.hedera.com:443");
         assertThat(mirrorNodeAddress.getName()).isNull();
         assertThat(mirrorNodeAddress.getAddress()).isEqualTo("mainnet-public.mirrornode.hedera.com");
-        assertThat(mirrorNodeAddress.getPort()).isEqualTo(PORT_MIRROR_PLAIN);
-        assertThat(mirrorNodeAddress.toString()).isEqualTo("mainnet-public.mirrornode.hedera.com:5600");
+        assertThat(mirrorNodeAddress.getPort()).isEqualTo(PORT_MIRROR_TLS);
+        assertThat(mirrorNodeAddress.toString()).isEqualTo("mainnet-public.mirrornode.hedera.com:443");
 
         var mirrorNodeAddressSecure = mirrorNodeAddress.toSecure();
         assertThat(mirrorNodeAddressSecure.getName()).isNull();
         assertThat(mirrorNodeAddressSecure.getAddress()).isEqualTo("mainnet-public.mirrornode.hedera.com");
         assertThat(mirrorNodeAddressSecure.getPort()).isEqualTo(PORT_MIRROR_TLS);
         assertThat(mirrorNodeAddressSecure.toString()).isEqualTo("mainnet-public.mirrornode.hedera.com:443");
-
-        var mirrorNodeAddressInsecure = mirrorNodeAddressSecure.toInsecure();
-        assertThat(mirrorNodeAddressInsecure.getName()).isNull();
-        assertThat(mirrorNodeAddressInsecure.getAddress()).isEqualTo("mainnet-public.mirrornode.hedera.com");
-        assertThat(mirrorNodeAddressInsecure.getPort()).isEqualTo(PORT_MIRROR_PLAIN);
-        assertThat(mirrorNodeAddressInsecure.toString()).isEqualTo("mainnet-public.mirrornode.hedera.com:5600");
 
         assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> BaseNodeAddress.fromString("this is a random string with spaces:443"));
         assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> BaseNodeAddress.fromString("mainnet-public.mirrornode.hedera.com:notarealport"));


### PR DESCRIPTION
**Description**:
Changes:
- `setTransportSecurity()` and `getNodesForKey()` moved from `BaseNetwork` to `Network`
- `toInsecure()` and `toSecure()` moved from `BaseNode` to `Node`
- Removed `PORT_MIRROR_PLAIN` from `BaseNodeAddress`

**Related issue(s)**:

Fixes #1316 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
