### PR TITLE
fix: build fail after updating protobufs

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/RequestType.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/RequestType.java
@@ -397,7 +397,27 @@ public enum RequestType {
     /**
      * Update the metadata of one or more NFT's of a specific token type.
      */
-    TOKEN_UPDATE_NFTS(HederaFunctionality.TokenUpdateNfts);
+    TOKEN_UPDATE_NFTS(HederaFunctionality.TokenUpdateNfts),
+
+    /**
+     * Create a node
+     */
+    NODE_CREATE(HederaFunctionality.NodeCreate),
+
+    /**
+     * Update a node
+     */
+    NODE_UPDATE(HederaFunctionality.NodeUpdate),
+
+    /**
+     * Delete a node
+     */
+    NODE_DELETE(HederaFunctionality.NodeDelete),
+
+    /**
+     * Get Node information
+     */
+    NODE_GET_INFO(HederaFunctionality.NodeGetInfo);
 
     final HederaFunctionality code;
 
@@ -482,6 +502,10 @@ public enum RequestType {
             case UtilPrng -> PRNG;
             case TransactionGetFastRecord -> TRANSACTION_GET_FAST_RECORD;
             case TokenUpdateNfts -> TOKEN_UPDATE_NFTS;
+            case NodeCreate -> NODE_CREATE;
+            case NodeUpdate -> NODE_UPDATE;
+            case NodeDelete -> NODE_DELETE;
+            case NodeGetInfo -> NODE_GET_INFO;
             default -> throw new IllegalStateException("(BUG) unhandled HederaFunctionality");
         };
     }
@@ -564,6 +588,10 @@ public enum RequestType {
             case PRNG -> "PRNG";
             case TRANSACTION_GET_FAST_RECORD -> "TRANSACTION_GET_FAST_RECORD";
             case TOKEN_UPDATE_NFTS -> "TOKEN_UPDATE_NFTS";
+            case NODE_CREATE -> "NODE_CREATE";
+            case NODE_UPDATE -> "NODE_UPDATE";
+            case NODE_DELETE -> "NODE_DELETE";
+            case NODE_GET_INFO -> "NODE_GET_INFO";
         };
     }
 }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Status.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Status.java
