### PR TITLE
fix: set 'group' in root project

### DIFF
--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.root.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.root.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 plugins {
+    id("com.hedera.gradle.base")
     id("com.hedera.gradle.repositories")
     id("com.autonomousapps.dependency-analysis")
     id("io.github.gradle-nexus.publish-plugin")


### PR DESCRIPTION


**Description**:

...by applying 'com.hedera.gradle.base' to root.
This is needed by the Nexus publishing mechanism.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
