### PR TITLE
Node retry logic - retry all node proxies if a single node is specified

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNetwork.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNetwork.java
@@ -488,27 +488,36 @@ abstract class BaseNetwork<
     }
 
     /**
-     * Get a random node by key, or if null get a random healthy node.
+     * Get a random healthy node.
      *
-     * @param key                       the desired key
      * @return                          the node
      */
-    synchronized BaseNodeT getNode(@Nullable KeyT key) {
+    synchronized BaseNodeT getRandomNode() {
         // Attempt to readmit nodes each time a node is fetched.
         // Note: Readmitting nodes will only happen periodically so calling it each time should not harm
         // performance.
         readmitNodes();
 
-        if (key == null) {
-            if (healthyNodes.isEmpty()) {
-                throw new IllegalStateException("No healthy node was found");
-            }
-
-            return healthyNodes.get(random.nextInt(healthyNodes.size()));
+        if (healthyNodes.isEmpty()) {
+            throw new IllegalStateException("No healthy node was found");
         }
 
-        var list = network.get(key);
-        return list.get(random.nextInt(list.size()));
+        return healthyNodes.get(random.nextInt(healthyNodes.size()));
+    }
+
+    /**
+     * Get all node proxies by key
+     *
+     * @param key                       the desired key
+     * @return                          the list of node proxies
+     */
+    synchronized List<BaseNodeT> getNodeProxies(KeyT key) {
+        // Attempt to readmit nodes each time a node is fetched.
+        // Note: Readmitting nodes will only happen periodically so calling it each time should not harm
+        // performance.
+        readmitNodes();
+
+        return network.get(key);
     }
 
     /**
@@ -528,7 +537,7 @@ abstract class BaseNetwork<
         var returnNodes = new HashMap<KeyT, BaseNodeT>(count);
 
         for (var i = 0; i < count; i++ ) {
-            var node = getNode(null);
+            var node = getRandomNode();
 
             if (!returnNodes.containsKey(node.getKey())) {
                 returnNodes.put(node.getKey(), node);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
@@ -37,10 +37,7 @@ import org.threeten.bp.Duration;
 import org.threeten.bp.Instant;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Random;
+import java.util.*;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -62,7 +59,6 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
     static final Pattern RST_STREAM = Pattern
         .compile(".*\\brst[^0-9a-zA-Z]stream\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
-    protected static final Random random = new Random();
 
     /**
      * Used for logging
@@ -577,6 +573,7 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
             }
 
             nodes.addAll(nodeProxies);
+            nodes.shuffle();
 
             return;
         }
@@ -590,7 +587,7 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
                 throw new IllegalStateException("Some node account IDs did not map to valid nodes in the client's network");
             }
 
-            var node = nodeProxies.get(random.nextInt(nodeProxies.size()));
+            var node = nodeProxies.get(new Random().nextInt(nodeProxies.size()));
 
             nodes.add(Objects.requireNonNull(node));
         }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
@@ -573,14 +573,14 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
                 throw new IllegalStateException("Account ID did not map to valid node in the client's network");
             }
 
-            nodes.addAll(nodeProxies);
-            nodes.shuffle();
+            nodes.addAll(nodeProxies).shuffle();
 
             return;
         }
 
         // When multiple nodes are available the system retries with different node on each attempt
         // instead of different proxy of the same node
+        var random = new Random();
         for (var accountId : nodeAccountIds) {
             @Nullable
             var nodeProxies = client.network.getNodeProxies(accountId);
@@ -588,7 +588,7 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
                 throw new IllegalStateException("Some node account IDs did not map to valid nodes in the client's network");
             }
 
-            var node = nodeProxies.get(new Random().nextInt(nodeProxies.size()));
+            var node = nodeProxies.get(random.nextInt(nodeProxies.size()));
 
             nodes.add(Objects.requireNonNull(node));
         }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
@@ -59,6 +59,8 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
     static final Pattern RST_STREAM = Pattern
         .compile(".*\\brst[^0-9a-zA-Z]stream\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
+    @SuppressWarnings("java:S2245")
+    protected static final Random random = new Random();
 
     /**
      * Used for logging
@@ -580,7 +582,6 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
 
         // When multiple nodes are available the system retries with different node on each attempt
         // instead of different proxy of the same node
-        var random = new Random();
         for (var accountId : nodeAccountIds) {
             @Nullable
             var nodeProxies = client.network.getNodeProxies(accountId);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
@@ -40,6 +40,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Random;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -60,6 +61,8 @@ import static com.hedera.hashgraph.sdk.FutureConverter.toCompletableFuture;
 abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, ResponseT extends MessageLite, O> {
     static final Pattern RST_STREAM = Pattern
         .compile(".*\\brst[^0-9a-zA-Z]stream\\b.*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    protected static final Random random = new Random();
 
     /**
      * Used for logging
@@ -92,7 +95,7 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
     /**
      * List of healthy and unhealthy nodes with which execution will be attempted.
      */
-    protected List<Node> nodes = new ArrayList<>();
+    protected LockableList<Node> nodes = new LockableList<>();
 
     /**
      * Indicates if the request has been attempted to be sent to all nodes
@@ -564,12 +567,31 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
     @VisibleForTesting
     void setNodesFromNodeAccountIds(Client client) {
         nodes.clear();
+
+        // When a single node is explicitly set we get all of its proxies so in case of
+        // failure the system can retry with different proxy on each attempt
+        if (nodeAccountIds.size() == 1) {
+            var nodeProxies = client.network.getNodeProxies(nodeAccountIds.get(0));
+            if (nodeProxies == null || nodeProxies.size() == 0) {
+                throw new IllegalStateException("Account ID did not map to valid node in the client's network");
+            }
+
+            nodes.addAll(nodeProxies);
+
+            return;
+        }
+
+        // When multiple nodes are available the system retries with different node on each attempt
+        // instead of different proxy of the same node
         for (var accountId : nodeAccountIds) {
             @Nullable
-            var node = client.network.getNode(accountId);
-            if (node == null) {
+            var nodeProxies = client.network.getNodeProxies(accountId);
+            if (nodeProxies == null || nodeProxies.size() == 0) {
                 throw new IllegalStateException("Some node account IDs did not map to valid nodes in the client's network");
             }
+
+            var node = nodeProxies.get(random.nextInt(nodeProxies.size()));
+
             nodes.add(Objects.requireNonNull(node));
         }
     }
@@ -588,9 +610,9 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
 
         for (int _i = 0; _i < nodes.size(); _i++) {
             // NOTE: _i is NOT the index into this.nodes, it is just keeping track of how many times we've iterated.
-            // In the event of ServerErrors, this method depends on nodeAccountIds.getIndex() to have advanced to
-            // the next node.  nodeAccountIds gets advanced in advanceRequest().
-            node = nodes.get(nodeAccountIds.getIndex());
+            // In the event of ServerErrors, this method depends on the nodes list to have advanced to
+            // the next node.
+            node = nodes.getCurrent();
 
             if (!node.isHealthy()) {
                 // Keep track of the node with the smallest delay seen thus far. If we go through the entire list
@@ -727,7 +749,10 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
             attemptedAllNodes = true;
         }
 
-        nodeAccountIds.advance();
+        nodes.advance();
+        if (nodeAccountIds.size() > 1) {
+            nodeAccountIds.advance();
+        }
     }
 
     /**

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
@@ -560,6 +560,7 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
             logger.trace(" - Error: {}", error.getMessage());
     }
 
+    @SuppressWarnings("java:S2245")
     @VisibleForTesting
     void setNodesFromNodeAccountIds(Client client) {
         nodes.clear();

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/LockableList.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/LockableList.java
@@ -19,10 +19,7 @@
  */
 package com.hedera.hashgraph.sdk;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 /**
  * Internal utility class for a new lockable list type.
@@ -117,6 +114,19 @@ class LockableList<T> implements Iterable<T> {
         requireNotLocked();
 
         list.addAll(elements);
+
+        return this;
+    }
+
+    /**
+     * Shuffle the list items.
+     *
+     * @return                          the updated list
+     */
+    public LockableList<T> shuffle() {
+        requireNotLocked();
+
+        Collections.shuffle(list);
 
         return this;
     }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/LockableList.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/LockableList.java
@@ -20,6 +20,7 @@
 package com.hedera.hashgraph.sdk;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
@@ -102,6 +103,20 @@ class LockableList<T> implements Iterable<T> {
         for (var e : elements) {
             list.add(e);
         }
+
+        return this;
+    }
+
+    /**
+     * Add all items to this list instance.
+     *
+     * @param elements                  the list of items to add
+     * @return                          the updated list
+     */
+    LockableList<T> addAll(Collection<? extends T> elements) {
+        requireNotLocked();
+
+        list.addAll(elements);
 
         return this;
     }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ExecutableTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ExecutableTest.java
@@ -65,9 +65,9 @@ class ExecutableTest {
         when(node3.getAccountId()).thenReturn(new AccountId(3));
         when(node4.getAccountId()).thenReturn(new AccountId(4));
         when(node5.getAccountId()).thenReturn(new AccountId(5));
-        when(network.getNode(new AccountId(3))).thenReturn(node3);
-        when(network.getNode(new AccountId(4))).thenReturn(node4);
-        when(network.getNode(new AccountId(5))).thenReturn(node5);
+        when(network.getNodeProxies(new AccountId(3))).thenReturn(List.of(node3));
+        when(network.getNodeProxies(new AccountId(4))).thenReturn(List.of(node4));
+        when(network.getNodeProxies(new AccountId(5))).thenReturn(List.of(node5));
 
         nodeAccountIds = Arrays.asList(
             new AccountId(3),
@@ -220,6 +220,7 @@ class ExecutableTest {
         var node = tx.getNodeForExecute(1);
         assertThat(node).isEqualTo(node3);
         tx.nodeAccountIds.advance();
+        tx.nodes.advance();
 
         node = tx.getNodeForExecute(2);
         assertThat(node).isEqualTo(node3);


### PR DESCRIPTION
**Description**:

This PR modifies the node retry logic in order to support all node proxies on a single node account id.


**Related issue(s)**:

Fixes #796 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