@@ -1549,7 +1549,53 @@ public enum Status {
     /**
      * Admin key is not set on token
      */
-    TOKEN_HAS_NO_ADMIN_KEY(ResponseCodeEnum.TOKEN_HAS_NO_ADMIN_KEY);
+    TOKEN_HAS_NO_ADMIN_KEY(ResponseCodeEnum.TOKEN_HAS_NO_ADMIN_KEY),
+
+    /**
+     * The node has been marked as deleted
+     */
+    NODE_DELETED(ResponseCodeEnum.NODE_DELETED),
+
+    /**
+     * A node is not found during update and delete node transaction
+     */
+    INVALID_NODE_ID(ResponseCodeEnum.INVALID_NODE_ID),
+
+    /**
+     * gossip_endpoint has a fully qualified domain name instead of ip
+     */
+    INVALID_GOSSIP_ENDPOINT(ResponseCodeEnum.INVALID_GOSSIP_ENDPOINT),
+
+    /**
+     * The node account_id is invalid
+     */
+    INVALID_NODE_ACCOUNT_ID(ResponseCodeEnum.INVALID_NODE_ACCOUNT_ID),
+
+    /**
+     * The node description is invalid
+     */
+    INVALID_NODE_DESCRIPTION(ResponseCodeEnum.INVALID_NODE_DESCRIPTION),
+
+    /**
+     * service_endpoint is invalid
+     */
+    INVALID_SERVICE_ENDPOINT(ResponseCodeEnum.INVALID_SERVICE_ENDPOINT),
+
+    /**
+     * gossip_ca_certificate is invalid
+     */
+    INVALID_GOSSIP_CAE_CERTIFICATE(ResponseCodeEnum.INVALID_GOSSIP_CAE_CERTIFICATE),
+
+    /**
+     * grpc_certificate_hash is invalid
+     */
+    INVALID_GRPC_CERTIFICATE(ResponseCodeEnum.INVALID_GRPC_CERTIFICATE),
+
+    /**
+     * The maximum automatic associations value is not valid.<br/>
+     * The most common cause for this error is a value less than `-1`.
+     */
+    INVALID_MAX_AUTO_ASSOCIATIONS(ResponseCodeEnum.INVALID_MAX_AUTO_ASSOCIATIONS);
 
     final ResponseCodeEnum code;
 
@@ -1855,6 +1901,15 @@ public enum Status {
             case MISSING_TOKEN_METADATA -> MISSING_TOKEN_METADATA;
             case MISSING_SERIAL_NUMBERS -> MISSING_SERIAL_NUMBERS;
             case TOKEN_HAS_NO_ADMIN_KEY -> TOKEN_HAS_NO_ADMIN_KEY;
+            case NODE_DELETED -> NODE_DELETED;
+            case INVALID_NODE_ID -> INVALID_NODE_ID;
+            case INVALID_GOSSIP_ENDPOINT -> INVALID_GOSSIP_ENDPOINT;
+            case INVALID_NODE_ACCOUNT_ID -> INVALID_NODE_ACCOUNT_ID;
+            case INVALID_NODE_DESCRIPTION -> INVALID_NODE_DESCRIPTION;
+            case INVALID_SERVICE_ENDPOINT -> INVALID_SERVICE_ENDPOINT;
+            case INVALID_GOSSIP_CAE_CERTIFICATE -> INVALID_GOSSIP_CAE_CERTIFICATE;
+            case INVALID_GRPC_CERTIFICATE -> INVALID_GRPC_CERTIFICATE;
+            case INVALID_MAX_AUTO_ASSOCIATIONS -> INVALID_MAX_AUTO_ASSOCIATIONS;
             case UNRECOGNIZED ->
                 // NOTE: Protobuf deserialization will not give us the code on the wire
                 throw new IllegalArgumentException(

--- a/sdk/src/main/proto/address_book_service.proto
+++ b/sdk/src/main/proto/address_book_service.proto
@@ -1,0 +1,65 @@
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Hedera Network Services Protobuf
+ *
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hashgraph.sdk.proto";
+// <<<pbj.java_package = "com.hedera.hapi.node.addressbook">>> This comment is special code for setting PBJ Compiler java package
+
+import "query.proto";
+import "response.proto";
+import "transaction_response.proto";
+import "transaction.proto";
+
+/**
+ * Transactions for the AddressBook Service, those HAPI APIs facilitate changes to the nodes used across the Hedera network.
+ * All those transactions needs to be signed by the Hedera Council. Steps needed below:
+ * 1. The node operator creates and signs the transaction with their key (the key on the node operator account)
+ * 2. The node operator hands this transaction to Alex, who then gives it to the council to sign
+ * 3. When signed and submitted, the server will verify that account 2 keys have signed, and the keys on the operator account have signed.
+ * Hedera council should have ability to make all edits in addition to add/remove nodes
+ */
+service AddressBookService {
+    /**
+      * Prepare to add a new node to the network.
+      * When a valid council member initiates a HAPI transaction to add a new node,
+      * then the network should acknowledge the transaction and update the network’s Address Book within 24 hours.
+      * The added node will not be active until the network is upgraded.
+      */
+    rpc createNode (Transaction) returns (TransactionResponse);
+
+    /**
+     * Prepare to delete the node to the network.
+     * The deleted node will not be deleted until the network is upgraded.
+     * Such a deleted node can never be reused.
+     */
+    rpc deleteNode (Transaction) returns (TransactionResponse);
+
+    /**
+     * Prepare to update the node to the network.
+     * The node will not be updated until the network is upgraded.
+     */
+    rpc updateNode (Transaction) returns (TransactionResponse);
+
+    /**
+     * Retrieves the node information by node Id.
+     */
+    rpc getNodeInfo (Query) returns (Response);
+}

--- a/sdk/src/main/proto/basic_types.proto
+++ b/sdk/src/main/proto/basic_types.proto
@@ -647,7 +647,7 @@ message Key {
          * contractID key, which also requires the code in the active message frame belong to the
          * the contract with the given id.)
          */
-        ContractID delegatable_contract_id = 8; 
+        ContractID delegatable_contract_id = 8;
     }
 }
 
@@ -1188,9 +1188,29 @@ enum HederaFunctionality {
     TransactionGetFastRecord = 87;
 
     /**
-    * Update the metadata of one or more NFT's of a specific token type.
-    */
+     * Update the metadata of one or more NFT's of a specific token type.
+     */
     TokenUpdateNfts = 88;
+
+    /**
+     * Create a node
+     */
+    NodeCreate = 89;
+
+    /**
+     * Update a node
+     */
+    NodeUpdate = 90;
+
+    /**
+     * Delete a node
+     */
+    NodeDelete = 91;
+
+    /**
+     * Get Node information
+     */
+    NodeGetInfo = 92;
 }
 
 /**
@@ -1268,7 +1288,7 @@ message TransactionFeeSchedule {
     /**
      * Resource price coefficients
      */
-    FeeData feeData = 2 [deprecated=true];
+    FeeData feeData = 2 [deprecated = true];
 
     /**
      * Resource price coefficients. Supports subtype price definition.
@@ -1353,6 +1373,13 @@ message ServiceEndpoint {
      * The port of the node
      */
     int32 port = 2;
+
+    /**
+     * A node domain name
+     * This MUST be the fully qualified domain name of the node.
+     * This value MUST NOT be more than 253 characters.
+     */
+    string domain_name = 3;
 }
 
 /**
@@ -1370,18 +1397,18 @@ message NodeAddress {
      * The IP address of the Node with separator & octets encoded in UTF-8.  Usage is deprecated,
      * ServiceEndpoint is preferred to retrieve a node's list of IP addresses and ports
      */
