### PR TITLE
Fix `AccountId#toSolidityAddress()` does not return expected result when AccountId has a Key Alias

### DIFF
--- a/sdk/src/integrationTest/java/AccountIdPopulationIntegrationTest.java
+++ b/sdk/src/integrationTest/java/AccountIdPopulationIntegrationTest.java
@@ -60,4 +60,55 @@ class AccountIdPopulationIntegrationTest {
 
         assertThat(newAccountId.num).isEqualTo(accountId.num);
     }
+
+    @Test
+    @DisplayName("Can populate AccountId evm address from mirror node (using sync method)")
+    void canPopulateAccountIdEvmAddressSync() throws Exception {
+        var testEnv = new IntegrationTestEnv(1);
+
+        var privateKey = PrivateKey.generateECDSA();
+        var publicKey = privateKey.getPublicKey();
+
+        var evmAddress = publicKey.toEvmAddress();
+        var evmAddressAccount = AccountId.fromEvmAddress(evmAddress);
+
+        var tx = new TransferTransaction().addHbarTransfer(evmAddressAccount, new Hbar(1))
+            .addHbarTransfer(testEnv.operatorId, new Hbar(-1)).execute(testEnv.client);
+
+        var receipt = new TransactionReceiptQuery().setTransactionId(tx.transactionId).setIncludeChildren(true)
+            .execute(testEnv.client);
+
+        var newAccountId = receipt.children.get(0).accountId;
+
+        Thread.sleep(5000);
+        var accountId = newAccountId.populateAccountEvmAddress(testEnv.client);
+
+        assertThat(evmAddressAccount.evmAddress).isEqualTo(accountId.evmAddress);
+    }
+
+    @Test
+    @DisplayName("Can populate AccountId evm address from mirror node (using async method)")
+    void canPopulateAccountIdEvmAddressAsync() throws Exception {
+        var testEnv = new IntegrationTestEnv(1);
+
+        var privateKey = PrivateKey.generateECDSA();
+        var publicKey = privateKey.getPublicKey();
+
+        var evmAddress = publicKey.toEvmAddress();
+        var evmAddressAccount = AccountId.fromEvmAddress(evmAddress);
+
+        var tx = new TransferTransaction().addHbarTransfer(evmAddressAccount, new Hbar(1))
+            .addHbarTransfer(testEnv.operatorId, new Hbar(-1)).execute(testEnv.client);
+
+        var receipt = new TransactionReceiptQuery().setTransactionId(tx.transactionId).setIncludeChildren(true)
+            .execute(testEnv.client);
+
+        var newAccountId = receipt.children.get(0).accountId;
+
+        Thread.sleep(5000);
+        var accountId = newAccountId.populateAccountEvmAddressAsync(testEnv.client).get();
+
+        assertThat(evmAddressAccount.evmAddress).isEqualTo(accountId.evmAddress);
+    }
+
 }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountId.java
@@ -333,6 +333,36 @@ public final class AccountId implements Comparable<AccountId> {
     }
 
     /**
+     * Populates `evmAddress` field of the `AccountId` extracted from the Mirror Node.
+     * Sync version
+     *
+     * @param client
+     * @return populated AccountId instance
+     */
+    public AccountId populateAccountEvmAddress(Client client) throws ExecutionException, InterruptedException {
+        return populateAccountEvmAddressAsync(client).get();
+    }
+
+    /**
+     * Populates `evmAddress` field of the `AccountId` extracted from the Mirror Node.
+     * Async version
+     *
+     * @param client
+     * @return populated AccountId instance
+     */
+    public CompletableFuture<AccountId> populateAccountEvmAddressAsync(Client client) {
+        return EntityIdHelper.getEvmAddressFromMirrorNodeAsync(client, num)
+            .thenApply(evmAddressFromMirrorNode ->
+                new AccountId(
+                    this.shard,
+                    this.realm,
+                    this.num,
+                    this.checksum,
+                    this.aliasKey,
+                    evmAddressFromMirrorNode));
+    }
+
+    /**
      * @param client to validate against
      * @throws BadEntityIdException if entity ID is formatted poorly
      * @deprecated Use {@link #validateChecksum(Client)} instead.

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/EntityIdHelper.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/EntityIdHelper.java
@@ -299,6 +299,22 @@ class EntityIdHelper {
     }
 
     /**
+     * Get EvmAddress from mirror node using account num.
+     *
+     * @param client
+     * @param num
+     * @return
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public static CompletableFuture<EvmAddress> getEvmAddressFromMirrorNodeAsync(Client client, long num) {
+        String apiEndpoint = "/accounts/" + num;
+        return performQueryToMirrorNodeAsync(client, apiEndpoint)
+            .thenApply(response ->
+                EvmAddress.fromString(parseEvmAddressFromMirrorNodeResponse(response, "evm_address")));
+    }
+
+    /**
      * Get ContractId num from mirror node using evm address.
      *
      * @param client
@@ -348,6 +364,15 @@ class EntityIdHelper {
         String num = jsonObject.get(memberName).getAsString();
 
         return Long.parseLong(num.substring(num.lastIndexOf(".") + 1));
+    }
+
+    private static String parseEvmAddressFromMirrorNodeResponse(String responseBody, String memberName) {
+        JsonParser jsonParser = new JsonParser();
+        JsonObject jsonObject = jsonParser.parse(responseBody).getAsJsonObject();
+
+        String evmAddress = jsonObject.get(memberName).getAsString();
+
+        return evmAddress.substring(evmAddress.lastIndexOf(".") + 1);
     }
 
     @FunctionalInterface


### PR DESCRIPTION
**Description**:
Fix `AccountId#toSolidityAddress()` does not return expected result when AccountId has a Key Alias

**Related issue(s)**:
Fixes #1586 

**Notes for reviewer**:

**Checklist**
- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
