### PR TITLE
fix: allow certHash to contain upper or lower case characters

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/HederaTrustManager.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/HederaTrustManager.java
@@ -108,7 +108,7 @@ class HederaTrustManager implements X509TrustManager {
                 throw new IllegalStateException("Failed to find SHA-384 digest for certificate hashing", e);
             }
 
-            if (this.certHash.equals(Hex.toHexString(certHashBytes))) {
+            if (this.certHash.equalsIgnoreCase(Hex.toHexString(certHashBytes))) {
                 return;
             }
         }


### PR DESCRIPTION
**Description**:
Allow certHash to contain upper or lower case characters

**Related issue(s)**:

Fixes #1904 