-    bytes ipAddress = 1 [deprecated=true];
+    bytes ipAddress = 1 [deprecated = true];
 
     /**
      * The port number of the grpc server for the node.  Usage is deprecated, ServiceEndpoint is
      * preferred to retrieve a node's list of IP addresses and ports
      */
-    int32 portno = 2 [deprecated=true];
+    int32 portno = 2 [deprecated = true];
 
     /**
      * Usage is deprecated, nodeAccountId is preferred to retrieve a node's account ID
      */
-    bytes memo = 3 [deprecated=true];
+    bytes memo = 3 [deprecated = true];
 
     /**
      * The node's X509 RSA public key used to sign stream files (e.g., record stream 

--- a/sdk/src/main/proto/crypto_create.proto
+++ b/sdk/src/main/proto/crypto_create.proto
@@ -128,8 +128,12 @@ message CryptoCreateTransactionBody {
     string memo = 13;
 
     /**
-     * The maximum number of tokens that an Account can be implicitly associated with. Defaults to 0
-     * and up to a maximum value of 1000.
+     * The maximum number of tokens that can be auto-associated with the account.<br/>
+     * If this is less than or equal to `used_auto_associations`, or 0, then this account
+     * MUST manually associate with a token before transacting in that token.<br/>
+     * This value MAY also be `-1` to indicate no limit.<br/>
+     * This value MUST NOT be less than `-1`.<br/>
+     * By default this value is 0 for accounts except for auto-created accounts which default -1.
      */
     int32 max_automatic_token_associations = 14;
 

