### PR TITLE
chore: deprecate populateAccountNumAsync, populateAccountEvmAddressAsync methods in AccountId and populateContractNumAsync in ContractId

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountId.java
@@ -307,8 +307,19 @@ public final class AccountId implements Comparable<AccountId> {
      * @param client
      * @return populated AccountId instance
      */
-    public AccountId populateAccountNum(Client client) throws InterruptedException, ExecutionException {
-        return populateAccountNumAsync(client).get();
+    public AccountId populateAccountNum(Client client) {
+        MirrorNodeGateway mirrorNodeGateway = MirrorNodeGateway.forClient(client);
+        MirrorNodeService mirrorNodeService = new MirrorNodeService(mirrorNodeGateway);
+        var accountNumFromMirrorNode = mirrorNodeService.getAccountNum(evmAddress.toString());
+
+        return new AccountId(
+            this.shard,
+            this.realm,
+            accountNumFromMirrorNode,
+            this.checksum,
+            this.aliasKey,
+            this.evmAddress
+        );
     }
 
     /**
@@ -321,6 +332,7 @@ public final class AccountId implements Comparable<AccountId> {
      * @param client
      * @return populated AccountId instance
      */
+    @Deprecated
     public CompletableFuture<AccountId> populateAccountNumAsync(Client client) {
         MirrorNodeGateway mirrorNodeGateway = MirrorNodeGateway.forClient(client);
         MirrorNodeService mirrorNodeService = new MirrorNodeService(mirrorNodeGateway);
@@ -345,8 +357,19 @@ public final class AccountId implements Comparable<AccountId> {
      * @param client
      * @return populated AccountId instance
      */
-    public AccountId populateAccountEvmAddress(Client client) throws ExecutionException, InterruptedException {
-        return populateAccountEvmAddressAsync(client).get();
+    public AccountId populateAccountEvmAddress(Client client) {
+        MirrorNodeGateway mirrorNodeGateway = MirrorNodeGateway.forClient(client);
+        MirrorNodeService mirrorNodeService = new MirrorNodeService(mirrorNodeGateway);
+        var evmAddressFromMirrorNode = mirrorNodeService.getAccountEvmAddress(num);
+
+        return new AccountId(
+            this.shard,
+            this.realm,
+            this.num,
+            this.checksum,
+            this.aliasKey,
+            evmAddressFromMirrorNode
+        );
     }
 
     /**
@@ -357,6 +380,7 @@ public final class AccountId implements Comparable<AccountId> {
      * @param client
      * @return populated AccountId instance
      */
+    @Deprecated
     public CompletableFuture<AccountId> populateAccountEvmAddressAsync(Client client) {
         MirrorNodeGateway mirrorNodeGateway = MirrorNodeGateway.forClient(client);
         MirrorNodeService mirrorNodeService = new MirrorNodeService(mirrorNodeGateway);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountId.java
@@ -317,6 +317,7 @@ public final class AccountId implements Comparable<AccountId> {
      * automatically since there is no connection between the `num` and the `evmAddress`
      * Async version
      *
+     * @deprecated Use 'populateAccountNum' instead due to its nearly identical operation.
      * @param client
      * @return populated AccountId instance
      */
@@ -352,6 +353,7 @@ public final class AccountId implements Comparable<AccountId> {
      * Populates `evmAddress` field of the `AccountId` extracted from the Mirror Node.
      * Async version
      *
+     * @deprecated Use 'populateAccountEvmAddress' instead due to its nearly identical operation.
      * @param client
      * @return populated AccountId instance
      */

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractId.java
@@ -236,6 +236,7 @@ public class ContractId extends Key implements Comparable<ContractId> {
      * automatically since there is no connection between the `num` and the `evmAddress`
      * Async version
      *
+     * @deprecated Use 'populateContractNum' instead due to its nearly identical operation.
      * @param client
      * @return populated ContractId instance
      */

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractId.java
@@ -226,8 +226,14 @@ public class ContractId extends Key implements Comparable<ContractId> {
      * @param client
      * @return populated ContractId instance
      */
-    public ContractId populateContractNum(Client client) throws InterruptedException, ExecutionException {
-        return populateContractNumAsync(client).get();
+    public ContractId populateContractNum(Client client) {
+        EvmAddress address = new EvmAddress(this.evmAddress);
+        MirrorNodeGateway mirrorNodeGateway = MirrorNodeGateway.forClient(client);
+        MirrorNodeService mirrorNodeService = new MirrorNodeService(mirrorNodeGateway);
+
+        var contractNum = mirrorNodeService.getContractNum(address.toString());
+
+        return new ContractId(this.shard, this.realm, contractNum, checksum);
     }
 
     /**
@@ -240,6 +246,7 @@ public class ContractId extends Key implements Comparable<ContractId> {
      * @param client
      * @return populated ContractId instance
      */
+    @Deprecated
     public CompletableFuture<ContractId> populateContractNumAsync(Client client) {
         EvmAddress address = new EvmAddress(this.evmAddress);
         MirrorNodeGateway mirrorNodeGateway = MirrorNodeGateway.forClient(client);


### PR DESCRIPTION
This PR deprecates `populateAccountNumAsync`, `populateAccountEvmAddressAsync` methods in `AccountId` and `populateContractNumAsync` in `ContractId`.

Closes #1823