### PR TITLE
chore: apply workaround for sdk-full release

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+      inputs:
+        version:
+          type: string
+          description: Fake version
+          required: true
 
 defaults:
   run:
@@ -32,8 +38,14 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Retrieve Tag Version
+        if: ${{ github.event_name == 'push' }}
         id: tag
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> "${GITHUB_OUTPUT}"
+
+      - name: Retrieve Tag Version
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        id: tag
+        run: echo "version=${{github.event.inputs.version}}" >> "${GITHUB_OUTPUT}"
 
       - name: Setup Java
         uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
@@ -110,11 +122,13 @@ jobs:
         run: ./gradlew assemble :sdk:javadoc -Dfile.encoding=UTF-8 --scan
 
       - name: Nexus Release
-        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Dfile.encoding=UTF-8 --scan -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }}
+        #run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Dfile.encoding=UTF-8 --scan -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }}
+        run: ./gradlew publishToSonatype closeSonatypeStagingRepository --no-parallel -Dfile.encoding=UTF-8 --scan -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }}
 
       - name: Nexus Release sdk-full artifacts
         run:  |
          # This is a temporary fix and should be removed once https://github.com/hashgraph/hedera-sdk-java/pull/1732 is merged
          sed -i 's#sdk\.gradle#sdk-full.gradle#g' sdk/build.gradle
          git clean -fdx
-         run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Dfile.encoding=UTF-8 --scan -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }}
+         ./gradlew publishToSonatype closeSonatypeStagingRepository --no-parallel -Dfile.encoding=UTF-8 --scan -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }}
+      # ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Dfile.encoding=UTF-8 --scan -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -76,6 +76,7 @@ jobs:
       # This needs clause exists solely to provide a dependency on the previous step. This publish step will not occur
       # until the validate-release step completes successfully.
       - validate-release