--- a/sdk/src/main/proto/crypto_update.proto
+++ b/sdk/src/main/proto/crypto_update.proto
@@ -128,8 +128,12 @@ message CryptoUpdateTransactionBody {
     google.protobuf.StringValue memo = 14;
 
     /**
-     * The maximum number of tokens that an Account can be implicitly associated with. Up to a 1000
-     * including implicit and explicit associations.
+     * If set, modify the maximum number of tokens that can be auto-associated with the
+     * account.<br/>
+     * If this is set and less than or equal to `used_auto_associations`, or 0, then this account
+     * MUST manually associate with a token before transacting in that token.<br/>
+     * This value MAY also be `-1` to indicate no limit.<br/>
+     * This value MUST NOT be less than `-1`.
      */
     google.protobuf.Int32Value max_automatic_token_associations = 15;
 

--- a/sdk/src/main/proto/node.proto
+++ b/sdk/src/main/proto/node.proto
@@ -1,0 +1,107 @@
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Hedera Network Services Protobuf
+ *
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import "basic_types.proto";
+
+option java_package = "com.hedera.hashgraph.sdk.proto";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.addressbook">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Representation of a Node in the network Merkle tree
+ *
+ * A Node is identified by a single uint64 number, which is unique among all nodes.
+ */
+message Node {
+    /**
+     * The unique id of the Node.
+     */
+    uint64 node_id = 1;
+
+    /**
+     * The account is charged for transactions submitted by the node that fail due diligence
+     */
+    AccountID account_id = 2;
+
+    /**
+     * A description of the node, with UTF-8 encoding up to 100 bytes
+     */
+    string description = 3;
+
+    /**
+     * Node Gossip Endpoints, ip address or FQDN and port
+     */
+    repeated ServiceEndpoint gossip_endpoint = 4;
+
+    /**
+     * A node's service Endpoints, ip address or FQDN and port
+     */
+    repeated ServiceEndpoint service_endpoint = 5;
+
+    /**
+     * The node's X509 certificate used to sign stream files (e.g., record stream
+     * files). Precisely, this field is the DER encoding of gossip X509 certificate.
+     */
+    bytes gossip_ca_certificate = 6;
+
+    /**
+     * node x509 certificate hash. Hash of the node's TLS certificate. Precisely, this field is a string of
+     * hexadecimal characters which, translated to binary, are the SHA-384 hash of
+     * the UTF-8 NFKD encoding of the node's TLS cert in PEM format. Its value can be
+     * used to verify the node's certificate it presents during TLS negotiations.
+     */
+    bytes grpc_certificate_hash = 7;
+
+    /**
+     * The consensus weight of this node in the network.
+     */
+    uint64 weight = 8;
+
+    /**
+     * an enum to indicate the status of the node, not used in phase 2
+     */
+    //NodeStatus status = 9;
+
+}
+
+enum NodeStatus {
+    /**
+     * node in this state is deleted
+     */
+    DELETED = 0;
+
+    /**
+     * node in this state is waiting to be added by consensus roster
+     */
+    PENDING_ADDITION = 1;
+
+    /**
+     *  node in this state is waiting to be deleted by consensus roster
+     */
+    PENDING_DELETION = 2;
+
+    /**
+     * node in this state is active on the network and participating
+     * in network consensus.
+     */
+    IN_CONSENSUS = 3;
+}

--- a/sdk/src/main/proto/node_create.proto
+++ b/sdk/src/main/proto/node_create.proto
@@ -1,0 +1,88 @@
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Hedera Network Services Protobuf
+ *
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hashgraph.sdk.proto";
+// <<<pbj.java_package = "com.hedera.hapi.node.addressbook">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * A transaction body to add a new node to the network.
+ * After the node is created, the node_id for it is in the receipt.
+ *
+ * This transaction body SHALL be considered a "privileged transaction".
+ *
+ * This message supports a transaction to create a new node in the network.
+ * The transaction, once complete, enables a new consensus node
+ * to join the network, and requires governing council authorization.
+ *
+ * A `NodeCreateTransactionBody` MUST be signed by the governing council.<br/>
+ * The newly created node information will be used to generate config.txt and
+ * a-pulbic-NodeAlias.pem file per each node during phase 2,<br>
+ * not active until next freeze upgrade.
+ */
+message NodeCreateTransactionBody {
+
+    /**
+     * Node account id, mandatory field, ALIAS is not allowed, only ACCOUNT_NUM.
+     * If account_id does not exist, it will reject the transaction.
+     * Multiple nodes can have the same account_id.
+     */
+    AccountID account_id = 1;
+
+    /**
+     * Description of the node with UTF-8 encoding up to 100 bytes, optional field.
+     */
+    string description = 2;
+
+    /**
+     * Ip address and port, mandatory field. Fully qualified domain name is
+     * not allowed here. Maximum number of these endpoints is 10.
+     * The first in the list is used as the Internal IP address in config.txt,
+     * the second in the list is used as the External IP address in config.txt,
+     * the rest of IP addresses are ignored for DAB phase 2.
+     */
+    repeated ServiceEndpoint gossip_endpoint = 3;
+
+    /**
+     * A node's grpc service IP addresses and ports, IP:Port is mandatory,
+     * fully qualified domain name is optional. Maximum number of these endpoints is 8.
+     */
+    repeated ServiceEndpoint service_endpoint = 4;
+
+    /**
+     * The node's X509 certificate used to sign stream files (e.g., record stream
+     * files). Precisely, this field is the DER encoding of gossip X509 certificate.
+     * This is a mandatory field.
+     */
+    bytes gossip_ca_certificate = 5;
+
+    /**
+     * Hash of the node's TLS certificate. Precisely, this field is a string of
+     * hexadecimal characters which translated to binary, are the SHA-384 hash of
+     * the UTF-8 NFKD encoding of the node's TLS cert in PEM format.
+     * Its value can be used to verify the node's certificate it presents
+     * during TLS negotiations.node x509 certificate hash, optional field.
+     */
+    bytes grpc_certificate_hash = 6;
+}

--- a/sdk/src/main/proto/node_delete.proto
+++ b/sdk/src/main/proto/node_delete.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Hedera Network Services Protobuf
+ *
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hashgraph.sdk.proto";
+// <<<pbj.java_package = "com.hedera.hapi.node.addressbook">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Delete the given node. After deletion, it will be marked as deleted.
+ * But information about it will continue to exist for a year.
+ * For phase 2, this marks the node to be deleted in the merkle tree and will be used to write config.txt and
+ * a-pulbic-NodeAlias.pem file per each node during prepare freeze.
+ * The deleted node will not be deleted until the network is upgraded.
+ * Such a deleted node can never be reused.
+ * The council has to sign this transaction. This is a privileged transaction.
+ */
+message NodeDeleteTransactionBody {
+    /**
+     * The unique id of the node to be deleted. If invalid node is specified, transaction will
+     * result in INVALID_NODE_ID.
+     */
+    uint64 node_id = 1;
+}

--- a/sdk/src/main/proto/node_get_info.proto
+++ b/sdk/src/main/proto/node_get_info.proto
@@ -1,0 +1,129 @@
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Hedera Network Services Protobuf
+ *
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hashgraph.sdk.proto";
+// <<<pbj.java_package = "com.hedera.hapi.node.addressbook">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Gets information about Node instance. This needs super use privileges to succeed or should be a node operator.
+ */
+message NodeGetInfoQuery {
+    /**
+     * Standard information sent with every query operation.<br/>
+     * This includes the signed payment and what kind of response is requested
+     * (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * A node identifier for which information is requested.<br/>
+     * If the identified node is not valid, this request SHALL fail with
+     * a response code `INVALID_NODE_ID`.
+     */
+    uint64 node_id = 2;
+}
+
+/**
+ * A query response describing the current state of a node
+ */
+message NodeInfo {
+    /**
+     * A numeric node identifier.<br/>
+     * This value identifies this node within the network address book.
+     */
+    uint64 node_id = 1;
+
+    /**
+     * The account is charged for transactions submitted by the node that fail due diligence
+     */
+    AccountID account_id = 2;
+
+    /**
+     * A description of the node with UTF-8 encoding up to 100 bytes
+     */
+    string description = 3;
+
+    /**
+     * A node's Gossip Endpoints, ip address and port
+     */
+    repeated ServiceEndpoint gossip_endpoint = 4;
+
+    /**
+     * A node's service Endpoints, ip address or FQDN and port
+     */
+    repeated ServiceEndpoint service_endpoint = 5;
+
+    /**
+     * The node's X509 certificate used to sign stream files (e.g., record stream
+     * files). Precisely, this field is the DER encoding of gossip X509 certificate.
+     * files).
+     */
+    bytes gossip_ca_certificate = 6;
+
+    /**
+     * node x509 certificate hash. Hash of the node's TLS certificate. Precisely, this field is a string of
+     * hexadecimal characters which, translated to binary, are the SHA-384 hash of
+     * the UTF-8 NFKD encoding of the node's TLS cert in PEM format. Its value can be
+     * used to verify the node's certificate it presents during TLS negotiations.
+     */
+    bytes grpc_certificate_hash = 7;
+
+    /**
+     * The consensus weight of this node in the network.
+     */
+    uint64 weight = 8;
+
+    /**
+     * Whether the node has been deleted
+     */
+    bool deleted = 10;
+
+    /**
+     * A ledger ID.<br/>
+     * This identifies the network that responded to this query.
+     * The specific values are documented in [HIP-198]
+     * (https://hips.hedera.com/hip/hip-198).
+     */
+    bytes ledger_id = 9;
+}
+
+/**
+ * Response when the client sends the node NodeGetInfoQuery
+ */
+message NodeGetInfoResponse {
+    /**
+     * The standard response information for queries.<br/>
+     * This includes the values requested in the `QueryHeader`;
+     * cost, state proof, both, or neither.
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * The information requested about this node instance
+     */
+    NodeInfo nodeInfo = 2;
+}

--- a/sdk/src/main/proto/node_update.proto
+++ b/sdk/src/main/proto/node_update.proto
@@ -1,0 +1,74 @@
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Hedera Network Services Protobuf
+ *
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hashgraph.sdk.proto";
+// <<<pbj.java_package = "com.hedera.hapi.node.addressbook">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "google/protobuf/wrappers.proto";
+import "basic_types.proto";
+
+/**
+ * Modify the attribute of a node. If a field is not set in the transaction body, the
+ * corresponding node attribute will be unchanged.
+ * For phase 2, this marks node to be updated in the merkle tree and will be used to write config.txt and
+ * a-pulbic-NodeAlias.pem file per each node during prepare freeze.
+ * The node will not be updated until the network is upgraded.
+ * Original node account ID has to sign the transaction.
+ */
+message NodeUpdateTransactionBody {
+
+    /**
+     * The unique id of the Node to be updated. This must refer to an existing, non-deleted node.
+     */
+    uint64 node_id = 1;
+
+    /**
+     * If set, the new node account_id.
+     */
+    AccountID account_id = 2;
+
+    /**
+     * If set, the new description to be associated with the node.
+     */
+    google.protobuf.StringValue description = 3;
+
+    /**
+     * If set, the new ip address and port.
+     */
+    repeated ServiceEndpoint gossip_endpoint = 4;
+
+    /**
+     * If set, replace the current list of service_endpoints.
+     */
+    repeated ServiceEndpoint service_endpoint = 5;
+
+    /**
+     * If set, the new X509 certificate of the gossip node.
+     */
+    google.protobuf.BytesValue gossip_ca_certificate = 6;
+
+    /**
+     * If set, the new grpc x509 certificate hash.
+     */
+    google.protobuf.BytesValue grpc_certificate_hash = 7;
+}

--- a/sdk/src/main/proto/query.proto
+++ b/sdk/src/main/proto/query.proto
@@ -60,6 +60,7 @@ import "token_get_nft_info.proto";
 import "token_get_nft_infos.proto";
 
 import "get_account_details.proto";
+import "node_get_info.proto";
 
 /**
  * A single query, which is sent from the client to a node. This includes all possible queries. Each
@@ -197,5 +198,10 @@ message Query {
          * Gets all information about an account including allowances granted by the account
          */
         GetAccountDetailsQuery accountDetails = 58;
+
+        /**
+         * Get all information about a node
+         */
+        NodeGetInfoQuery nodeGetInfo = 59;
     }
 }

