### PR TITLE
chore: deprecate TokenRelationship.symbol field due to lack of support by consensus nodes and mirror node

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenRelationship.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenRelationship.java
@@ -37,6 +37,10 @@ public class TokenRelationship {
     public final TokenId tokenId;
     /**
      * The Symbol of the token
+     *
+     * @deprecated Not supported by consensus nodes (from hedera-services tag v0.50.x).
+     * Although the Mirror Node REST APIs still contain this feature, there is no straightforward way of integration,
+     * leading to this field being deprecated.
      */
     public final String symbol;
     /**


### PR DESCRIPTION
This PR deprecates `TokenRelationship.symbol` field due to lack of support by consensus nodes and mirror node.

Closes #1821