+
     steps:
       -   name: Harden Runner
           uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -73,8 +73,8 @@ jobs:
       - name: Validate Release (dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          if [[ "${{ steps.workflow_tag.outputs.version }}" != "${{ steps.project.outputs.version }}" ]]; then
-            echo "::error file=version.gradle,line=5,title=Version Mismatch::Tag version '${{ steps.workflow_tag.outputs.version }}' does not match the Gradle project version '${{ steps.project.outputs.version }}'. Please update the 'version.gradle' file before tagging."
+          if [[ "${{ steps.workflow_tag.outputs.version }}" != "${{github.event.inputs.version}}" ]]; then
+            echo "::error file=version.gradle,line=5,title=Version Mismatch::Tag version '${{ steps.workflow_tag.outputs.version }}' does not match the Gradle project version '${{github.event.inputs.version}}'. Please update the 'version.gradle' file before tagging."
             exit 1
           fi
 

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Retrieve Tag Version
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        id: tag
+        id: workflow_tag
         run: echo "version=${{github.event.inputs.version}}" >> "${GITHUB_OUTPUT}"
 
       - name: Setup Java
@@ -63,9 +63,18 @@ jobs:
         run: echo "version=$(./gradlew -q showVersion | tr -d '[:space:]')" >> "${GITHUB_OUTPUT}"
 
       - name: Validate Release
+        if: ${{ github.event_name == 'push' }}
         run: |
           if [[ "${{ steps.tag.outputs.version }}" != "${{ steps.project.outputs.version }}" ]]; then
             echo "::error file=version.gradle,line=5,title=Version Mismatch::Tag version '${{ steps.tag.outputs.version }}' does not match the Gradle project version '${{ steps.project.outputs.version }}'. Please update the 'version.gradle' file before tagging."
+            exit 1
+          fi
+
+      - name: Validate Release
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          if [[ "${{ steps.workflow_tag.outputs.version }}" != "${{ steps.project.outputs.version }}" ]]; then
+            echo "::error file=version.gradle,line=5,title=Version Mismatch::Tag version '${{ steps.workflow_tag.outputs.version }}' does not match the Gradle project version '${{ steps.project.outputs.version }}'. Please update the 'version.gradle' file before tagging."
             exit 1
           fi
 

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -70,14 +70,6 @@ jobs:
             exit 1
           fi
 
-      - name: Validate Release (workflow_dispatch)
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          if [[ "${{ steps.workflow_tag.outputs.version }}" != "${{github.event.inputs.version}}" ]]; then
-            echo "::error file=version.gradle,line=5,title=Version Mismatch::Tag version '${{ steps.workflow_tag.outputs.version }}' does not match the Gradle project version '${{github.event.inputs.version}}'. Please update the 'version.gradle' file before tagging."
-            exit 1
-          fi
-
   maven-central:
     name: Publish to Maven Central
     runs-on: [ self-hosted, Linux, medium, ephemeral ]

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -42,7 +42,7 @@ jobs:
         id: tag
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> "${GITHUB_OUTPUT}"
 
-      - name: Retrieve Tag Version
+      - name: Retrieve Tag Version (dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
         id: workflow_tag
         run: echo "version=${{github.event.inputs.version}}" >> "${GITHUB_OUTPUT}"
@@ -70,7 +70,7 @@ jobs:
             exit 1
           fi
 
-      - name: Validate Release
+      - name: Validate Release (dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           if [[ "${{ steps.workflow_tag.outputs.version }}" != "${{ steps.project.outputs.version }}" ]]; then

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -8,7 +8,7 @@ on:
       inputs:
         version:
           type: string
-          description: Fake version
+          description: Test Version String (No release to Maven Central)
           required: true
 
 defaults:
@@ -42,7 +42,7 @@ jobs:
         id: tag
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> "${GITHUB_OUTPUT}"
 
-      - name: Retrieve Tag Version (dispatch)
+      - name: Retrieve Tag Version (workflow_dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
         id: workflow_tag
         run: echo "version=${{github.event.inputs.version}}" >> "${GITHUB_OUTPUT}"
@@ -70,7 +70,7 @@ jobs:
             exit 1
           fi
 
-      - name: Validate Release (dispatch)
+      - name: Validate Release (workflow_dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           if [[ "${{ steps.workflow_tag.outputs.version }}" != "${{github.event.inputs.version}}" ]]; then
@@ -132,13 +132,25 @@ jobs:
         run: ./gradlew assemble :sdk:javadoc -Dfile.encoding=UTF-8 --scan
 
       - name: Nexus Release
-        #run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Dfile.encoding=UTF-8 --scan -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }}
+        if: ${{ github.event_name == 'push' }}
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Dfile.encoding=UTF-8 --scan -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }}
+
+      - name: Nexus Release (workflow_dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: ./gradlew publishToSonatype closeSonatypeStagingRepository --no-parallel -Dfile.encoding=UTF-8 --scan -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }}
 
       - name: Nexus Release sdk-full artifacts
+        if: ${{ github.event_name == 'push' }}
         run:  |
          # This is a temporary fix and should be removed once https://github.com/hashgraph/hedera-sdk-java/pull/1732 is merged
          sed -i 's#sdk\.gradle#sdk-full.gradle#g' sdk/build.gradle
          git clean -fdx
-         ./gradlew publishToSonatype closeSonatypeStagingRepository --no-parallel -Dfile.encoding=UTF-8 --scan -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }}
-      # ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Dfile.encoding=UTF-8 --scan -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }}
+         ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Dfile.encoding=UTF-8 --scan -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }}
+
+      - name: Nexus Release sdk-full artifacts (workflow_dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          # This is a temporary fix and should be removed once https://github.com/hashgraph/hedera-sdk-java/pull/1732 is merged
+          sed -i 's#sdk\.gradle#sdk-full.gradle#g' sdk/build.gradle
+          git clean -fdx
+          ./gradlew publishToSonatype closeSonatypeStagingRepository --no-parallel -Dfile.encoding=UTF-8 --scan -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -111,3 +111,10 @@ jobs:
 
       - name: Nexus Release
         run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Dfile.encoding=UTF-8 --scan -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }}
+
+      - name: Nexus Release sdk-full artifacts
+        run:  |
+         # This is a temporary fix and should be removed once https://github.com/hashgraph/hedera-sdk-java/pull/1732 is merged
+         sed -i 's#sdk\.gradle#sdk-full.gradle#g' sdk/build.gradle
+         git clean -fdx
+         run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Dfile.encoding=UTF-8 --scan -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }}

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 // https://github.com/google/protobuf-gradle-plugin
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.24.3"
+        artifact = "com.google.protobuf:protoc:3.23.4"
     }
     plugins {
         grpc {

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractInfoTest.snap
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractInfoTest.snap
@@ -24,7 +24,6 @@ com.hedera.hashgraph.sdk.ContractInfoTest.toProtobuf=[
       "memoizedSerializedSize": 0,
       "isMutable": false
     },
-    "bitField0_": 27,
     "contractID_": {
       "memoizedHashCode": 0,
       "memoizedSerializedSize": 2147483647,

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractNonceInfoTest.snap
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractNonceInfoTest.snap
@@ -24,7 +24,6 @@ com.hedera.hashgraph.sdk.ContractNonceInfoTest.toProtobuf=[
       "memoizedSerializedSize": 0,
       "isMutable": false
     },
-    "bitField0_": 1,
     "contractId_": {
       "memoizedHashCode": 0,
       "memoizedSerializedSize": 2147483647,


### PR DESCRIPTION
**Description**:
This PR ports the previous workaround for releasing the `sdk-full` artifact as a temporary solution until #1732 is merged.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