--- a/sdk/src/main/proto/response.proto
+++ b/sdk/src/main/proto/response.proto
@@ -60,6 +60,7 @@ import "token_get_nft_infos.proto";
 import "schedule_get_info.proto";
 
 import "get_account_details.proto";
+import "node_get_info.proto";
 
 /**
  * A single response, which is returned from the node to the client, after the client sent the node
@@ -191,5 +192,10 @@ message Response {
          * Gets all information about an account including allowances granted by the account
          */
         GetAccountDetailsResponse accountDetails = 158;
+
+        /**
+         * Get all information about a node
+         */
+        NodeGetInfoResponse nodeGetInfo = 159;
     }
 }

--- a/sdk/src/main/proto/response_code.proto
+++ b/sdk/src/main/proto/response_code.proto
@@ -1397,4 +1397,50 @@ enum ResponseCodeEnum {
    * Admin key is not set on token
    */
   TOKEN_HAS_NO_ADMIN_KEY = 337;
+
+  /**
+   * The node has been marked as deleted
+   */
+  NODE_DELETED = 338;
+
+  /**
+   * A node is not found during update and delete node transaction
+   */
+  INVALID_NODE_ID = 339;
+
+  /**
+   * gossip_endpoint has a fully qualified domain name instead of ip
+   */
+  INVALID_GOSSIP_ENDPOINT = 340;
+
+  /**
+   * The node account_id is invalid
+   */
+  INVALID_NODE_ACCOUNT_ID = 341;
+
+  /**
+   * The node description is invalid
+   */
+  INVALID_NODE_DESCRIPTION = 342;
+
+  /**
+   * service_endpoint is invalid
+   */
+  INVALID_SERVICE_ENDPOINT = 343;
+
+  /**
+   * gossip_ca_certificate is invalid
+   */
+  INVALID_GOSSIP_CAE_CERTIFICATE = 344;
+
+  /**
+   * grpc_certificate_hash is invalid
+   */
+  INVALID_GRPC_CERTIFICATE = 345;
+
+  /**
+   * The maximum automatic associations value is not valid.<br/>
+   * The most common cause for this error is a value less than `-1`.
+   */
+  INVALID_MAX_AUTO_ASSOCIATIONS = 346;
 }

