### PR TITLE
chore: undeprecate fields that are populated from the Mirror Node REST API

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountBalance.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountBalance.java
@@ -47,16 +47,8 @@ public class AccountBalance {
     @Nonnegative
     public final Map<TokenId, Long> token = new HashMap<>();
 
-    /**
-     * @deprecated - use a mirror node query
-     */
-    @Deprecated
     public final Map<TokenId, Long> tokens;
 
-    /**
-     * @deprecated - use a mirror node query
-     */
-    @Deprecated
     @Nonnegative
     public final Map<TokenId, Integer> tokenDecimals;
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountInfo.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountInfo.java
@@ -113,10 +113,6 @@ public final class AccountInfo {
      */
     public final List<LiveHash> liveHashes;
 
-    /**
-     * @deprecated use a mirror node query instead
-     */
-    @Deprecated
     public final Map<TokenId, TokenRelationship> tokenRelationships;
 
     /**

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractInfo.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractInfo.java
@@ -104,10 +104,7 @@ public final class ContractInfo {
 
     /**
      * The tokens associated to the contract
-     *
-     * @deprecated use a mirror node query instead
      */
-    @Deprecated
     public final Map<TokenId, TokenRelationship> tokenRelationships;
 
     /**


### PR DESCRIPTION
This PR undeprecates fields that are populated from the Mirror Node REST API.

Closes #1820