### PR TITLE
Hotfix issue #1606.

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Delayer.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Delayer.java
@@ -20,6 +20,8 @@
 package com.hedera.hashgraph.sdk;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.time.Duration;
@@ -32,6 +34,12 @@ import java.util.concurrent.TimeUnit;
  */
 final class Delayer {
     private static final Logger logger = LoggerFactory.getLogger(Delayer.class);
+
+    private static final ScheduledExecutorService SCHEDULER = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r);
+        t.setDaemon(true);
+        return t;
+    });
 
     private static final Duration MIN_DELAY = Duration.ofMillis(500);
 
@@ -67,6 +75,10 @@ final class Delayer {
         return CompletableFuture.runAsync(
             () -> {
             },
-            CompletableFuture.delayedExecutor(milliseconds, TimeUnit.MILLISECONDS, executor));
+            delayedExecutor(milliseconds, TimeUnit.MILLISECONDS, executor));
+    }
+
+    private static Executor delayedExecutor(long delay, TimeUnit unit, Executor executor) {
+        return r -> SCHEDULER.schedule(() -> executor.execute(r), delay, unit);
     }
 }


### PR DESCRIPTION
**Description**:
Hotfix issue #1606. Prevents Android app on API level 30 from crashing.

**Related issue(s)**:
Fixes #1606