--- a/sdk/src/main/proto/schedulable_transaction_body.proto
+++ b/sdk/src/main/proto/schedulable_transaction_body.proto
@@ -73,6 +73,10 @@ import "token_update_nfts.proto";
 import "schedule_delete.proto";
 import "util_prng.proto";
 
+import "node_create.proto";
+import "node_update.proto";
+import "node_delete.proto";
+
 /**
  * A schedulable transaction. Note that the global/dynamic system property
  * <tt>scheduling.whitelist</tt> controls which transaction types may be scheduled. As of Hedera
@@ -289,5 +293,20 @@ message SchedulableTransactionBody {
      * Update the metadata of one or more NFT's of a specific token type.
      */
     TokenUpdateNftsTransactionBody token_update_nfts = 41;
+
+    /**
+     * Transaction body for a scheduled transaction to create a new node.
+     */
+    NodeCreateTransactionBody nodeCreate = 42;
+
+    /**
+     * Transaction body for a scheduled transaction to modify an existing node.
+     */
+    NodeUpdateTransactionBody nodeUpdate = 43;
+
+    /**
+     * Transaction body for a scheduled transaction to remove a node.
+     */
+    NodeDeleteTransactionBody nodeDelete = 44;
   }
 }

--- a/sdk/src/main/proto/transaction_body.proto
+++ b/sdk/src/main/proto/transaction_body.proto
@@ -85,6 +85,10 @@ import "schedule_sign.proto";
 import "node_stake_update.proto";
 import "util_prng.proto";
 
