### PR TITLE
Add `populateAccountNum()` to `AccountId` and `ContractId` classes

### DIFF
--- a/sdk/src/integrationTest/java/AccountIdPopulationIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountIdPopulationIntegrationTest.java
@@ -1,0 +1,37 @@
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.TransactionReceiptQuery;
+import com.hedera.hashgraph.sdk.TransferTransaction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AccountIdPopulationIntegrationTest {
+    @Test
+    @DisplayName("Can populate AccountId num from mirror node")
+    void canPopulateAccountIdNum() throws Exception {
+        var testEnv = new IntegrationTestEnv(1);
+
+        var privateKey = PrivateKey.generateECDSA();
+        var publicKey = privateKey.getPublicKey();
+
+        var evmAddress = publicKey.toEvmAddress();
+        var evmAddressAccount = AccountId.fromEvmAddress(evmAddress);
+
+        var tx = new TransferTransaction().addHbarTransfer(evmAddressAccount, new Hbar(1))
+            .addHbarTransfer(testEnv.operatorId, new Hbar(-1)).execute(testEnv.client);
+
+        var receipt = new TransactionReceiptQuery().setTransactionId(tx.transactionId).setIncludeChildren(true)
+            .execute(testEnv.client);
+
+        var newAccountId = receipt.children.get(0).accountId;
+
+        var idMirror = AccountId.fromEvmAddress(evmAddress);
+        Thread.sleep(5000);
+        var accountId = idMirror.populateAccountNum(testEnv.client);
+
+        assertThat(newAccountId.num).isEqualTo(accountId.num);
+    }
+}

