### PR TITLE
ci: update workflows to use latitude.sh based runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: [ self-hosted, Linux, medium, ephemeral ]
+    runs-on: client-sdk-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
@@ -54,7 +54,7 @@ jobs:
 
   test:
     name: Unit and Integration Tests
-    runs-on: [ self-hosted, Linux, medium, ephemeral ]
+    runs-on: client-sdk-linux-medium
     needs:
       - build
     steps:
@@ -118,7 +118,7 @@ jobs:
 
   run-examples:
     name: Run Examples
-    runs-on: [ self-hosted, Linux, medium, ephemeral ]
+    runs-on: client-sdk-linux-medium
     needs:
       - build
     steps:
@@ -173,7 +173,7 @@ jobs:
 
   test-tck:
       name: TCK Tests
-      runs-on: [ self-hosted, Linux, medium, ephemeral ]
+      runs-on: client-sdk-linux-medium
       needs:
           - build
       steps:

--- a/.github/workflows/disabled/main.yml
+++ b/.github/workflows/disabled/main.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: client-sdk-linux-medium
     strategy:
       matrix:
         version: [ 'current', 'latest' ]

--- a/.github/workflows/disabled/previewnet.yml
+++ b/.github/workflows/disabled/previewnet.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: client-sdk-linux-medium
 
     steps:
       - uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
         run: ./gradlew build
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: client-sdk-linux-medium
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/disabled/testnet.yml
+++ b/.github/workflows/disabled/testnet.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   compile:
-    runs-on: ubuntu-latest
+    runs-on: client-sdk-linux-medium
 
     steps:
       - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
         run: ./gradlew :examples:compileJava
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: client-sdk-linux-medium
 
     steps:
       - uses: actions/checkout@v2
@@ -69,7 +69,7 @@ jobs:
         run: ./gradlew build sonarqube --info
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: client-sdk-linux-medium
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   publish:
     name: Publish
-    runs-on: [ self-hosted, Linux, medium, ephemeral ]
+    runs-on: client-sdk-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   validate-release:
     name: Validate Release
-    runs-on: [ self-hosted, Linux, medium, ephemeral ]
+    runs-on: client-sdk-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
@@ -72,7 +72,7 @@ jobs:
 
   maven-central:
     name: Publish to Maven Central
-    runs-on: [ self-hosted, Linux, medium, ephemeral ]
+    runs-on: client-sdk-linux-medium
     needs:
       # This needs clause exists solely to provide a dependency on the previous step. This publish step will not occur
       # until the validate-release step completes successfully.


### PR DESCRIPTION
## Description

This pull request changes the following:

- Updates the CI workflows `runs-on` labels to use the new Latitude.sh based runners.

### Related Issues

- Closes #1973 