### PR TITLE
Fix for `java.lang.VerifyError` exception in examples.

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,10 +1,11 @@
 dependencies {
+    implementation project(":sdk")
+
     implementation "com.google.code.gson:gson:2.10.1"
     implementation "org.slf4j:slf4j-simple:2.0.7"
     implementation "io.grpc:grpc-netty-shaded:1.56.1"
     implementation "io.github.cdimascio:java-dotenv:5.3.1"
     implementation "com.google.errorprone:error_prone_core:2.19.1"
-    implementation project(path: ':sdk')
 }
 
 tasks.addRule("Pattern: run<Example>: Runs an example.") { String taskName ->


### PR DESCRIPTION
**Description**:
Fix for `java.lang.VerifyError` exception in examples.

**Related issue(s)**:
Fixes #1478 

**Checklist**
- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
