### PR TITLE
Add more unit tests for `SystemDeleteTransaction`

### DIFF
--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/SystemDeleteTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/SystemDeleteTransactionTest.java
@@ -19,23 +19,28 @@
  */
 package com.hedera.hashgraph.sdk;
 
-import com.hedera.hashgraph.sdk.proto.FileUpdateTransactionBody;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.hedera.hashgraph.sdk.proto.SchedulableTransactionBody;
 import com.hedera.hashgraph.sdk.proto.SystemDeleteTransactionBody;
+import com.hedera.hashgraph.sdk.proto.TimestampSeconds;
+import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import io.github.jsonSnapshot.SnapshotMatcher;
+import java.time.Instant;
+import java.util.Arrays;
 import org.junit.AfterClass;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import java.time.Instant;
-
-import java.util.Arrays;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class SystemDeleteTransactionTest {
     private static final PrivateKey unusedPrivateKey = PrivateKey.fromString(
         "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10");
-
+    private static final FileId testFileId = FileId.fromString("4.2.0");
+    private static final ContractId testContractId = ContractId.fromString("0.6.9");
     final Instant validStart = Instant.ofEpochSecond(1554158542);
 
     @BeforeAll
@@ -50,38 +55,28 @@ public class SystemDeleteTransactionTest {
 
     @Test
     void shouldSerializeFile() {
-        SnapshotMatcher.expect(spawnTestTransactionFile()
-            .toString()
-        ).toMatchSnapshot();
+        SnapshotMatcher.expect(spawnTestTransactionFile().toString()).toMatchSnapshot();
     }
 
     private SystemDeleteTransaction spawnTestTransactionFile() {
-        return new SystemDeleteTransaction()
-            .setNodeAccountIds(Arrays.asList(AccountId.fromString("0.0.5005"), AccountId.fromString("0.0.5006")))
+        return new SystemDeleteTransaction().setNodeAccountIds(
+                Arrays.asList(AccountId.fromString("0.0.5005"), AccountId.fromString("0.0.5006")))
             .setTransactionId(TransactionId.withValidStart(AccountId.fromString("0.0.5006"), validStart))
-            .setFileId(FileId.fromString("0.0.444"))
-            .setExpirationTime(validStart)
-            .setMaxTransactionFee(new Hbar(1))
-            .freeze()
-            .sign(unusedPrivateKey);
+            .setFileId(FileId.fromString("0.0.444")).setExpirationTime(validStart).setMaxTransactionFee(new Hbar(1))
+            .freeze().sign(unusedPrivateKey);
     }
 
     @Test
     void shouldSerializeContract() {
-        SnapshotMatcher.expect(spawnTestTransactionContract()
-            .toString()
-        ).toMatchSnapshot();
+        SnapshotMatcher.expect(spawnTestTransactionContract().toString()).toMatchSnapshot();
     }
 
     private SystemDeleteTransaction spawnTestTransactionContract() {
-        return new SystemDeleteTransaction()
-            .setNodeAccountIds(Arrays.asList(AccountId.fromString("0.0.5005"), AccountId.fromString("0.0.5006")))
+        return new SystemDeleteTransaction().setNodeAccountIds(
+                Arrays.asList(AccountId.fromString("0.0.5005"), AccountId.fromString("0.0.5006")))
             .setTransactionId(TransactionId.withValidStart(AccountId.fromString("0.0.5006"), validStart))
-            .setContractId(ContractId.fromString("0.0.444"))
-            .setExpirationTime(validStart)
-            .setMaxTransactionFee(new Hbar(1))
-            .freeze()
-            .sign(unusedPrivateKey);
+            .setContractId(ContractId.fromString("0.0.444")).setExpirationTime(validStart)
+            .setMaxTransactionFee(new Hbar(1)).freeze().sign(unusedPrivateKey);
     }
 
     @Test
@@ -101,11 +96,101 @@ public class SystemDeleteTransactionTest {
     @Test
     void fromScheduledTransaction() {
         var transactionBody = SchedulableTransactionBody.newBuilder()
-            .setSystemDelete(SystemDeleteTransactionBody.newBuilder().build())
-            .build();
+            .setSystemDelete(SystemDeleteTransactionBody.newBuilder().build()).build();
 
         var tx = Transaction.fromScheduledTransaction(transactionBody);
 
         assertThat(tx).isInstanceOf(SystemDeleteTransaction.class);
+    }
+
+    @Test
+    void constructSystemDeleteTransactionFromTransactionBodyProtobuf() {
+        var transactionBodyWithFileId = SystemDeleteTransactionBody.newBuilder().setFileID(testFileId.toProtobuf())
+            .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(validStart.getEpochSecond()));
+
+        var transactionBodyWithContractId = SystemDeleteTransactionBody.newBuilder()
+            .setContractID(testContractId.toProtobuf())
+            .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(validStart.getEpochSecond()));
+
+        var txWithFileId = TransactionBody.newBuilder().setSystemDelete(transactionBodyWithFileId).build();
+        var systemDeleteTransactionWithFileId = new SystemDeleteTransaction(txWithFileId);
+
+        var txWithContractId = TransactionBody.newBuilder().setSystemDelete(transactionBodyWithContractId).build();
+        var systemDeleteTransactionWithContractId = new SystemDeleteTransaction(txWithContractId);
+
+        assertNotNull(systemDeleteTransactionWithFileId.getFileId());
+        assertThat(systemDeleteTransactionWithFileId.getFileId()).isEqualTo(testFileId);
+        assertNull(systemDeleteTransactionWithFileId.getContractId());
+        assertThat(systemDeleteTransactionWithFileId.getExpirationTime().getEpochSecond()).isEqualTo(
+            validStart.getEpochSecond());
+
+        assertNull(systemDeleteTransactionWithContractId.getFileId());
+        assertNotNull(systemDeleteTransactionWithContractId.getContractId());
+        assertThat(systemDeleteTransactionWithContractId.getContractId()).isEqualTo(testContractId);
+        assertThat(systemDeleteTransactionWithContractId.getExpirationTime().getEpochSecond()).isEqualTo(
+            validStart.getEpochSecond());
+    }
+
+    @Test
+    void getSetFileId() {
+        var systemDeleteTransaction = new SystemDeleteTransaction().setFileId(testFileId);
+        assertNotNull(systemDeleteTransaction.getFileId());
+        assertThat(systemDeleteTransaction.getFileId()).isEqualTo(testFileId);
+    }
+
+    @Test
+    void getSetFileIdFrozen() {
+        var tx = spawnTestTransactionFile();
+        assertThrows(IllegalStateException.class, () -> tx.setFileId(testFileId));
+    }
+
+    @Test
+    void getSetContractId() {
+        var systemDeleteTransaction = new SystemDeleteTransaction().setContractId(testContractId);
+        assertNotNull(systemDeleteTransaction.getContractId());
+        assertThat(systemDeleteTransaction.getContractId()).isEqualTo(testContractId);
+    }
+
+    @Test
+    void getSetContractIdFrozen() {
+        var tx = spawnTestTransactionContract();
+        assertThrows(IllegalStateException.class, () -> tx.setContractId(testContractId));
+    }
+
+    @Test
+    void getSetExpirationTime() {
+        var systemDeleteTransaction = new SystemDeleteTransaction().setExpirationTime(validStart);
+        assertNotNull(systemDeleteTransaction.getExpirationTime());
+        assertThat(systemDeleteTransaction.getExpirationTime().getEpochSecond()).isEqualTo(validStart.getEpochSecond());
+    }
+
+    @Test
+    void getSetExpirationTimeFrozen() {
+        var tx = spawnTestTransactionFile();
+        assertThrows(IllegalStateException.class, () -> tx.setExpirationTime(validStart));
+    }
+
+    // ported from C++ SDK, in Java it does not pass
+    @Test
+    @Disabled
+    void resetFileId() {
+        var systemDeleteTransaction = new SystemDeleteTransaction();
+        systemDeleteTransaction.setFileId(testFileId);
+        systemDeleteTransaction.setContractId(testContractId);
+
+        assertNull(systemDeleteTransaction.getFileId());
+        assertNotNull(systemDeleteTransaction.getContractId());
+    }
+
+    // ported from C++ SDK, in Java it does not pass
+    @Test
+    @Disabled
+    void resetContractId() {
+        var systemDeleteTransaction = new SystemDeleteTransaction();
+        systemDeleteTransaction.setContractId(testContractId);
+        systemDeleteTransaction.setFileId(testFileId);
+
+        assertNull(systemDeleteTransaction.getContractId());
+        assertNotNull(systemDeleteTransaction.getFileId());
     }
 }


### PR DESCRIPTION
**Description**:
- added more unit tests for `SystemDeleteTransaction`;
- reformatted and rearranged code;

**Related issue(s)**:
Fixes #1576 

**Notes for reviewer**:
Please pay attention to `resetFileId` and `resetContractId` tests -- setter functions in the Java SDK work differently then in C++ SDK, hence, these tests do not pass.

**Checklist**
- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
