### PR TITLE
fix: handle `FEE_SCHEDULE_FILE_PART_UPLOADED` status

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TransactionReceipt.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TransactionReceipt.java
@@ -308,7 +308,7 @@ public final class TransactionReceipt {
      * @throws ReceiptStatusException when shouldValidate is true and the transaction status is not SUCCESS
      */
     public TransactionReceipt validateStatus(boolean shouldValidate) throws ReceiptStatusException {
-        if (shouldValidate && status != Status.SUCCESS) {
+        if (shouldValidate && status != Status.SUCCESS && status != Status.FEE_SCHEDULE_FILE_PART_UPLOADED) {
             throw new ReceiptStatusException(transactionId, this);
         }
         return this;

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/FileUpdateIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/FileUpdateIntegrationTest.java
@@ -22,6 +22,7 @@ package com.hedera.hashgraph.sdk.test.integration;
 import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.FileCreateTransaction;
 import com.hedera.hashgraph.sdk.FileDeleteTransaction;
+import com.hedera.hashgraph.sdk.FileId;
 import com.hedera.hashgraph.sdk.FileInfoQuery;
 import com.hedera.hashgraph.sdk.FileUpdateTransaction;
 import com.hedera.hashgraph.sdk.KeyList;
@@ -130,4 +131,21 @@ public class FileUpdateIntegrationTest {
 
         testEnv.close();
     }
+
+    @Test
+    @DisplayName("Can update fee schedule file")
+    void canUpdateFeeScheduleFile() throws Exception {
+        var testEnv = new IntegrationTestEnv(1);
+
+        var fileId = new FileId(0, 0, 111);
+        var receipt = new FileUpdateTransaction()
+            .setFileId(fileId)
+            .setContents("[e2e::FileUpdateTransaction]")
+            .execute(testEnv.client)
+            .getReceipt(testEnv.client);
+
+        assertThat(receipt.status).isEqualTo(Status.FEE_SCHEDULE_FILE_PART_UPLOADED);
+        testEnv.close();
+    }
+
 }

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/FileUpdateIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/FileUpdateIntegrationTest.java
@@ -20,6 +20,7 @@
 package com.hedera.hashgraph.sdk.test.integration;
 
 import com.google.errorprone.annotations.Var;
+import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.FileCreateTransaction;
 import com.hedera.hashgraph.sdk.FileDeleteTransaction;
 import com.hedera.hashgraph.sdk.FileId;
@@ -27,6 +28,7 @@ import com.hedera.hashgraph.sdk.FileInfoQuery;
 import com.hedera.hashgraph.sdk.FileUpdateTransaction;
 import com.hedera.hashgraph.sdk.KeyList;
 import com.hedera.hashgraph.sdk.PrecheckStatusException;
+import com.hedera.hashgraph.sdk.PrivateKey;
 import com.hedera.hashgraph.sdk.ReceiptStatusException;
 import com.hedera.hashgraph.sdk.Status;
 import org.junit.jupiter.api.DisplayName;
@@ -136,6 +138,8 @@ public class FileUpdateIntegrationTest {
     @DisplayName("Can update fee schedule file")
     void canUpdateFeeScheduleFile() throws Exception {
         var testEnv = new IntegrationTestEnv(1);
+        testEnv.client.setOperator(new AccountId(0, 0, 2), PrivateKey.fromString(
+            "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137"));
 
         var fileId = new FileId(0, 0, 111);
         var receipt = new FileUpdateTransaction()
@@ -147,5 +151,4 @@ public class FileUpdateIntegrationTest {
         assertThat(receipt.status).isEqualTo(Status.FEE_SCHEDULE_FILE_PART_UPLOADED);
         testEnv.close();
     }
-
 }


### PR DESCRIPTION
**Description**:
handle `FEE_SCHEDULE_FILE_PART_UPLOADED` status in transaction receipt

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-sdk-java/issues/1950

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
