### PR TITLE
chore: add CI pipeline to release SDK artifacts to Maven Central

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,101 @@
+name: Release Artifacts
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+env:
+  LC_ALL: C.UTF-8
+  GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+jobs:
+  validate-release:
+    name: Validate Release
+    runs-on: [ self-hosted, Linux, medium, ephemeral ]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Retrieve Tag Version
+        id: tag
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "${GITHUB_OUTPUT}"
+
+      - name: Setup Java
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
+        with:
+          cache-read-only: false
+
+      - name: Determine Project Version
+        id: project
+        run: echo "version=$(./gradlew -q showVersion | tr -d '[:space:]')" >> "${GITHUB_OUTPUT}"
+
+      - name: Validate Release
+        run: |
+          if [[ "${{ steps.tag.outputs.version }}" != "${{ steps.project.outputs.version }}" ]]; then
+            echo "::error file=version.gradle,line=5,title=Version Mismatch::Tag version '${{ steps.tag.outputs.version }}' does not match the Gradle project version '${{ steps.project.outputs.version }}'. Please update the 'version.gradle' file before tagging."
+            exit 1
+          fi
+
+  maven-central:
+    name: Publish to Maven Central
+    runs-on: [ self-hosted, Linux, medium, ephemeral ]
+    needs:
+      - validate-release
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Install GnuPG Tools
+        if: ${{ inputs.dry-run-enabled != true }}
+        run: |
+          if ! command -v gpg2 >/dev/null 2>&1; then
+            echo "::group::Updating APT Repository Indices"
+              sudo apt update
+            echo "::endgroup::"
+            echo "::group::Installing GnuPG Tools"
+              sudo apt install -y gnupg2
+            echo "::endgroup::"
+          fi
+
+      - name: Import GPG key
+        id: gpg_key
+        uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef # v6.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_KEY_CONTENTS }}
+          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+
+      - name: Setup Java
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
+        with:
+          cache-read-only: false
+
+      - name: Compile SDK & Javadoc
+        run: ./gradlew assemble :sdk:javadoc -Dfile.encoding=UTF-8 --scan
+
+      - name: Nexus Release
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Dfile.encoding=UTF-8 --scan -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -101,3 +101,11 @@ nexusPublishing {
         }
     }
 }
+
+tasks.register("showVersion") {
+    group = "versioning"
+    inputs.property("version", project.version)
+    doLast {
+        println(inputs.properties["version"])
+    }
+}

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -248,4 +248,5 @@ publishing {
 
 signing {
     sign publishing.publications.mavenJava
+    useGpgCmd()
 }


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds a new CI pipeline which will publish and release the SDK artifact via Maven Central.
  - This workflow will ensure the Gradle project version matches the semantic version tag.

### Related Issues

- Closes #1664  