+import "node_create.proto";
+import "node_update.proto";
+import "node_delete.proto";
+
 /**
  * A single transaction. All transaction types are possible here.
  */
@@ -356,5 +360,20 @@ message TransactionBody {
      * Update the metadata of one or more NFT's of a specific token type.
      */
     TokenUpdateNftsTransactionBody token_update_nfts = 53;
+
+    /**
+     * A transaction body for a `createNode` request.
+     */
+    NodeCreateTransactionBody nodeCreate = 54;
+
+    /**
+     * A transaction body for an `updateNode` request.
+     */
+    NodeUpdateTransactionBody nodeUpdate = 55;
+
+    /**
+     * A transaction body for a `deleteNode` request.
+     */
+    NodeDeleteTransactionBody nodeDelete = 56;
   }
 }

--- a/sdk/src/main/proto/transaction_receipt.proto
+++ b/sdk/src/main/proto/transaction_receipt.proto
@@ -164,4 +164,9 @@ message TransactionReceipt {
      * the newly created NFTs
      */
     repeated int64 serialNumbers = 14;
+
+    /**
+     * In the receipt of a NodeCreate, NodeUpdate, NodeDelete, the id of the newly created node.
+     */
+    uint64 node_id = 15;
 }


### PR DESCRIPTION
This PR addresses the issue when gradle build fails with an error after updating protobufs.

Following step was automated in relevant python script: updating protobuf imports in the processed protobufs under `sdk/src/main/proto` (removing `state/` in order to import protobufs from the same folder).

Also protobufs were updated to validate fix against CI checks.

Closes #1747