### PR TITLE
feat: minimal change to test custom network

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/LedgerId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/LedgerId.java
@@ -51,7 +51,7 @@ public class LedgerId {
      *
      * @param idBytes                   the id (0=mainnet, 1=testnet, 2=previewnet, ...)
      */
-    LedgerId(byte[] idBytes) {
+    protected LedgerId(byte[] idBytes) {
         this.idBytes = idBytes;
     }
 
@@ -146,7 +146,7 @@ public class LedgerId {
      *
      * @return                          is it one of the three standard networks
      */
-    boolean isKnownNetwork() {
+    protected boolean isKnownNetwork() {
         return isMainnet() || isTestnet() || isPreviewnet();
     }
 


### PR DESCRIPTION
**Description**:
A minimal change to allow testing a custom network.

Allows testing a custom network, though not nearly as nicely as PR #1901. This change allows for additional ledger IDs without relying on split package access to package-private methods.

**Related issue(s)**:

Fixes #1900 