--- a/sdk/src/integrationTest/java/AccountIdPopulationIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountIdPopulationIntegrationTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 
 class AccountIdPopulationIntegrationTest {
     @Test
-    @DisplayName("Can populate AccountId num from mirror node")
-    void canPopulateAccountIdNum() throws Exception {
+    @DisplayName("Can populate AccountId num from mirror node (using sync method)")
+    void canPopulateAccountIdNumSync() throws Exception {
         var testEnv = new IntegrationTestEnv(1);
 
         var privateKey = PrivateKey.generateECDSA();
@@ -31,6 +31,32 @@ class AccountIdPopulationIntegrationTest {
         var idMirror = AccountId.fromEvmAddress(evmAddress);
         Thread.sleep(5000);
         var accountId = idMirror.populateAccountNum(testEnv.client);
+
+        assertThat(newAccountId.num).isEqualTo(accountId.num);
+    }
+
+    @Test
+    @DisplayName("Can populate AccountId num from mirror node (using async method)")
+    void canPopulateAccountIdNumAsync() throws Exception {
+        var testEnv = new IntegrationTestEnv(1);
+
+        var privateKey = PrivateKey.generateECDSA();
+        var publicKey = privateKey.getPublicKey();
+
+        var evmAddress = publicKey.toEvmAddress();
+        var evmAddressAccount = AccountId.fromEvmAddress(evmAddress);
+
+        var tx = new TransferTransaction().addHbarTransfer(evmAddressAccount, new Hbar(1))
+            .addHbarTransfer(testEnv.operatorId, new Hbar(-1)).execute(testEnv.client);
+
+        var receipt = new TransactionReceiptQuery().setTransactionId(tx.transactionId).setIncludeChildren(true)
+            .execute(testEnv.client);
+
+        var newAccountId = receipt.children.get(0).accountId;
+
+        var idMirror = AccountId.fromEvmAddress(evmAddress);
+        Thread.sleep(5000);
+        var accountId = idMirror.populateAccountNumAsync(testEnv.client).get();
 
         assertThat(newAccountId.num).isEqualTo(accountId.num);
     }

--- a/sdk/src/integrationTest/java/ContractIdPopulationIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractIdPopulationIntegrationTest.java
@@ -10,10 +10,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class ContractIdPopulationIntegrationTest {
-    // figure out why evmAdress is null
     @Test
-    @DisplayName("Can populate ContractId num from mirror node")
-    void canPopulateContractIdNum() throws Exception {
+    @DisplayName("Can populate ContractId num from mirror node (using sync method)")
+    void canPopulateContractIdNumSync() throws Exception {
         var testEnv = new IntegrationTestEnv(1);
 
         var testContractByteCode = "608060405234801561001057600080fd5b50336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506101cb806100606000396000f3fe608060405260043610610046576000357c01000000000000000000000000000000000000000000000000000000009004806341c0e1b51461004b578063cfae321714610062575b600080fd5b34801561005757600080fd5b506100606100f2565b005b34801561006e57600080fd5b50610077610162565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156100b757808201518184015260208101905061009c565b50505050905090810190601f1680156100e45780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161415610160573373ffffffffffffffffffffffffffffffffffffffff16ff5b565b60606040805190810160405280600d81526020017f48656c6c6f2c20776f726c64210000000000000000000000000000000000000081525090509056fea165627a7a72305820ae96fb3af7cde9c0abfe365272441894ab717f816f07f41f07b1cbede54e256e0029";
@@ -25,7 +24,6 @@ class ContractIdPopulationIntegrationTest {
 
         var receipt = response.setValidateStatus(true).getReceipt(testEnv.client);
         var fileId = Objects.requireNonNull(receipt.fileId);
-
 
         response = new ContractCreateTransaction()
             .setAdminKey(testEnv.operatorKey)
@@ -43,8 +41,49 @@ class ContractIdPopulationIntegrationTest {
             .setContractId(contractId)
             .execute(testEnv.client);
 
-        var idMirror = ContractId.fromSolidityAddress(info.contractAccountId);
+        var idMirror = ContractId.fromEvmAddress(0, 0, info.contractAccountId);
+        Thread.sleep(5000);
+
         var newContractId = idMirror.populateContractNum(testEnv.client);
+
+        assertThat(contractId.num).isEqualTo(newContractId.num);
+    }
+
+    @Test
+    @DisplayName("Can populate ContractId num from mirror node (using async method)")
+    void canPopulateContractIdNumAsync() throws Exception {
+        var testEnv = new IntegrationTestEnv(1);
+
+        var testContractByteCode = "608060405234801561001057600080fd5b50336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506101cb806100606000396000f3fe608060405260043610610046576000357c01000000000000000000000000000000000000000000000000000000009004806341c0e1b51461004b578063cfae321714610062575b600080fd5b34801561005757600080fd5b506100606100f2565b005b34801561006e57600080fd5b50610077610162565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156100b757808201518184015260208101905061009c565b50505050905090810190601f1680156100e45780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161415610160573373ffffffffffffffffffffffffffffffffffffffff16ff5b565b60606040805190810160405280600d81526020017f48656c6c6f2c20776f726c64210000000000000000000000000000000000000081525090509056fea165627a7a72305820ae96fb3af7cde9c0abfe365272441894ab717f816f07f41f07b1cbede54e256e0029";
+
+        var response = new FileCreateTransaction()
+            .setKeys(testEnv.operatorKey)
+            .setContents(testContractByteCode)
+            .execute(testEnv.client);
+
+        var receipt = response.setValidateStatus(true).getReceipt(testEnv.client);
+        var fileId = Objects.requireNonNull(receipt.fileId);
+
+        response = new ContractCreateTransaction()
+            .setAdminKey(testEnv.operatorKey)
+            .setGas(100000)
+            .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
+            .setBytecodeFileId(fileId)
+            .setContractMemo("[e2e::canPopulateContractIdNum]")
+            .execute(testEnv.client);
+
+        receipt = response.setValidateStatus(true).getReceipt(testEnv.client);
+
+        var contractId = Objects.requireNonNull(receipt.contractId);
+
+        var info = new ContractInfoQuery()
+            .setContractId(contractId)
+            .execute(testEnv.client);
+
+        var idMirror = ContractId.fromEvmAddress(0, 0, info.contractAccountId);
+        Thread.sleep(5000);
+
+        var newContractId = idMirror.populateContractNumAsync(testEnv.client).get();
 
         assertThat(contractId.num).isEqualTo(newContractId.num);
     }

--- a/sdk/src/integrationTest/java/ContractIdPopulationIntegrationTest.java
+++ b/sdk/src/integrationTest/java/ContractIdPopulationIntegrationTest.java
@@ -1,0 +1,51 @@
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.hashgraph.sdk.ContractCreateTransaction;
+import com.hedera.hashgraph.sdk.ContractFunctionParameters;
+import com.hedera.hashgraph.sdk.ContractId;
+import com.hedera.hashgraph.sdk.ContractInfoQuery;
+import com.hedera.hashgraph.sdk.FileCreateTransaction;
+import java.util.Objects;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ContractIdPopulationIntegrationTest {
+    // figure out why evmAdress is null
+    @Test
+    @DisplayName("Can populate ContractId num from mirror node")
+    void canPopulateContractIdNum() throws Exception {
+        var testEnv = new IntegrationTestEnv(1);
+
+        var testContractByteCode = "608060405234801561001057600080fd5b50336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506101cb806100606000396000f3fe608060405260043610610046576000357c01000000000000000000000000000000000000000000000000000000009004806341c0e1b51461004b578063cfae321714610062575b600080fd5b34801561005757600080fd5b506100606100f2565b005b34801561006e57600080fd5b50610077610162565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156100b757808201518184015260208101905061009c565b50505050905090810190601f1680156100e45780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161415610160573373ffffffffffffffffffffffffffffffffffffffff16ff5b565b60606040805190810160405280600d81526020017f48656c6c6f2c20776f726c64210000000000000000000000000000000000000081525090509056fea165627a7a72305820ae96fb3af7cde9c0abfe365272441894ab717f816f07f41f07b1cbede54e256e0029";
+
+        var response = new FileCreateTransaction()
+            .setKeys(testEnv.operatorKey)
+            .setContents(testContractByteCode)
+            .execute(testEnv.client);
+
+        var receipt = response.setValidateStatus(true).getReceipt(testEnv.client);
+        var fileId = Objects.requireNonNull(receipt.fileId);
+
+
+        response = new ContractCreateTransaction()
+            .setAdminKey(testEnv.operatorKey)
+            .setGas(100000)
+            .setConstructorParameters(new ContractFunctionParameters().addString("Hello from Hedera."))
+            .setBytecodeFileId(fileId)
+            .setContractMemo("[e2e::canPopulateContractIdNum]")
+            .execute(testEnv.client);
+
+        receipt = response.setValidateStatus(true).getReceipt(testEnv.client);
+
+        var contractId = Objects.requireNonNull(receipt.contractId);
+
+        var info = new ContractInfoQuery()
+            .setContractId(contractId)
+            .execute(testEnv.client);
+
+        var idMirror = ContractId.fromSolidityAddress(info.contractAccountId);
+        var newContractId = idMirror.populateContractNum(testEnv.client);
+
+        assertThat(contractId.num).isEqualTo(newContractId.num);
+    }
+}

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountId.java
@@ -207,18 +207,14 @@ public final class AccountId implements Comparable<AccountId> {
      * @return                          the account id object
      */
     public static AccountId fromEvmAddress(EvmAddress evmAddress, @Nonnegative long shard, @Nonnegative long realm) {
-        if (EntityIdHelper.isLongZeroAddress(evmAddress.toBytes())) {
-            return fromSolidityAddress(evmAddress.toString());
-        } else {
-            return new AccountId(
-                shard,
-                realm,
-                0,
-                null,
-                null,
-                evmAddress
-            );
-        }
+        return new AccountId(
+            shard,
+            realm,
+            0,
+            null,
+            null,
+            evmAddress
+        );
     }
 
     /**
@@ -303,28 +299,26 @@ public final class AccountId implements Comparable<AccountId> {
     }
 
     /**
-     * @description Gets the actual `num` field of the `AccountId` from the Mirror Node.
+     * Gets the actual `num` field of the `AccountId` from the Mirror Node.
      * Should be used after generating `AccountId.fromEvmAddress()` because it sets the `num` field to `0`
      * automatically since there is no connection between the `num` and the `evmAddress`
-     *
      * Sync version
      *
-     * @param {Client} client
-     * @returns populated AccountId instance
+     * @param client
+     * @return populated AccountId instance
      */
     public AccountId populateAccountNum(Client client) throws InterruptedException, ExecutionException {
         return populateAccountNumAsync(client).get();
     }
 
     /**
-     * @description Gets the actual `num` field of the `AccountId` from the Mirror Node.
+     * Gets the actual `num` field of the `AccountId` from the Mirror Node.
      * Should be used after generating `AccountId.fromEvmAddress()` because it sets the `num` field to `0`
      * automatically since there is no connection between the `num` and the `evmAddress`
-     *
      * Async version
      *
-     * @param {Client} client
-     * @returns populated AccountId instance
+     * @param client
+     * @return populated AccountId instance
      */
     public CompletableFuture<AccountId> populateAccountNumAsync(Client client) {
         return EntityIdHelper.getAccountNumFromMirrorNodeAsync(client, evmAddress.toString())

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountId.java
@@ -224,7 +224,7 @@ public final class AccountId implements Comparable<AccountId> {
      * @return                          the account id object
      */
     public static AccountId fromSolidityAddress(String address) {
-        if (EntityIdHelper.isLongZeroAddress(Hex.decode(address))) {
+        if (EntityIdHelper.isLongZeroAddress(EntityIdHelper.decodeSolidityAddress(address))) {
             return EntityIdHelper.fromSolidityAddress(address, AccountId::new);
         } else {
             return fromEvmAddress(address);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractId.java
@@ -218,28 +218,26 @@ public class ContractId extends Key implements Comparable<ContractId> {
     }
 
     /**
-     * @description Gets the actual `num` field of the `ContractId` from the Mirror Node.
+     *  Gets the actual `num` field of the `ContractId` from the Mirror Node.
      * Should be used after generating `ContractId.fromEvmAddress()` because it sets the `num` field to `0`
      * automatically since there is no connection between the `num` and the `evmAddress`
-     *
      * Sync version
      *
-     * @param {Client} client
-     * @returns {Promise<ContractId>}
+     * @param client
+     * @return populated ContractId instance
      */
     public ContractId populateContractNum(Client client) throws InterruptedException, ExecutionException {
         return populateContractNumAsync(client).get();
     }
 
     /**
-     * @description Gets the actual `num` field of the `ContractId` from the Mirror Node.
+     * Gets the actual `num` field of the `ContractId` from the Mirror Node.
      * Should be used after generating `ContractId.fromEvmAddress()` because it sets the `num` field to `0`
      * automatically since there is no connection between the `num` and the `evmAddress`
-     *
      * Async version
      *
-     * @param {Client} client
-     * @returns {Promise<ContractId>}
+     * @param client
+     * @return populated ContractId instance
      */
     public CompletableFuture<ContractId> populateContractNumAsync(Client client) {
         EvmAddress address = new EvmAddress(this.evmAddress);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractId.java
@@ -134,7 +134,7 @@ public class ContractId extends Key implements Comparable<ContractId> {
      * @return                          the contract id object
      */
     public static ContractId fromSolidityAddress(String address) {
-        if (EntityIdHelper.isLongZeroAddress(Hex.decode(address))) {
+        if (EntityIdHelper.isLongZeroAddress(EntityIdHelper.decodeSolidityAddress(address))) {
             return EntityIdHelper.fromSolidityAddress(address, ContractId::new);
         } else {
             return fromEvmAddress(0, 0, address);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/EntityIdHelper.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/EntityIdHelper.java
@@ -113,7 +113,7 @@ class EntityIdHelper {
      * @param address the string representation
      * @return the decoded address
      */
-    private static byte[] decodeSolidityAddress(@Var String address) {
+    public static byte[] decodeSolidityAddress(@Var String address) {
         address = address.startsWith("0x") ? address.substring(2) : address;
 
         if (address.length() != SOLIDITY_ADDRESS_LEN_HEX) {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/EntityIdHelper.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/EntityIdHelper.java
@@ -327,6 +327,10 @@ class EntityIdHelper {
 
         String apiUrl = "https://" + mirrorUrl.get() + "/api/v1" + apiEndpoint;
 
+        if (client.getLedgerId() == null) {
+            apiUrl = "http://" + mirrorUrl.get() + ":5551/api/v1" + apiEndpoint;
+        }
+
         HttpClient httpClient = HttpClient.newHttpClient();
         HttpRequest httpRequest = HttpRequest.newBuilder()
             .timeout(MIRROR_NODE_CONNECTION_TIMEOUT)


### PR DESCRIPTION
**Description**:
- added checks inside `fromSolidityAddress()` and, based on the result, pass the flow to the proper method ([Reference PR](https://github.com/hashgraph/hedera-sdk-js/pull/1741/files));
- added `populateAccountNum()` to `AccountId` and `ContractId` classes ([Reference PR](https://github.com/hashgraph/hedera-sdk-go/pull/784/files)).

**Related issue(s)**:
Fixes #1537 

**Checklist**
- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
