### PR TITLE
build: remove inconsistent code analysis / align with hedera-services

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,13 +102,6 @@ jobs:
         run: |
           ./gradlew -POPERATOR_ID=$OPERATOR_ID -POPERATOR_KEY=$OPERATOR_KEY -PHEDERA_NETWORK=$HEDERA_NETWORK jacocoTestReport --scan
 
-      - name: Sonar Scan
-        if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonarqube --info --scan
-
       - name: Upload coverage to Codecov
         if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0

--- a/gradle/plugins/build.gradle.kts
+++ b/gradle/plugins/build.gradle.kts
@@ -26,14 +26,11 @@ repositories.gradlePluginPortal()
 
 dependencies {
     implementation("com.autonomousapps:dependency-analysis-gradle-plugin:2.1.4")
-    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.12")
     implementation("com.google.protobuf:protobuf-gradle-plugin:0.9.4")
     implementation("io.github.gradle-nexus:publish-plugin:1.3.0")
-    implementation("net.ltgt.gradle:gradle-errorprone-plugin:3.1.0")
-    implementation("org.gradlex:extra-java-module-info:1.8")
+    implementation("org.gradlex:extra-java-module-info:1.9")
     implementation("org.gradlex:java-module-dependencies:1.6.5")
     implementation("org.gradlex:jvm-dependency-conflict-resolution:2.1")
-    implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.4.1.3373")
 
     implementation("org.gradle.toolchains:foojay-resolver:0.8.0")
     implementation("com.gradle:develocity-gradle-plugin:3.17.2")

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.examples.java.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.examples.java.gradle.kts
@@ -18,8 +18,6 @@
  *
  */
 
-import net.ltgt.gradle.errorprone.errorprone
-
 plugins {
     id("application")
     id("com.hedera.gradle.java-base")
@@ -28,13 +26,6 @@ plugins {
 javaModuleDependencies {
     moduleNameToGA.put("com.hedera.hashgraph.sdk", "com.hedera.hashgraph:sdk")
     moduleNameToGA.put("com.hedera.hashgraph.sdk.full", "com.hedera.hashgraph:sdk-full")
-}
-
-tasks.withType<JavaCompile>().configureEach {
-    options.errorprone {
-        disable("DefaultPackage")
-        disable("SystemOut")
-    }
 }
 
 tasks.register<RunAllExample>("runAllExamples") {

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.java-base.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.java-base.gradle.kts
@@ -1,5 +1,3 @@
-import net.ltgt.gradle.errorprone.errorprone
-
 /*-
  *
  * Hedera Java SDK
@@ -23,7 +21,6 @@ import net.ltgt.gradle.errorprone.errorprone
 plugins {
     id("java")
     id("jacoco")
-    id("net.ltgt.errorprone")
     id("org.gradlex.java-module-dependencies")
     id("com.hedera.gradle.base")
     id("com.hedera.gradle.repositories")
@@ -45,56 +42,26 @@ jvmDependencyConflicts {
     consistentResolution.platform("com.hedera.hashgraph:sdk-dependency-versions")
 }
 
-dependencies {
-    // https://github.com/google/error-prone
-    // https://errorprone.info/
-    errorprone("com.google.errorprone:error_prone_core:2.21.1")
-
-    // https://github.com/uber/NullAway
-    errorprone("com.uber.nullaway:nullaway:0.10.14")
-
-    // https://github.com/grpc/grpc-java-api-checker
-    errorprone("io.grpc:grpc-java-api-checker:1.1.0")
-}
+val deactivatedCompileLintOptions =
+    listOf(
+        "module", // module not found when doing 'exports to ...'
+        "serial", // serializable class ... has no definition of serialVersionUID
+        "processing", // No processor claimed any of these annotations: ...
+        "try", // auto-closeable resource ignore is never referenced... (AutoClosableLock)
+        "missing-explicit-ctor", // class ... declares no explicit constructors
+        "removal",
+        "deprecation",
+        "overrides", // overrides equals, but neither it ... overrides hashCode method
+        "unchecked",
+        "rawtypes",
+        "exports",
+        "dep-ann"
+    )
 
 tasks.withType<JavaCompile>().configureEach {
     options.encoding = "UTF-8"
-
-    // Disable warnings because I'm tired of them :P
-    options.isWarnings = false
-
-    options.errorprone {
-        // https://github.com/uber/NullAway
-        warn("NullAway")
-        option("NullAway:AnnotatedPackages", "com.hedera.hashgraph.sdk")
-        option("NullAway:TreatGeneratedAsUnannotated", "true")
-
-        // https://github.com/grpc/grpc-java-api-checker
-        disable("GrpcExperimentalApi")
-        warn("GrpcInternal")
-
-        // Enable _all_ error prone checks then selectively disble
-        // Checks that are default-disabled are enabled as warnings
-        allDisabledChecksAsWarnings = true
-        disable("TryFailRefactoring")
-        disable("ThrowSpecificExceptions")
-        disable("FutureReturnValueIgnored")
-        disable("FieldCanBeFinal")
-        disable("Finally")
-        disable("BooleanParameter")
-        disable("ThreadJoinLoop")
-        disable("UnnecessaryDefaultInEnumSwitch")
-        disable("UngroupedOverloads")
-        disable("InlineMeSuggester")
-
-        // Uncomment do disable Android + JDK7 checks
-        // disable("Java7ApiChecker")
-        // disable("AndroidJdkLibsChecker")
-
-        // Ignore generated and protobuf code
-        disableWarningsInGeneratedCode = true
-        excludedPaths = ".*generated.*"
-    }
+    options.compilerArgs.add("-Werror")
+    options.compilerArgs.add("-Xlint:all,-" + deactivatedCompileLintOptions.joinToString(",-"))
 }
 
 tasks.withType<AbstractArchiveTask>().configureEach {

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.java.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.java.gradle.kts
@@ -24,8 +24,6 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 plugins {
     id("java-library")
     id("com.google.protobuf")
-    id("com.github.spotbugs")
-    id("org.sonarqube")
     id("com.hedera.gradle.java-base")
     id("com.hedera.gradle.publish")
 }
@@ -105,16 +103,16 @@ tasks.jacocoTestReport {
 protobuf {
     protoc {
         // shouldn't be updated for now (breaking changes after 4.x.x)
-        artifact = "com.google.protobuf:protoc:3.25.3"
+        artifact = "com.google.protobuf:protoc:3.25.4"
     }
     plugins {
         id("grpc") {
-            artifact = "io.grpc:protoc-gen-grpc-java:1.50.2"
+            artifact = "io.grpc:protoc-gen-grpc-java:1.66.0"
         }
     }
 }
 tasks.generateProto {
-    plugins { plugins.register("grpc") }
+    plugins { plugins.register("grpc") { option("@generated=omit") } }
 }
 
 tasks.compileJava {
@@ -131,45 +129,4 @@ tasks.jar {
 
 sourceSets.all {
     configurations[getTaskName("", "compileProtoPath")].extendsFrom(configurations["internal"])
-}
-
-spotbugs {
-    //ignoreFailures = false
-    //showStackTraces = true
-    //showProgress = false
-    //reportLevel = 'default'
-    //effort = 'default'
-    //visitors = [ 'FindSqlInjection', 'SwitchFallthrough' ]
-    //omitVisitors = [ 'FindNonShortCircuit' ]
-    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
-    //includeFilter = file('spotbugs-include.xml')
-    //excludeFilter = file('spotbugs-exclude.xml')
-    onlyAnalyze = listOf("com.hedera.hashgraph.sdk.*")
-    //projectName = name
-    //release = version
-    //extraArgs = [ '-nested:false' ]
-    //jvmArgs = [ '-Duser.language=ja' ]
-    //maxHeapSize = '512m'
-}
-
-tasks.spotbugsMain {
-    reports.register("html") {
-        required = true
-        outputLocation = layout.buildDirectory.file("reports/spotbugs/main/spotbugs.html")
-        setStylesheet("fancy-hist.xsl")
-    }
-}
-
-dependencies {
-    spotbugs("com.github.spotbugs:spotbugs:4.8.4")
-    spotbugs("com.google.code.findbugs:jsr305:3.0.2")
-}
-
-sonarqube {
-    properties {
-        property("sonar.projectKey", "hashgraph_hedera-sdk-java")
-        property("sonar.organization", "hashgraph")
-        property("sonar.host.url", "https://sonarcloud.io")
-        property("sonar.exclusions", "examples/**")
-    }
 }

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.patch-modules.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.patch-modules.gradle.kts
@@ -24,13 +24,6 @@ plugins {
     id("org.gradlex.jvm-dependency-conflict-resolution")
 }
 
-// Do annotation processing on the classpath, because 'Error Prone' has many non-module dependencies
-sourceSets.all {
-    configurations.getByName(annotationProcessorConfigurationName) {
-        attributes { attribute(Attribute.of("javaModule", Boolean::class.javaObjectType), false) }
-    }
-}
-
 // Fix or enhance the metadata of third-party Modules. This is about the metadata in the
 // repositories: '*.pom' and '*.module' files.
 jvmDependencyConflicts.patch {
@@ -41,7 +34,6 @@ jvmDependencyConflicts.patch {
             "com.google.android:annotations",
             "com.google.code.findbugs:annotations",
             "com.google.code.findbugs:jsr305",
-            "com.google.errorprone:error_prone_annotations",
             "com.google.guava:listenablefuture",
             "com.google.j2objc:j2objc-annotations",
             "org.checkerframework:checker-compat-qual",
@@ -76,21 +68,7 @@ extraJavaModuleInfo {
     module("com.google.guava:failureaccess", "com.google.common.util.concurrent.internal")
     module("com.google.guava:guava", "com.google.common") {
         exportAllPackages()
-        requires("com.google.common.util.concurrent.internal")
-        requires("java.logging")
-    }
-    module("guava-32.1.3-jre.jar", "com.google.common") {
-        /**
-         * Repetition of the rule above:
-         *
-         * There is an issue when the version is "android", but the selected Jar
-         * with classifier is "jre". If this causes a problem depends on the local
-         * Gradle dependency cache state (most likely).
-         * This is an issue that needs to be investigated and fixed in
-         * https://github.com/gradlex-org/extra-java-module-info
-         */
-        exportAllPackages()
-        requires("com.google.common.util.concurrent.internal")
+        requireAllDefinedDependencies()
         requires("java.logging")
     }
     module("com.google.protobuf:protobuf-java", "com.google.protobuf") {
@@ -128,10 +106,7 @@ extraJavaModuleInfo {
         requires("java.logging")
     }
     module("io.perfmark:perfmark-api", "io.perfmark")
-    module("javax.annotation:javax.annotation-api", "java.annotation") {
-        exportAllPackages()
-        mergeJar("com.google.code.findbugs:jsr305")
-    }
+    module("com.google.code.findbugs:jsr305", "java.annotation")
     module("org.jetbrains:annotations", "org.jetbrains.annotations")
 
     // Full protobuf only
@@ -159,8 +134,4 @@ extraJavaModuleInfo {
     module("org.mockito:mockito-core", "org.mockito")
     module("org.mockito:mockito-junit-jupiter", "org.mockito.junit.jupiter")
     module("org.objenesis:objenesis", "org.objenesis")
-}
-
-dependencies {
-    javaModulesMergeJars("com.google.code.findbugs:jsr305:3.0.2")
 }

--- a/scripts/generate_contract_function_param_methods.py
+++ b/scripts/generate_contract_function_param_methods.py
@@ -47,7 +47,7 @@ def add_with_param_type(bit_width, param_type, map_method_name, exception_commen
         "* @return {@code this}\n"
         "*/\n"
         "public ContractFunctionParameters addInt" + str(bit_width) + "Array(" + param_type + "[] intArray) {\n"
-        "    @Var ByteString arrayBytes = ByteString.copyFrom(\n"
+        "    ByteString arrayBytes = ByteString.copyFrom(\n"
         "        J8Arrays.stream(intArray)." + map_method_name + "(i -> int256(i, " + str(bit_width) + "))\n"
         "        .collect(Collectors.toList()));\n"
         "\n"
@@ -70,7 +70,7 @@ def add_with_param_type(bit_width, param_type, map_method_name, exception_commen
         exception_comment +
         "*/\n"
         "public ContractFunctionParameters addUint" + str(bit_width) + "Array(" + param_type + "[] intArray) {\n"
-        "    @Var ByteString arrayBytes = ByteString.copyFrom(\n"
+        "    ByteString arrayBytes = ByteString.copyFrom(\n"
         "        J8Arrays.stream(intArray)." + map_method_name + "(i -> uint256(i, " + str(bit_width) + "))\n"
         "        .collect(Collectors.toList()));\n"
         "\n"

--- a/sdk-dependency-versions/build.gradle.kts
+++ b/sdk-dependency-versions/build.gradle.kts
@@ -26,12 +26,6 @@ dependencies.constraints {
     api("com.esaulpaugh:headlong:12.1.0") {
         because("headlong")
     }
-    api("com.github.spotbugs:spotbugs-annotations:4.8.6") {
-        because("com.github.spotbugs.annotations")
-    }
-    api("com.google.errorprone:error_prone_annotations:2.21.1") {
-        because("com.google.errorprone.annotations")
-    }
     api("com.google.code.gson:gson:2.10.1") {
         because("com.google.gson")
     }
@@ -58,7 +52,7 @@ dependencies.constraints {
     api("io.grpc:grpc-stub:1.64.0") {
         because("io.grpc.stub")
     }
-    api("javax.annotation:javax.annotation-api:1.3.2") {
+    api("com.google.code.findbugs:jsr305:3.0.2") {
         because("java.annotation")
     }
     api("org.bouncycastle:bcpkix-jdk18on:1.78.1") {

--- a/sdk-full/src/main/java/module-info.java
+++ b/sdk-full/src/main/java/module-info.java
@@ -33,9 +33,7 @@ module com.hedera.hashgraph.sdk.full {
     requires org.bouncycastle.provider;
     requires org.slf4j;
 
-    requires static com.github.spotbugs.annotations;
-    requires static com.google.errorprone.annotations;
-    requires static java.annotation;
+    requires static transitive java.annotation;
 
     exports com.hedera.hashgraph.sdk;
     exports com.hedera.hashgraph.sdk.logger;

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -37,8 +37,6 @@ testModuleInfo {
     requires("org.mockito")
 
     requiresStatic("java.annotation")
-    requiresStatic("com.github.spotbugs.annotations")
-    requiresStatic("com.google.errorprone.annotations")
 
     runtimeOnly("io.grpc.netty.shaded")
     runtimeOnly("org.slf4j.simple")

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountCreateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountCreateTransaction.java
@@ -26,7 +26,6 @@ import com.hedera.hashgraph.sdk.proto.CryptoServiceGrpc;
 import com.hedera.hashgraph.sdk.proto.SchedulableTransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.MethodDescriptor;
 import java.time.Duration;
 
@@ -194,10 +193,6 @@ public final class AccountCreateTransaction extends Transaction<AccountCreateTra
      * @return                          the duration for auto-renew
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     public Duration getAutoRenewPeriod() {
         return autoRenewPeriod;
     }
@@ -214,10 +209,6 @@ public final class AccountCreateTransaction extends Transaction<AccountCreateTra
      * @param autoRenewPeriod the auto renew period for this account.
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public AccountCreateTransaction setAutoRenewPeriod(Duration autoRenewPeriod) {
         requireNotFrozen();
         Objects.requireNonNull(autoRenewPeriod);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountUpdateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AccountUpdateTransaction.java
@@ -28,7 +28,6 @@ import com.hedera.hashgraph.sdk.proto.CryptoUpdateTransactionBody;
 import com.hedera.hashgraph.sdk.proto.SchedulableTransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.MethodDescriptor;
 import java.time.Duration;
 import java.time.Instant;
@@ -218,10 +217,6 @@ public final class AccountUpdateTransaction extends Transaction<AccountUpdateTra
      * @return                          the expiration time
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "An instant can't actually be mutated"
-    )
     public Instant getExpirationTime() {
         return expirationTime;
     }
@@ -233,10 +228,6 @@ public final class AccountUpdateTransaction extends Transaction<AccountUpdateTra
      * @param expirationTime The Instant to be set as the expiration time
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "An Instant can't actually be mutated"
-    )
     public AccountUpdateTransaction setExpirationTime(Instant expirationTime) {
         Objects.requireNonNull(expirationTime);
         requireNotFrozen();
@@ -250,10 +241,6 @@ public final class AccountUpdateTransaction extends Transaction<AccountUpdateTra
      * @return                          the auto renew period
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     public Duration getAutoRenewPeriod() {
         return autoRenewPeriod;
     }
@@ -267,10 +254,6 @@ public final class AccountUpdateTransaction extends Transaction<AccountUpdateTra
      * @param autoRenewPeriod The Duration to be set for auto renewal
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public AccountUpdateTransaction setAutoRenewPeriod(Duration autoRenewPeriod) {
         Objects.requireNonNull(autoRenewPeriod);
         requireNotFrozen();

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/AddressBookQuery.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/AddressBookQuery.java
@@ -20,7 +20,6 @@
 package com.hedera.hashgraph.sdk;
 
 import com.hedera.hashgraph.sdk.proto.mirror.NetworkServiceGrpc;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.Deadline;
@@ -140,10 +139,6 @@ public class AddressBookQuery {
      * @param maxBackoff the maximum backoff duration
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public AddressBookQuery setMaxBackoff(Duration maxBackoff) {
         Objects.requireNonNull(maxBackoff);
         if (maxBackoff.toMillis() < 500L) {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNetwork.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNetwork.java
@@ -20,7 +20,6 @@
 package com.hedera.hashgraph.sdk;
 
 import com.google.common.annotations.VisibleForTesting;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Duration;
 import java.time.Instant;
 
@@ -111,10 +110,6 @@ abstract class BaseNetwork<
     private LedgerId ledgerId;
 
     @VisibleForTesting
-    @SuppressFBWarnings(
-        value = "URF_UNREAD_FIELD",
-        justification = "this field is used for testing"
-    )
     boolean hasShutDownNow = false;
 
     protected BaseNetwork(ExecutorService executor) {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNode.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNode.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk;
 
-import com.google.errorprone.annotations.Var;
 import io.grpc.ChannelCredentials;
 import io.grpc.ConnectivityState;
 import io.grpc.Grpc;
@@ -307,7 +306,7 @@ abstract class BaseNode<N extends BaseNode<N, KeyT>, KeyT> {
         }
         hasConnected = (getChannel().getState(true) == ConnectivityState.READY);
         try {
-            for (@Var int i = 0; i < GET_STATE_MAX_ATTEMPTS && !hasConnected; i++) {
+            for (int i = 0; i < GET_STATE_MAX_ATTEMPTS && !hasConnected; i++) {
                 Duration currentTimeout = Duration.between(Instant.now(), timeoutTime);
                 if (currentTimeout.isNegative() || currentTimeout.isZero()) {
                     return false;

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ChunkedTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ChunkedTransaction.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk;
 
-import com.google.errorprone.annotations.Var;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.hashgraph.sdk.proto.SignatureMap;
@@ -356,7 +355,6 @@ abstract class ChunkedTransaction<T extends ChunkedTransaction<T>> extends Trans
     public CompletableFuture<List<TransactionResponse>> executeAllAsync(Client client, Duration timeoutPerChunk) {
         freezeAndSign(client);
 
-        @Var
         CompletableFuture<List<com.hedera.hashgraph.sdk.TransactionResponse>> future =
             CompletableFuture.supplyAsync(() -> new ArrayList<>(transactionIds.size()));
 
@@ -464,7 +462,7 @@ abstract class ChunkedTransaction<T extends ChunkedTransaction<T>> extends Trans
 
     @Override
     int getRequiredChunks() {
-        @Var var requiredChunks = (this.data.size() + (chunkSize - 1)) / chunkSize;
+        var requiredChunks = (this.data.size() + (chunkSize - 1)) / chunkSize;
 
         if (requiredChunks == 0) {
             requiredChunks = 1;
@@ -487,7 +485,7 @@ abstract class ChunkedTransaction<T extends ChunkedTransaction<T>> extends Trans
         for (int i = 0; i < requiredChunks; i++) {
             if (!transactionIds.isEmpty()) {
                 var startIndex = i * chunkSize;
-                @Var var endIndex = startIndex + chunkSize;
+                var endIndex = startIndex + chunkSize;
 
                 if (endIndex > this.data.size()) {
                     endIndex = this.data.size();

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -26,7 +26,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.hedera.hashgraph.sdk.logger.LogLevel;
 import com.hedera.hashgraph.sdk.logger.Logger;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
@@ -907,10 +906,6 @@ public final class Client implements AutoCloseable {
      *
      * @return maxBackoff
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     public Duration getMaxBackoff() {
         return maxBackoff;
     }
@@ -922,10 +917,6 @@ public final class Client implements AutoCloseable {
      * @param maxBackoff The maximum amount of time to wait between retries
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public Client setMaxBackoff(Duration maxBackoff) {
         if (maxBackoff == null || maxBackoff.toNanos() < 0) {
             throw new IllegalArgumentException("maxBackoff must be a positive duration");
@@ -941,10 +932,6 @@ public final class Client implements AutoCloseable {
      *
      * @return minBackoff
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     public Duration getMinBackoff() {
         return minBackoff;
     }
@@ -956,10 +943,6 @@ public final class Client implements AutoCloseable {
      * @param minBackoff The minimum amount of time to wait between retries
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public Client setMinBackoff(Duration minBackoff) {
         if (minBackoff == null || minBackoff.toNanos() < 0) {
             throw new IllegalArgumentException("minBackoff must be a positive duration");
@@ -1270,10 +1253,6 @@ public final class Client implements AutoCloseable {
      *
      * @return the timeout value
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     public synchronized Duration getRequestTimeout() {
         return requestTimeout;
     }
@@ -1284,10 +1263,6 @@ public final class Client implements AutoCloseable {
      * @param requestTimeout the timeout value
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public synchronized Client setRequestTimeout(Duration requestTimeout) {
         this.requestTimeout = Objects.requireNonNull(requestTimeout);
         return this;
@@ -1298,10 +1273,6 @@ public final class Client implements AutoCloseable {
      *
      * @return the timeout value
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     public Duration getCloseTimeout() {
         return closeTimeout;
     }
@@ -1312,10 +1283,6 @@ public final class Client implements AutoCloseable {
      * @param closeTimeout the timeout value
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public Client setCloseTimeout(Duration closeTimeout) {
         this.closeTimeout = Objects.requireNonNull(closeTimeout);
         network.setCloseTimeout(closeTimeout);
@@ -1328,10 +1295,6 @@ public final class Client implements AutoCloseable {
      *
      * @return the gRPC deadline value
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     public Duration getGrpcDeadline() {
         return grpcDeadline.get();
     }
@@ -1342,10 +1305,6 @@ public final class Client implements AutoCloseable {
      * @param grpcDeadline the gRPC deadline value
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public Client setGrpcDeadline(Duration grpcDeadline) {
         this.grpcDeadline.set(Objects.requireNonNull(grpcDeadline));
         return this;
@@ -1366,10 +1325,6 @@ public final class Client implements AutoCloseable {
      *
      * @return the networkUpdatePeriod
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     @Nullable
     public synchronized Duration getNetworkUpdatePeriod() {
         return this.networkUpdatePeriod;
@@ -1384,10 +1339,6 @@ public final class Client implements AutoCloseable {
      * @param networkUpdatePeriod the period for updating the Address Book
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public synchronized Client setNetworkUpdatePeriod(Duration networkUpdatePeriod) {
         cancelScheduledNetworkUpdate();
         this.networkUpdatePeriod = networkUpdatePeriod;

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractCreateFlow.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractCreateFlow.java
@@ -20,7 +20,6 @@
 package com.hedera.hashgraph.sdk;
 
 import com.google.protobuf.ByteString;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -321,10 +320,6 @@ public class ContractCreateFlow {
      * @return the auto renew period
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     public Duration getAutoRenewPeriod() {
         return autoRenewPeriod;
     }
@@ -335,10 +330,6 @@ public class ContractCreateFlow {
      * @param autoRenewPeriod The Duration to be set for auto renewal
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public ContractCreateFlow setAutoRenewPeriod(Duration autoRenewPeriod) {
         Objects.requireNonNull(autoRenewPeriod);
         this.autoRenewPeriod = autoRenewPeriod;

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractCreateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractCreateTransaction.java
@@ -26,7 +26,6 @@ import com.hedera.hashgraph.sdk.proto.SchedulableTransactionBody;
 import com.hedera.hashgraph.sdk.proto.SmartContractServiceGrpc;
 import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.MethodDescriptor;
 import org.bouncycastle.util.Arrays;
 import java.time.Duration;
@@ -336,10 +335,6 @@ public final class ContractCreateTransaction extends Transaction<ContractCreateT
      * @return                          the auto renew period
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     public Duration getAutoRenewPeriod() {
         return autoRenewPeriod;
     }
@@ -350,10 +345,6 @@ public final class ContractCreateTransaction extends Transaction<ContractCreateT
      * @param autoRenewPeriod The Duration to be set for auto renewal
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public ContractCreateTransaction setAutoRenewPeriod(Duration autoRenewPeriod) {
         Objects.requireNonNull(autoRenewPeriod);
         requireNotFrozen();

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractFunctionParameters.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractFunctionParameters.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk;
 
-import com.google.errorprone.annotations.Var;
 import com.google.protobuf.ByteString;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -114,7 +113,7 @@ public final class ContractFunctionParameters {
         head.add(uint256(elements.size(), 32));
 
         // points to start of dynamic segment, *not* including the length of the array
-        @Var long currOffset = offsetsLen * 32L;
+        long currOffset = offsetsLen * 32L;
 
         for (ByteString elem : elements) {
             head.add(uint256(currOffset, 64));
@@ -128,7 +127,7 @@ public final class ContractFunctionParameters {
         return int256(val, bitWidth, true);
     }
 
-    static ByteString int256(long val, @Var int bitWidth, boolean signed) {
+    static ByteString int256(long val, int bitWidth, boolean signed) {
         // don't try to get wider than a `long` as it should just be filled with padding
         bitWidth = Math.min(bitWidth, 64);
         ByteString.Output output = ByteString.newOutput(bitWidth / 8);
@@ -199,7 +198,7 @@ public final class ContractFunctionParameters {
         return rem == 32 ? input : input.concat(padding.substring(0, rem));
     }
 
-    private static byte[] decodeAddress(@Var String address) {
+    private static byte[] decodeAddress(String address) {
         address = address.startsWith("0x") ? address.substring(2) : address;
 
         if (address.length() != ADDRESS_LEN_HEX) {
@@ -738,7 +737,7 @@ public final class ContractFunctionParameters {
     public ContractFunctionParameters addInt8Array(byte[] intArray) {
         IntStream intStream = IntStream.range(0, intArray.length).map(idx -> intArray[idx]);
 
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             intStream.mapToObj(i -> int256(i, 8))
                 .collect(Collectors.toList()));
 
@@ -756,7 +755,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt16Array(int[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).mapToObj(i -> int256(i, 16))
                 .collect(Collectors.toList()));
 
@@ -774,7 +773,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt24Array(int[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).mapToObj(i -> int256(i, 24))
                 .collect(Collectors.toList()));
 
@@ -792,7 +791,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt32Array(int[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).mapToObj(i -> int256(i, 32))
                 .collect(Collectors.toList()));
 
@@ -810,7 +809,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt40Array(long[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).mapToObj(i -> int256(i, 40))
                 .collect(Collectors.toList()));
 
@@ -828,7 +827,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt48Array(long[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).mapToObj(i -> int256(i, 48))
                 .collect(Collectors.toList()));
 
@@ -846,7 +845,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt56Array(long[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).mapToObj(i -> int256(i, 56))
                 .collect(Collectors.toList()));
 
@@ -864,7 +863,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt64Array(long[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).mapToObj(i -> int256(i, 64))
                 .collect(Collectors.toList()));
 
@@ -882,7 +881,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt72Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 72))
                 .collect(Collectors.toList()));
 
@@ -900,7 +899,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt80Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 80))
                 .collect(Collectors.toList()));
 
@@ -918,7 +917,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt88Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 88))
                 .collect(Collectors.toList()));
 
@@ -936,7 +935,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt96Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 96))
                 .collect(Collectors.toList()));
 
@@ -954,7 +953,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt104Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 104))
                 .collect(Collectors.toList()));
 
@@ -972,7 +971,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt112Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 112))
                 .collect(Collectors.toList()));
 
@@ -990,7 +989,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt120Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 120))
                 .collect(Collectors.toList()));
 
@@ -1008,7 +1007,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt128Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 128))
                 .collect(Collectors.toList()));
 
@@ -1026,7 +1025,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt136Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 136))
                 .collect(Collectors.toList()));
 
@@ -1044,7 +1043,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt144Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 144))
                 .collect(Collectors.toList()));
 
@@ -1062,7 +1061,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt152Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 152))
                 .collect(Collectors.toList()));
 
@@ -1080,7 +1079,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt160Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 160))
                 .collect(Collectors.toList()));
 
@@ -1098,7 +1097,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt168Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 168))
                 .collect(Collectors.toList()));
 
@@ -1116,7 +1115,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt176Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 176))
                 .collect(Collectors.toList()));
 
@@ -1134,7 +1133,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt184Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 184))
                 .collect(Collectors.toList()));
 
@@ -1152,7 +1151,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt192Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 192))
                 .collect(Collectors.toList()));
 
@@ -1170,7 +1169,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt200Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 200))
                 .collect(Collectors.toList()));
 
@@ -1188,7 +1187,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt208Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 208))
                 .collect(Collectors.toList()));
 
@@ -1206,7 +1205,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt216Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 216))
                 .collect(Collectors.toList()));
 
@@ -1224,7 +1223,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt224Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 224))
                 .collect(Collectors.toList()));
 
@@ -1242,7 +1241,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt232Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 232))
                 .collect(Collectors.toList()));
 
@@ -1260,7 +1259,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt240Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 240))
                 .collect(Collectors.toList()));
 
@@ -1278,7 +1277,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt248Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 248))
                 .collect(Collectors.toList()));
 
@@ -1296,7 +1295,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addInt256Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> int256(i, 256))
                 .collect(Collectors.toList()));
 
@@ -1821,7 +1820,7 @@ public final class ContractFunctionParameters {
     public ContractFunctionParameters addUint8Array(byte[] intArray) {
         IntStream intStream = IntStream.range(0, intArray.length).map(idx -> intArray[idx]);
 
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             intStream.mapToObj(i -> uint256(i, 8))
                 .collect(Collectors.toList()));
 
@@ -1842,7 +1841,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addUint16Array(int[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).mapToObj(i -> uint256(i, 16))
                 .collect(Collectors.toList()));
 
@@ -1863,7 +1862,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addUint24Array(int[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).mapToObj(i -> uint256(i, 24))
                 .collect(Collectors.toList()));
 
@@ -1884,7 +1883,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addUint32Array(int[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).mapToObj(i -> uint256(i, 32))
                 .collect(Collectors.toList()));
 
@@ -1905,7 +1904,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addUint40Array(long[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).mapToObj(i -> uint256(i, 40))
                 .collect(Collectors.toList()));
 
@@ -1926,7 +1925,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addUint48Array(long[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).mapToObj(i -> uint256(i, 48))
                 .collect(Collectors.toList()));
 
@@ -1947,7 +1946,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addUint56Array(long[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).mapToObj(i -> uint256(i, 56))
                 .collect(Collectors.toList()));
 
@@ -1968,7 +1967,7 @@ public final class ContractFunctionParameters {
      * @return {@code this}
      */
     public ContractFunctionParameters addUint64Array(long[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).mapToObj(i -> uint256(i, 64))
                 .collect(Collectors.toList()));
 
@@ -1990,7 +1989,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint72Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 72))
                 .collect(Collectors.toList()));
 
@@ -2012,7 +2011,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint80Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 80))
                 .collect(Collectors.toList()));
 
@@ -2034,7 +2033,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint88Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 88))
                 .collect(Collectors.toList()));
 
@@ -2056,7 +2055,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint96Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 96))
                 .collect(Collectors.toList()));
 
@@ -2078,7 +2077,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint104Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 104))
                 .collect(Collectors.toList()));
 
@@ -2100,7 +2099,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint112Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 112))
                 .collect(Collectors.toList()));
 
@@ -2122,7 +2121,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint120Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 120))
                 .collect(Collectors.toList()));
 
@@ -2144,7 +2143,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint128Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 128))
                 .collect(Collectors.toList()));
 
@@ -2166,7 +2165,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint136Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 136))
                 .collect(Collectors.toList()));
 
@@ -2188,7 +2187,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint144Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 144))
                 .collect(Collectors.toList()));
 
@@ -2210,7 +2209,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint152Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 152))
                 .collect(Collectors.toList()));
 
@@ -2232,7 +2231,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint160Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 160))
                 .collect(Collectors.toList()));
 
@@ -2254,7 +2253,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint168Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 168))
                 .collect(Collectors.toList()));
 
@@ -2276,7 +2275,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint176Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 176))
                 .collect(Collectors.toList()));
 
@@ -2298,7 +2297,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint184Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 184))
                 .collect(Collectors.toList()));
 
@@ -2320,7 +2319,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint192Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 192))
                 .collect(Collectors.toList()));
 
@@ -2342,7 +2341,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint200Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 200))
                 .collect(Collectors.toList()));
 
@@ -2364,7 +2363,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint208Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 208))
                 .collect(Collectors.toList()));
 
@@ -2386,7 +2385,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint216Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 216))
                 .collect(Collectors.toList()));
 
@@ -2408,7 +2407,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint224Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 224))
                 .collect(Collectors.toList()));
 
@@ -2430,7 +2429,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint232Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 232))
                 .collect(Collectors.toList()));
 
@@ -2452,7 +2451,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint240Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 240))
                 .collect(Collectors.toList()));
 
@@ -2474,7 +2473,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint248Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 248))
                 .collect(Collectors.toList()));
 
@@ -2496,7 +2495,7 @@ public final class ContractFunctionParameters {
      * @throws IllegalArgumentException if {@code bigInt.signum() < 0}.
      */
     public ContractFunctionParameters addUint256Array(BigInteger[] intArray) {
-        @Var ByteString arrayBytes = ByteString.copyFrom(
+        ByteString arrayBytes = ByteString.copyFrom(
             Arrays.stream(intArray).map(i -> uint256(i, 256))
                 .collect(Collectors.toList()));
 
@@ -2607,7 +2606,7 @@ public final class ContractFunctionParameters {
      */
     ByteString toBytes(@Nullable String funcName) {
         // offset for dynamic-length data, immediately after value arguments
-        @Var var dynamicOffset = args.size() * 32;
+        var dynamicOffset = args.size() * 32;
 
         var paramsBytes = new ArrayList<ByteString>(args.size() + 1);
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractUpdateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ContractUpdateTransaction.java
@@ -28,7 +28,6 @@ import com.hedera.hashgraph.sdk.proto.SchedulableTransactionBody;
 import com.hedera.hashgraph.sdk.proto.SmartContractServiceGrpc;
 import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.MethodDescriptor;
 import java.time.Duration;
 import java.time.Instant;
@@ -145,10 +144,6 @@ public final class ContractUpdateTransaction extends Transaction<ContractUpdateT
      * @return                          the contract expiration time
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "An instant can't actually be mutated"
-    )
     public Instant getExpirationTime() {
         return expirationTime;
     }
@@ -160,10 +155,6 @@ public final class ContractUpdateTransaction extends Transaction<ContractUpdateT
      * @param expirationTime The Instant to be set for expiration time
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "An Instant can't actually be mutated"
-    )
     public ContractUpdateTransaction setExpirationTime(Instant expirationTime) {
         Objects.requireNonNull(expirationTime);
         requireNotFrozen();
@@ -241,7 +232,6 @@ public final class ContractUpdateTransaction extends Transaction<ContractUpdateT
      * @param maxAutomaticTokenAssociations The maximum automatic token associations
      * @return  {@code this}
      */
-
     public ContractUpdateTransaction setMaxAutomaticTokenAssociations(int maxAutomaticTokenAssociations) {
         requireNotFrozen();
         this.maxAutomaticTokenAssociations = maxAutomaticTokenAssociations;
@@ -254,10 +244,6 @@ public final class ContractUpdateTransaction extends Transaction<ContractUpdateT
      * @return                          the duration for auto-renew
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     public Duration getAutoRenewPeriod() {
         return autoRenewPeriod;
     }
@@ -268,10 +254,6 @@ public final class ContractUpdateTransaction extends Transaction<ContractUpdateT
      * @param autoRenewPeriod The Duration to be set for auto renewal
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public ContractUpdateTransaction setAutoRenewPeriod(Duration autoRenewPeriod) {
         Objects.requireNonNull(autoRenewPeriod);
         requireNotFrozen();

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Endpoint.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Endpoint.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk;
 
-import com.google.errorprone.annotations.Var;
 import com.google.protobuf.ByteString;
 import com.hedera.hashgraph.sdk.proto.ServiceEndpoint;
 
@@ -52,7 +51,7 @@ public class Endpoint implements Cloneable {
      * @return                          the endpoint object
      */
     static Endpoint fromProtobuf(ServiceEndpoint serviceEndpoint) {
-        @Var var port = (int) (serviceEndpoint.getPort() & 0x00000000ffffffffL);
+        var port = (int) (serviceEndpoint.getPort() & 0x00000000ffffffffL);
 
         if (port == 0 || port == 50111) {
             port = 50211;

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/EntityIdHelper.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/EntityIdHelper.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk;
 
-import com.google.errorprone.annotations.Var;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.io.IOException;
@@ -113,7 +112,7 @@ class EntityIdHelper {
      * @param address the string representation
      * @return the decoded address
      */
-    public static byte[] decodeSolidityAddress(@Var String address) {
+    public static byte[] decodeSolidityAddress(String address) {
         address = address.startsWith("0x") ? address.substring(2) : address;
 
         if (address.length() != SOLIDITY_ADDRESS_LEN_HEX) {
@@ -159,16 +158,11 @@ class EntityIdHelper {
     static String checksum(LedgerId ledgerId, String addr) {
         StringBuilder answer = new StringBuilder();
         List<Integer> d = new ArrayList<>(); // Digits with 10 for ".", so if addr == "0.0.123" then d == [0, 10, 0, 10, 1, 2, 3]
-        @Var
         long s0 = 0; // Sum of even positions (mod 11)
-        @Var
         long s1 = 0; // Sum of odd positions (mod 11)
-        @Var
         long s = 0; // Weighted sum of all positions (mod p3)
-        @Var
         long sh = 0; // Hash of the ledger ID
         @SuppressWarnings("UnusedVariable")
-        @Var
         long c = 0; // The checksum, as a single number
         long p3 = 26 * 26 * 26; // 3 digits in base 26
         long p5 = 26 * 26 * 26 * 26 * 26; // 5 digits in base 26

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/FeeSchedule.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/FeeSchedule.java
@@ -21,7 +21,6 @@ package com.hedera.hashgraph.sdk;
 
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.InvalidProtocolBufferException;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Instant;
 
 import javax.annotation.Nullable;
@@ -118,10 +117,6 @@ public class FeeSchedule implements Cloneable {
      * @return                          the expiration time
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "An Instant can't actually be mutated"
-    )
     public Instant getExpirationTime() {
         return expirationTime;
     }
@@ -132,10 +127,6 @@ public class FeeSchedule implements Cloneable {
      * @param expirationTime            the expiration time
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "An Instant can't actually be mutated"
-    )
     public FeeSchedule setExpirationTime(@Nullable Instant expirationTime) {
         this.expirationTime = expirationTime;
         return this;

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/FileCreateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/FileCreateTransaction.java
@@ -26,7 +26,6 @@ import com.hedera.hashgraph.sdk.proto.FileServiceGrpc;
 import com.hedera.hashgraph.sdk.proto.SchedulableTransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.MethodDescriptor;
 import java.time.Instant;
 
@@ -88,10 +87,6 @@ public final class FileCreateTransaction extends Transaction<FileCreateTransacti
      * @return                          expiration time
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "An Instant can't actually be mutated"
-    )
     public Instant getExpirationTime() {
         return expirationTime;
     }
@@ -108,10 +103,6 @@ public final class FileCreateTransaction extends Transaction<FileCreateTransacti
      * @param expirationTime the {@link Instant} at which this file should expire.
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "An Instant can't actually be mutated"
-    )
     public FileCreateTransaction setExpirationTime(Instant expirationTime) {
         requireNotFrozen();
         Objects.requireNonNull(expirationTime);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/FileUpdateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/FileUpdateTransaction.java
@@ -27,7 +27,6 @@ import com.hedera.hashgraph.sdk.proto.FileUpdateTransactionBody;
 import com.hedera.hashgraph.sdk.proto.SchedulableTransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.MethodDescriptor;
 import java.time.Instant;
 
@@ -137,10 +136,6 @@ public final class FileUpdateTransaction extends Transaction<FileUpdateTransacti
      * @return                          the expiration time
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "An Instant can't actually be mutated"
-    )
     public Instant getExpirationTime() {
         return expirationTime;
     }
@@ -154,10 +149,6 @@ public final class FileUpdateTransaction extends Transaction<FileUpdateTransacti
      * @param expirationTime the new {@link Instant} at which the transaction will expire.
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "An Instant can't actually be mutated"
-    )
     public FileUpdateTransaction setExpirationTime(Instant expirationTime) {
         Objects.requireNonNull(expirationTime);
         requireNotFrozen();

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/FreezeTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/FreezeTransaction.java
@@ -26,7 +26,6 @@ import com.hedera.hashgraph.sdk.proto.FreezeTransactionBody;
 import com.hedera.hashgraph.sdk.proto.SchedulableTransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.MethodDescriptor;
 import java.time.Instant;
 import java.time.OffsetTime;
@@ -94,10 +93,6 @@ public final class FreezeTransaction extends Transaction<FreezeTransaction> {
      * @param startTime                 the start time
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "An Instant can't actually be mutated"
-    )
     public FreezeTransaction setStartTime(Instant startTime) {
         requireNotFrozen();
         Objects.requireNonNull(startTime);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/HederaTrustManager.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/HederaTrustManager.java
@@ -20,7 +20,6 @@
 package com.hedera.hashgraph.sdk;
 
 import com.google.protobuf.ByteString;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.bouncycastle.util.encoders.Hex;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemWriter;
@@ -75,10 +74,6 @@ class HederaTrustManager implements X509TrustManager {
     }
 
     @Override
-    @SuppressFBWarnings(
-        value = "DLS_DEAD_LOCAL_STORE",
-        justification = "SpotBugs seems to be getting confused by the control flow here.  It thinks certHashBytes is not used."
-    )
     public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
         if (certHash == null) {
             return;

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Keystore.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Keystore.java
@@ -25,7 +25,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.stream.JsonWriter;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Optional;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.util.encoders.Hex;
@@ -169,10 +168,6 @@ final class Keystore {
         return new Keystore(Crypto.decryptAesCtr128(cipherKey, iv, cipherBytes));
     }
 
-    @SuppressFBWarnings(
-        value = "DCN_NULLPOINTER_EXCEPTION",
-        justification = "This control flow seems reasonable to me"
-    )
     private static JsonObject expectObject(JsonObject object, String key) {
         try {
             return object.get(key).getAsJsonObject();
@@ -181,10 +176,6 @@ final class Keystore {
         }
     }
 
-    @SuppressFBWarnings(
-        value = "DCN_NULLPOINTER_EXCEPTION",
-        justification = "This control flow seems reasonable to me"
-    )
     private static int expectInt(JsonObject object, String key) {
         try {
             return object.get(key).getAsInt();
@@ -193,10 +184,6 @@ final class Keystore {
         }
     }
 
-    @SuppressFBWarnings(
-        value = "DCN_NULLPOINTER_EXCEPTION",
-        justification = "This control flow seems reasonable to me"
-    )
     private static String expectString(JsonObject object, String key) {
         try {
             return object.get(key).getAsString();

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/LiveHashAddTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/LiveHashAddTransaction.java
@@ -27,7 +27,6 @@ import com.hedera.hashgraph.sdk.proto.LiveHash;
 import com.hedera.hashgraph.sdk.proto.SchedulableTransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.MethodDescriptor;
 import java.time.Duration;
 
@@ -156,10 +155,6 @@ public final class LiveHashAddTransaction extends Transaction<LiveHashAddTransac
      * @return                          the duration
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     public Duration getDuration() {
         return duration;
     }
@@ -170,10 +165,6 @@ public final class LiveHashAddTransaction extends Transaction<LiveHashAddTransac
      * @param duration The Duration to be set
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public LiveHashAddTransaction setDuration(Duration duration) {
         requireNotFrozen();
         Objects.requireNonNull(duration);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Mnemonic.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Mnemonic.java
@@ -20,7 +20,6 @@
 package com.hedera.hashgraph.sdk;
 
 import com.google.common.base.Joiner;
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.utils.Bip32Utils;
 import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.crypto.digests.SHA512Digest;
@@ -153,8 +152,8 @@ public final class Mnemonic {
 
             words = new ArrayList<>(24);
         }
-        @Var var scratch = 0;
-        @Var var offset = 0;
+        var scratch = 0;
+        var offset = 0;
 
         for (var b : bytes) {
             // shift `bytes` into `scratch`, popping off 11-bit indices when we can
@@ -194,7 +193,6 @@ public final class Mnemonic {
 
     private static int getWordIndex(CharSequence word, boolean isLegacy) {
         var wordList = getWordList(isLegacy);
-        @Var
         var found = -1;
         for (var i = 0; i < wordList.size(); i++) {
             if (word.toString().equals(wordList.get(i))) {
@@ -265,14 +263,14 @@ public final class Mnemonic {
     }
 
     private static int[] convertRadix(int[] nums, int fromRadix, int toRadix, int toLength) {
-        @Var BigInteger num = BigInteger.valueOf(0);
+        BigInteger num = BigInteger.valueOf(0);
         for (int element : nums) {
             num = num.multiply(BigInteger.valueOf(fromRadix));
             num = num.add(BigInteger.valueOf(element));
         }
 
         var result = new int[toLength];
-        for (@Var var i = toLength - 1; i >= 0; i -= 1) {
+        for (var i = toLength - 1; i >= 0; i -= 1) {
             BigInteger tem = num.divide(BigInteger.valueOf(toRadix));
             BigInteger rem = num.mod(BigInteger.valueOf(toRadix));
             num = tem;
@@ -283,7 +281,7 @@ public final class Mnemonic {
     }
 
     private static int crc8(int[] data) {
-        @Var var crc = 0xFF;
+        var crc = 0xFF;
 
         for (var i = 0; i < data.length - 1; i += 1) {
             crc ^= data[i];
@@ -434,8 +432,8 @@ public final class Mnemonic {
             buffer = ByteBuffer.allocate(33);
         }
         // reverse algorithm of `entropyToWords()` below
-        @Var int scratch = 0;
-        @Var int offset = 0;
+        int scratch = 0;
+        int offset = 0;
         for (CharSequence word : words) {
             int index = getWordIndex(word, false);
 
@@ -486,8 +484,8 @@ public final class Mnemonic {
         }
 
         byte[] array = byteBuffer.array();
-        @Var var i = 0;
-        @Var var j = 3;
+        var i = 0;
+        var j = 3;
         byte[] array2 = new byte[data.length - 1];
         //remove all the fill 0s
         while (j < array.length) {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Network.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Network.java
@@ -20,7 +20,6 @@
 package com.hedera.hashgraph.sdk;
 
 import com.google.common.io.ByteStreams;
-import com.google.errorprone.annotations.Var;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -316,7 +315,7 @@ class Network extends BaseNetwork<Network, AccountId, Node> {
             network.clear();
 
             for (int i = 0; i < nodes.size(); i++) {
-                @Var var node = nodes.get(i);
+                var node = nodes.get(i);
                 node.close(closeTimeout);
 
                 node = transportSecurity ? node.toSecure() : node.toInsecure();

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/NodeAddress.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/NodeAddress.java
@@ -22,7 +22,6 @@ package com.hedera.hashgraph.sdk;
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.ByteString;
 import com.hedera.hashgraph.sdk.proto.ServiceEndpoint;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
@@ -180,10 +179,6 @@ public class NodeAddress implements Cloneable {
      * @return                          the certificate hash
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A ByteString can't actually be mutated"
-    )
     public ByteString getCertHash() {
         return certHash;
     }
@@ -195,10 +190,6 @@ public class NodeAddress implements Cloneable {
      * @return {@code this}
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A ByteString can't actually be mutated"
-    )
     public NodeAddress setCertHash(ByteString certHash) {
         this.certHash = certHash;
         return this;

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/PrivateKey.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/PrivateKey.java
@@ -19,8 +19,6 @@
  */
 package com.hedera.hashgraph.sdk;
 
-import com.google.errorprone.annotations.Var;
-import com.hedera.hashgraph.sdk.proto.SignedTransaction;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.sec.ECPrivateKey;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
@@ -112,7 +110,7 @@ public abstract class PrivateKey extends Key {
     @Deprecated
     public static PrivateKey fromMnemonic(Mnemonic mnemonic, String passphrase) {
         var seed = mnemonic.toSeed(passphrase);
-        @Var PrivateKey derivedKey = fromSeedED25519(seed);
+        PrivateKey derivedKey = fromSeedED25519(seed);
 
         // BIP-44 path with the Hedera Hbar coin-type (omitting key index)
         // we pre-derive most of the path as the mobile wallets don't expose more than the index
@@ -393,7 +391,7 @@ public abstract class PrivateKey extends Key {
             transaction.freeze();
         }
 
-        var builder = (SignedTransaction.Builder) transaction.innerSignedTransactions.get(0);
+        var builder = transaction.innerSignedTransactions.get(0);
         var signature = sign(builder.getBodyBytes().toByteArray());
 
         transaction.addSignature(getPublicKey(), signature);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/PublicKey.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/PublicKey.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk;
 
-import com.google.errorprone.annotations.Var;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.hashgraph.sdk.proto.SignaturePair;
@@ -197,7 +196,7 @@ public abstract class PublicKey extends Key {
         }
 
         for (var signedTransaction : transaction.innerSignedTransactions) {
-            @Var var found = false;
+            var found = false;
 
             for (var sigPair : signedTransaction.getSigMap().getSigPairList()) {
                 if (sigPair.getPubKeyPrefix().equals(ByteString.copyFrom(toBytesRaw()))) {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/ScheduleCreateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/ScheduleCreateTransaction.java
@@ -25,7 +25,6 @@ import com.hedera.hashgraph.sdk.proto.ScheduleCreateTransactionBody;
 import com.hedera.hashgraph.sdk.proto.ScheduleServiceGrpc;
 import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.MethodDescriptor;
 import java.time.Instant;
 
@@ -77,10 +76,6 @@ public final class ScheduleCreateTransaction extends Transaction<ScheduleCreateT
      * @return The expiration time
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "An Instant can't actually be mutated"
-    )
     public Instant getExpirationTime() {
         return expirationTime;
     }
@@ -95,10 +90,6 @@ public final class ScheduleCreateTransaction extends Transaction<ScheduleCreateT
      * @param expirationTime The expiration time
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "An Instant can't actually be mutated"
-    )
     public ScheduleCreateTransaction setExpirationTime(Instant expirationTime) {
         this.expirationTime = expirationTime;
         return this;

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/SystemDeleteTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/SystemDeleteTransaction.java
@@ -26,7 +26,6 @@ import com.hedera.hashgraph.sdk.proto.SmartContractServiceGrpc;
 import com.hedera.hashgraph.sdk.proto.SystemDeleteTransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.MethodDescriptor;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -137,10 +136,6 @@ public final class SystemDeleteTransaction extends Transaction<SystemDeleteTrans
      * @return                          the expiration time
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "An Instant can't actually be mutated"
-    )
     public Instant getExpirationTime() {
         return expirationTime;
     }
@@ -152,10 +147,6 @@ public final class SystemDeleteTransaction extends Transaction<SystemDeleteTrans
      * @param expirationTime The Instant to be set as expiration time
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "An Instant can't actually be mutated"
-    )
     public SystemDeleteTransaction setExpirationTime(Instant expirationTime) {
         Objects.requireNonNull(expirationTime);
         requireNotFrozen();

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenCreateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenCreateTransaction.java
@@ -26,7 +26,6 @@ import com.hedera.hashgraph.sdk.proto.TokenCreateTransactionBody;
 import com.hedera.hashgraph.sdk.proto.TokenServiceGrpc;
 import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.MethodDescriptor;
 import java.time.Duration;
 import java.time.Instant;
@@ -547,10 +546,6 @@ public class TokenCreateTransaction extends Transaction<TokenCreateTransaction> 
      * @return                          the expiration time
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "An Instant can't actually be mutated"
-    )
     public Instant getExpirationTime() {
         return expirationTime;
     }
@@ -561,10 +556,6 @@ public class TokenCreateTransaction extends Transaction<TokenCreateTransaction> 
      * @param expirationTime            the expiration time
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "An Instant can't actually be mutated"
-    )
     public TokenCreateTransaction setExpirationTime(Instant expirationTime) {
         Objects.requireNonNull(expirationTime);
         requireNotFrozen();
@@ -602,10 +593,6 @@ public class TokenCreateTransaction extends Transaction<TokenCreateTransaction> 
      * @return                          the auto renew period
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     public Duration getAutoRenewPeriod() {
         return autoRenewPeriod;
     }
@@ -616,10 +603,6 @@ public class TokenCreateTransaction extends Transaction<TokenCreateTransaction> 
      * @param period                    the auto renew period
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public TokenCreateTransaction setAutoRenewPeriod(Duration period) {
         Objects.requireNonNull(period);
         requireNotFrozen();

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenUpdateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TokenUpdateTransaction.java
@@ -28,7 +28,6 @@ import com.hedera.hashgraph.sdk.proto.TokenServiceGrpc;
 import com.hedera.hashgraph.sdk.proto.TokenUpdateTransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.MethodDescriptor;
 import java.time.Duration;
 import java.time.Instant;
@@ -474,10 +473,6 @@ public class TokenUpdateTransaction extends Transaction<TokenUpdateTransaction> 
      * @return                          the expiration time
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "An Instant can't actually be mutated"
-    )
     public Instant getExpirationTime() {
         return expirationTime;
     }
@@ -488,10 +483,6 @@ public class TokenUpdateTransaction extends Transaction<TokenUpdateTransaction> 
      * @param expirationTime            the expiration time
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "An Instant can't actually be mutated"
-    )
     public TokenUpdateTransaction setExpirationTime(Instant expirationTime) {
         Objects.requireNonNull(expirationTime);
         requireNotFrozen();
@@ -529,10 +520,6 @@ public class TokenUpdateTransaction extends Transaction<TokenUpdateTransaction> 
      * @return                          the auto renew period
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     public Duration getAutoRenewPeriod() {
         return autoRenewPeriod;
     }
@@ -543,10 +530,6 @@ public class TokenUpdateTransaction extends Transaction<TokenUpdateTransaction> 
      * @param period                    the auto renew period
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public TokenUpdateTransaction setAutoRenewPeriod(Duration period) {
         Objects.requireNonNull(period);
         requireNotFrozen();

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicCreateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicCreateTransaction.java
@@ -25,7 +25,6 @@ import com.hedera.hashgraph.sdk.proto.ConsensusServiceGrpc;
 import com.hedera.hashgraph.sdk.proto.SchedulableTransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.MethodDescriptor;
 import java.time.Duration;
 
@@ -206,10 +205,6 @@ public final class TopicCreateTransaction extends Transaction<TopicCreateTransac
      * @return                          the auto renew period
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     public Duration getAutoRenewPeriod() {
         return autoRenewPeriod;
     }
@@ -224,10 +219,6 @@ public final class TopicCreateTransaction extends Transaction<TopicCreateTransac
      * @param autoRenewPeriod The Duration to be set for auto renewal
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public TopicCreateTransaction setAutoRenewPeriod(Duration autoRenewPeriod) {
         Objects.requireNonNull(autoRenewPeriod);
         requireNotFrozen();

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessage.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessage.java
@@ -20,7 +20,6 @@
 package com.hedera.hashgraph.sdk;
 
 import com.google.common.base.MoreObjects;
-import com.google.errorprone.annotations.Var;
 import com.google.protobuf.ByteString;
 import com.hedera.hashgraph.sdk.proto.mirror.ConsensusTopicResponse;
 import java.time.Instant;
@@ -116,9 +115,9 @@ public final class TopicMessage {
     static TopicMessage ofMany(List<ConsensusTopicResponse> responses) {
         // response should be in the order of oldest to newest (not chunk order)
         var chunks = new TopicMessageChunk[responses.size()];
-        @Var TransactionId transactionId = null;
+        TransactionId transactionId = null;
         var contents = new ByteString[responses.size()];
-        @Var long totalSize = 0;
+        long totalSize = 0;
 
         for (ConsensusTopicResponse r : responses) {
             if (transactionId == null && r.getChunkInfo().hasInitialTransactionID()) {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicMessageQuery.java
@@ -19,13 +19,11 @@
  */
 package com.hedera.hashgraph.sdk;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.proto.Timestamp;
 import com.hedera.hashgraph.sdk.proto.TransactionID;
 import com.hedera.hashgraph.sdk.proto.mirror.ConsensusServiceGrpc;
 import com.hedera.hashgraph.sdk.proto.mirror.ConsensusTopicQuery;
 import com.hedera.hashgraph.sdk.proto.mirror.ConsensusTopicResponse;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.Status;
@@ -158,10 +156,6 @@ public final class TopicMessageQuery {
      * @param maxBackoff the maximum backoff
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public TopicMessageQuery setMaxBackoff(Duration maxBackoff) {
         if (maxBackoff == null || maxBackoff.toMillis() < 500L) {
             throw new IllegalArgumentException("maxBackoff must be at least 500 ms");
@@ -275,7 +269,6 @@ public final class TopicMessageQuery {
 
         client.trackSubscription(subscriptionHandle);
 
-        @Var
         var newBuilder = builder;
 
         // Update the start time and limit on retry

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicUpdateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TopicUpdateTransaction.java
@@ -26,7 +26,6 @@ import com.hedera.hashgraph.sdk.proto.ConsensusUpdateTopicTransactionBody;
 import com.hedera.hashgraph.sdk.proto.SchedulableTransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionResponse;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.MethodDescriptor;
 import java.time.Duration;
 import java.time.Instant;
@@ -244,10 +243,6 @@ public final class TopicUpdateTransaction extends Transaction<TopicUpdateTransac
      * @return                          the auto renew period
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     public Duration getAutoRenewPeriod() {
         return autoRenewPeriod;
     }
@@ -258,10 +253,6 @@ public final class TopicUpdateTransaction extends Transaction<TopicUpdateTransac
      * @param autoRenewPeriod The Duration to be set for auto renewal
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public TopicUpdateTransaction setAutoRenewPeriod(Duration autoRenewPeriod) {
         Objects.requireNonNull(autoRenewPeriod);
         requireNotFrozen();
@@ -320,10 +311,6 @@ public final class TopicUpdateTransaction extends Transaction<TopicUpdateTransac
      * @return Expiration time
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "An Instant can't actually be mutated"
-    )
     public Instant getExpirationTime() {
         return expirationTime;
     }
@@ -336,10 +323,6 @@ public final class TopicUpdateTransaction extends Transaction<TopicUpdateTransac
      * @param expirationTime the new expiration time
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "An Instant can't actually be mutated"
-    )
     public TopicUpdateTransaction setExpirationTime(Instant expirationTime) {
         requireNotFrozen();
         this.expirationTime = Objects.requireNonNull(expirationTime);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk;
 
-import com.google.errorprone.annotations.Var;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.hashgraph.sdk.proto.SchedulableTransactionBody;
@@ -28,7 +27,6 @@ import com.hedera.hashgraph.sdk.proto.SignaturePair;
 import com.hedera.hashgraph.sdk.proto.SignedTransaction;
 import com.hedera.hashgraph.sdk.proto.TransactionBody;
 import com.hedera.hashgraph.sdk.proto.TransactionList;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.reflect.Modifier;
 import java.time.Duration;
 import java.time.Instant;
@@ -215,9 +213,9 @@ public abstract class Transaction<T extends Transaction<T>>
             nodeAccountIds.remove(new AccountId(0));
 
             // Verify that transaction bodies match
-            for (@Var int i = 0; i < txCount; i++) {
-                @Var TransactionBody firstTxBody = null;
-                for (@Var int j = 0; j < nodeCount; j++) {
+            for (int i = 0; i < txCount; i++) {
+                TransactionBody firstTxBody = null;
+                for (int j = 0; j < nodeCount; j++) {
                     int k = i * nodeCount + j;
                     var txBody = TransactionBody.parseFrom(innerSignedTransactions.get(k).getBodyBytes());
                     if (firstTxBody == null) {
@@ -255,7 +253,7 @@ public abstract class Transaction<T extends Transaction<T>>
      */
     public static Transaction<?> fromBytes(byte[] bytes) throws InvalidProtocolBufferException {
         var txs = new LinkedHashMap<TransactionId, LinkedHashMap<AccountId, com.hedera.hashgraph.sdk.proto.Transaction>>();
-        @Var TransactionBody.DataCase dataCase = TransactionBody.DataCase.DATA_NOT_SET;
+        TransactionBody.DataCase dataCase = TransactionBody.DataCase.DATA_NOT_SET;
 
         var list = TransactionList.parseFrom(bytes);
 
@@ -536,7 +534,7 @@ public abstract class Transaction<T extends Transaction<T>>
                     if (listA.size() != listB.size()) {
                         throwProtoMatchException(methodFieldName, "of size " + listA.size(), "of size " + listB.size());
                     }
-                    for (@Var int i = 0; i < listA.size(); i++) {
+                    for (int i = 0; i < listA.size(); i++) {
                         // System.out.println("comparing " + thisFieldName + "." + methodFieldName + "[" + i + "]");
                         requireProtoMatches(listA.get(i), listB.get(i), ignoreSet, methodFieldName + "[" + i + "]");
                     }
@@ -643,10 +641,6 @@ public abstract class Transaction<T extends Transaction<T>>
      * @return the transaction valid duration
      */
     @Nullable
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP",
-        justification = "A Duration can't actually be mutated"
-    )
     public final Duration getTransactionValidDuration() {
         return transactionValidDuration;
     }
@@ -659,10 +653,6 @@ public abstract class Transaction<T extends Transaction<T>>
      * @param validDuration The duration to be set
      * @return {@code this}
      */
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "A Duration can't actually be mutated"
-    )
     public final T setTransactionValidDuration(Duration validDuration) {
         requireNotFrozen();
         Objects.requireNonNull(validDuration);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TransactionId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TransactionId.java
@@ -22,7 +22,6 @@ package com.hedera.hashgraph.sdk;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 
-import com.google.errorprone.annotations.Var;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.hashgraph.sdk.proto.TransactionID;
 import java.time.Duration;
@@ -151,7 +150,6 @@ public final class TransactionId implements Comparable<TransactionId> {
      * @return                          the new transaction id
      */
     public static TransactionId fromString(String s) {
-        @Var
         var parts = s.split("/", 2);
 
         var nonce = (parts.length == 2) ? Integer.parseInt(parts[1]) : null;

--- a/sdk/src/main/java/module-info.java
+++ b/sdk/src/main/java/module-info.java
@@ -33,9 +33,7 @@ module com.hedera.hashgraph.sdk {
     requires org.bouncycastle.provider;
     requires org.slf4j;
 
-    requires static com.github.spotbugs.annotations;
-    requires static com.google.errorprone.annotations;
-    requires static java.annotation;
+    requires static transitive java.annotation;
 
     exports com.hedera.hashgraph.sdk;
     exports com.hedera.hashgraph.sdk.logger;

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractFunctionParametersTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractFunctionParametersTest.java
@@ -563,9 +563,9 @@ public class ContractFunctionParametersTest {
                 if (bitWidth == 8) {
                     return (byte) (1 << (bitWidth - 1));
                 } else if (bitWidth <= 32) {
-                    return (int) (1 << (bitWidth - 1));
+                    return (1 << (bitWidth - 1));
                 } else if (bitWidth <= 64) {
-                    return (long) (1L << (bitWidth - 1));
+                    return (1L << (bitWidth - 1));
                 } else {
                     return BigInteger.ONE.shiftLeft(bitWidth - 1);
                 }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ExecutableTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ExecutableTest.java
@@ -25,7 +25,6 @@ import com.hedera.hashgraph.sdk.proto.QueryHeader;
 import com.hedera.hashgraph.sdk.proto.Response;
 import com.hedera.hashgraph.sdk.proto.ResponseCodeEnum;
 import com.hedera.hashgraph.sdk.proto.ResponseHeader;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.MethodDescriptor;
 import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.BeforeEach;
@@ -556,10 +555,6 @@ class ExecutableTest {
     }
 
     @Test
-    @SuppressFBWarnings(
-        value = "NP_NONNULL_PARAM_VIOLATION",
-        justification = "Cannot make TransactionResponse constructor public"
-    )
     void shouldRetryReturnsCorrectStates() {
         var tx = new DummyTransaction();
 

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/KeyTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/KeyTest.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk;
 
-import com.google.errorprone.annotations.Var;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.hashgraph.sdk.proto.Key;
@@ -249,7 +248,7 @@ class KeyTest {
         assertThat(keyList).contains(key2);
         assertThat(keyList).contains(key3);
 
-        @Var var arr = keyList.toArray();
+        var arr = keyList.toArray();
         assertThat(arr[0]).isEqualTo(key1);
         assertThat(arr[1]).isEqualTo(key2);
         assertThat(arr[2]).isEqualTo(key3);

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/AccountUpdateIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/AccountUpdateIntegrationTest.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.AccountCreateTransaction;
 import com.hedera.hashgraph.sdk.AccountInfoQuery;
 import com.hedera.hashgraph.sdk.AccountUpdateTransaction;
@@ -51,9 +50,9 @@ class AccountUpdateIntegrationTest {
 
             var accountId = Objects.requireNonNull(response.getReceipt(testEnv.client).accountId);
 
-            @Var var info = new AccountInfoQuery()
-                .setAccountId(accountId)
-                .execute(testEnv.client);
+            var info = new AccountInfoQuery()
+            .setAccountId(accountId)
+            .execute(testEnv.client);
 
             assertThat(info.accountId).isEqualTo(accountId);
             assertThat(info.isDeleted).isFalse();

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ClientIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ClientIntegrationTest.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,7 +35,7 @@ public class ClientIntegrationTest {
     @Test
     @DisplayName("setNetwork() functions correctly")
     void testReplaceNodes() throws Exception {
-        @Var Map<String, AccountId> network = new HashMap<>();
+        Map<String, AccountId> network = new HashMap<>();
         network.put("0.testnet.hedera.com:50211", new AccountId(3));
         network.put("1.testnet.hedera.com:50211", new AccountId(4));
 

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractBytecodeIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractBytecodeIntegrationTest.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.ContractByteCodeQuery;
 import com.hedera.hashgraph.sdk.ContractCreateTransaction;
 import com.hedera.hashgraph.sdk.ContractDeleteTransaction;
@@ -35,7 +34,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Objects;
 
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -47,7 +45,7 @@ public class ContractBytecodeIntegrationTest {
 	void canQueryContractBytecode() throws Exception {
 		try (var testEnv = new IntegrationTestEnv(1)) {
 
-			@Var var response = new FileCreateTransaction()
+        var response = new FileCreateTransaction()
 				.setKeys(testEnv.operatorKey)
 				.setContents(SMART_CONTRACT_BYTECODE)
 				.execute(testEnv.client);
@@ -89,7 +87,7 @@ public class ContractBytecodeIntegrationTest {
 	void getCostBigMaxQueryContractBytecode() throws Exception {
 		try (var testEnv = new IntegrationTestEnv(1)) {
 
-			@Var var response = new FileCreateTransaction()
+        var response = new FileCreateTransaction()
 				.setKeys(testEnv.operatorKey)
 				.setContents(SMART_CONTRACT_BYTECODE)
 				.execute(testEnv.client);
@@ -135,7 +133,7 @@ public class ContractBytecodeIntegrationTest {
 	void getCostSmallMaxQueryContractBytecode() throws Exception {
 		try (var testEnv = new IntegrationTestEnv(1)) {
 
-			@Var var response = new FileCreateTransaction()
+       var response = new FileCreateTransaction()
 					.setKeys(testEnv.operatorKey)
 					.setContents(SMART_CONTRACT_BYTECODE)
 					.execute(testEnv.client);
@@ -179,7 +177,7 @@ public class ContractBytecodeIntegrationTest {
 	void getCostInsufficientTxFeeQueryContractBytecode() throws Exception {
 		try (var testEnv = new IntegrationTestEnv(1)) {
 
-			@Var var response = new FileCreateTransaction()
+        var response = new FileCreateTransaction()
 					.setKeys(testEnv.operatorKey)
 					.setContents(SMART_CONTRACT_BYTECODE)
 					.execute(testEnv.client);

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractCallIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractCallIntegrationTest.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.ContractCallQuery;
 import com.hedera.hashgraph.sdk.ContractCreateTransaction;
 import com.hedera.hashgraph.sdk.ContractDeleteTransaction;
@@ -46,11 +45,10 @@ public class ContractCallIntegrationTest {
     void canCallContractFunction() throws Exception {
         try (var testEnv = new IntegrationTestEnv(1)) {
 
-            @Var
             var response = new FileCreateTransaction()
-                .setKeys(testEnv.operatorKey)
-                .setContents(SMART_CONTRACT_BYTECODE)
-                .execute(testEnv.client);
+            .setKeys(testEnv.operatorKey)
+            .setContents(SMART_CONTRACT_BYTECODE)
+            .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
@@ -229,10 +227,10 @@ public class ContractCallIntegrationTest {
     void getCostBigMaxContractCallFunction() throws Exception {
         try (var testEnv = new IntegrationTestEnv(1)) {
 
-            @Var var response = new FileCreateTransaction()
-                .setKeys(testEnv.operatorKey)
-                .setContents(SMART_CONTRACT_BYTECODE)
-                .execute(testEnv.client);
+            var response = new FileCreateTransaction()
+            .setKeys(testEnv.operatorKey)
+            .setContents(SMART_CONTRACT_BYTECODE)
+            .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
@@ -276,10 +274,10 @@ public class ContractCallIntegrationTest {
     void getCostSmallMaxContractCallFunction() throws Exception {
         try (var testEnv = new IntegrationTestEnv(1)) {
 
-            @Var var response = new FileCreateTransaction()
-                .setKeys(testEnv.operatorKey)
-                .setContents(SMART_CONTRACT_BYTECODE)
-                .execute(testEnv.client);
+            var response = new FileCreateTransaction()
+            .setKeys(testEnv.operatorKey)
+            .setContents(SMART_CONTRACT_BYTECODE)
+            .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
@@ -322,10 +320,10 @@ public class ContractCallIntegrationTest {
     void getCostInsufficientTxFeeContractCallFunction() throws Exception {
         try (var testEnv = new IntegrationTestEnv(1)) {
 
-            @Var var response = new FileCreateTransaction()
-                .setKeys(testEnv.operatorKey)
-                .setContents(SMART_CONTRACT_BYTECODE)
-                .execute(testEnv.client);
+            var response = new FileCreateTransaction()
+            .setKeys(testEnv.operatorKey)
+            .setContents(SMART_CONTRACT_BYTECODE)
+            .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractCreateIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractCreateIntegrationTest.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.ContractCreateTransaction;
 import com.hedera.hashgraph.sdk.ContractDeleteTransaction;
 import com.hedera.hashgraph.sdk.ContractFunctionParameters;
@@ -46,10 +45,10 @@ public class ContractCreateIntegrationTest {
     void canCreateContract() throws Exception {
         try (var testEnv = new IntegrationTestEnv(1)) {
 
-            @Var var response = new FileCreateTransaction()
-                .setKeys(testEnv.operatorKey)
-                .setContents(SMART_CONTRACT_BYTECODE)
-                .execute(testEnv.client);
+            var response = new FileCreateTransaction()
+            .setKeys(testEnv.operatorKey)
+            .setContents(SMART_CONTRACT_BYTECODE)
+            .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
@@ -94,10 +93,10 @@ public class ContractCreateIntegrationTest {
     void canCreateContractWithNoAdminKey() throws Exception {
         try (var testEnv = new IntegrationTestEnv(1)) {
 
-            @Var var response = new FileCreateTransaction()
-                .setKeys(testEnv.operatorKey)
-                .setContents(SMART_CONTRACT_BYTECODE)
-                .execute(testEnv.client);
+            var response = new FileCreateTransaction()
+            .setKeys(testEnv.operatorKey)
+            .setContents(SMART_CONTRACT_BYTECODE)
+            .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractDeleteIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractDeleteIntegrationTest.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.ContractCreateTransaction;
 import com.hedera.hashgraph.sdk.ContractDeleteTransaction;
 import com.hedera.hashgraph.sdk.ContractFunctionParameters;
@@ -46,11 +45,10 @@ public class ContractDeleteIntegrationTest {
     void canDeleteContractWithAdminKey() throws Exception {
         try (var testEnv = new IntegrationTestEnv(1)) {
 
-            @Var
             var response = new FileCreateTransaction()
-                .setKeys(testEnv.operatorKey)
-                .setContents(SMART_CONTRACT_BYTECODE)
-                .execute(testEnv.client);
+            .setKeys(testEnv.operatorKey)
+            .setContents(SMART_CONTRACT_BYTECODE)
+            .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractExecuteIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractExecuteIntegrationTest.java
@@ -22,7 +22,6 @@ package com.hedera.hashgraph.sdk.test.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.ContractCreateTransaction;
 import com.hedera.hashgraph.sdk.ContractDeleteTransaction;
 import com.hedera.hashgraph.sdk.ContractExecuteTransaction;
@@ -44,10 +43,10 @@ public class ContractExecuteIntegrationTest {
     void canExecuteContractMethods() throws Exception {
         try (var testEnv = new IntegrationTestEnv(1)) {
 
-            @Var var response = new FileCreateTransaction()
-                .setKeys(testEnv.operatorKey)
-                .setContents(SMART_CONTRACT_BYTECODE)
-                .execute(testEnv.client);
+            var response = new FileCreateTransaction()
+            .setKeys(testEnv.operatorKey)
+            .setContents(SMART_CONTRACT_BYTECODE)
+            .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractFunctionParametersIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractFunctionParametersIntegrationTest.java
@@ -22,7 +22,6 @@ package com.hedera.hashgraph.sdk.test.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.esaulpaugh.headlong.abi.Address;
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.ContractCallQuery;
 import com.hedera.hashgraph.sdk.ContractCreateTransaction;
 import com.hedera.hashgraph.sdk.ContractDeleteTransaction;
@@ -52,7 +51,7 @@ public class ContractFunctionParametersIntegrationTest {
     public static void beforeAll() throws Exception {
         testEnv = new IntegrationTestEnv(1);
 
-        @Var var response = new FileCreateTransaction().setKeys(testEnv.operatorKey).execute(testEnv.client);
+        var response = new FileCreateTransaction().setKeys(testEnv.operatorKey).execute(testEnv.client);
 
         fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractInfoIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractInfoIntegrationTest.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,10 +35,10 @@ public class ContractInfoIntegrationTest {
     void canQueryContractInfo() throws Exception {
         try (var testEnv = new IntegrationTestEnv(1)) {
 
-            @Var var response = new FileCreateTransaction()
-                .setKeys(testEnv.operatorKey)
-                .setContents(SMART_CONTRACT_BYTECODE)
-                .execute(testEnv.client);
+            var response = new FileCreateTransaction()
+            .setKeys(testEnv.operatorKey)
+            .setContents(SMART_CONTRACT_BYTECODE)
+            .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
@@ -87,10 +86,10 @@ public class ContractInfoIntegrationTest {
     void canQueryContractInfoWhenAdminKeyIsNull() throws Exception {
         try (var testEnv = new IntegrationTestEnv(1)) {
 
-            @Var var response = new FileCreateTransaction()
-                .setKeys(testEnv.operatorKey)
-                .setContents(SMART_CONTRACT_BYTECODE)
-                .execute(testEnv.client);
+            var response = new FileCreateTransaction()
+            .setKeys(testEnv.operatorKey)
+            .setContents(SMART_CONTRACT_BYTECODE)
+            .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
@@ -138,10 +137,10 @@ public class ContractInfoIntegrationTest {
     void getCostBigMaxContractInfoFunction() throws Exception {
         try (var testEnv = new IntegrationTestEnv(1)) {
 
-            @Var var response = new FileCreateTransaction()
-                .setKeys(testEnv.operatorKey)
-                .setContents(SMART_CONTRACT_BYTECODE)
-                .execute(testEnv.client);
+            var response = new FileCreateTransaction()
+            .setKeys(testEnv.operatorKey)
+            .setContents(SMART_CONTRACT_BYTECODE)
+            .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
@@ -183,10 +182,10 @@ public class ContractInfoIntegrationTest {
     void getCostSmallMaxContractInfoFunction() throws Exception {
         try (var testEnv = new IntegrationTestEnv(1)) {
 
-            @Var var response = new FileCreateTransaction()
-                .setKeys(testEnv.operatorKey)
-                .setContents(SMART_CONTRACT_BYTECODE)
-                .execute(testEnv.client);
+            var response = new FileCreateTransaction()
+            .setKeys(testEnv.operatorKey)
+            .setContents(SMART_CONTRACT_BYTECODE)
+            .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
@@ -227,10 +226,10 @@ public class ContractInfoIntegrationTest {
     void getCostInsufficientTxFeeContractInfoFunction() throws Exception {
         try (var testEnv = new IntegrationTestEnv(1)) {
 
-            @Var var response = new FileCreateTransaction()
-                .setKeys(testEnv.operatorKey)
-                .setContents(SMART_CONTRACT_BYTECODE)
-                .execute(testEnv.client);
+            var response = new FileCreateTransaction()
+            .setKeys(testEnv.operatorKey)
+            .setContents(SMART_CONTRACT_BYTECODE)
+            .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractNonceInfoIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractNonceInfoIntegrationTest.java
@@ -21,7 +21,6 @@ package com.hedera.hashgraph.sdk.test.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.ContractCreateTransaction;
 import com.hedera.hashgraph.sdk.ContractDeleteTransaction;
 import com.hedera.hashgraph.sdk.ContractId;
@@ -40,10 +39,10 @@ public class ContractNonceInfoIntegrationTest {
     void canIncrementNonceThroughContractConstructor() throws Exception {
         try (var testEnv = new IntegrationTestEnv(1)) {
 
-            @Var var response = new FileCreateTransaction()
-                .setKeys(testEnv.operatorKey)
-                .setContents(SMART_CONTRACT_BYTECODE)
-                .execute(testEnv.client);
+            var response = new FileCreateTransaction()
+            .setKeys(testEnv.operatorKey)
+            .setContents(SMART_CONTRACT_BYTECODE)
+            .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractUpdateIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ContractUpdateIntegrationTest.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.ContractCreateTransaction;
 import com.hedera.hashgraph.sdk.ContractDeleteTransaction;
 import com.hedera.hashgraph.sdk.ContractFunctionParameters;
@@ -46,10 +45,10 @@ class ContractUpdateIntegrationTest {
     void canUpdateContract() throws Exception {
         try (var testEnv = new IntegrationTestEnv(1)) {
 
-            @Var var response = new FileCreateTransaction()
-                .setKeys(testEnv.operatorKey)
-                .setContents(SMART_CONTRACT_BYTECODE)
-                .execute(testEnv.client);
+            var response = new FileCreateTransaction()
+            .setKeys(testEnv.operatorKey)
+            .setContents(SMART_CONTRACT_BYTECODE)
+            .execute(testEnv.client);
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
@@ -63,9 +62,9 @@ class ContractUpdateIntegrationTest {
 
             var contractId = Objects.requireNonNull(response.getReceipt(testEnv.client).contractId);
 
-            @Var var info = new ContractInfoQuery()
-                .setContractId(contractId)
-                .execute(testEnv.client);
+            var info = new ContractInfoQuery()
+            .setContractId(contractId)
+            .execute(testEnv.client);
 
             assertThat(info.contractId).isEqualTo(contractId);
             assertThat(info.accountId).isNotNull();

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/FileAppendIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/FileAppendIntegrationTest.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.FileAppendTransaction;
 import com.hedera.hashgraph.sdk.FileContentsQuery;
 import com.hedera.hashgraph.sdk.FileCreateTransaction;
@@ -48,9 +47,9 @@ public class FileAppendIntegrationTest {
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
-            @Var var info = new FileInfoQuery()
-                .setFileId(fileId)
-                .execute(testEnv.client);
+            var info = new FileInfoQuery()
+            .setFileId(fileId)
+            .execute(testEnv.client);
 
             assertThat(info.fileId).isEqualTo(fileId);
             assertThat(info.size).isEqualTo(28);
@@ -103,9 +102,9 @@ public class FileAppendIntegrationTest {
 
             Thread.sleep(5000);
 
-            @Var var info = new FileInfoQuery()
-                .setFileId(fileId)
-                .execute(testEnv.client);
+            var info = new FileInfoQuery()
+            .setFileId(fileId)
+            .execute(testEnv.client);
 
             assertThat(info.fileId).isEqualTo(fileId);
             assertThat(info.size).isEqualTo(28);
@@ -164,9 +163,9 @@ public class FileAppendIntegrationTest {
 
             Thread.sleep(5000);
 
-            @Var var info = new FileInfoQuery()
-                .setFileId(fileId)
-                .execute(testEnv.client);
+            var info = new FileInfoQuery()
+            .setFileId(fileId)
+            .execute(testEnv.client);
 
             assertThat(info.fileId).isEqualTo(fileId);
             assertThat(info.size).isEqualTo(28);

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/FileUpdateIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/FileUpdateIntegrationTest.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.FileCreateTransaction;
 import com.hedera.hashgraph.sdk.FileDeleteTransaction;
@@ -52,9 +51,9 @@ public class FileUpdateIntegrationTest {
 
             var fileId = Objects.requireNonNull(response.getReceipt(testEnv.client).fileId);
 
-            @Var var info = new FileInfoQuery()
-                .setFileId(fileId)
-                .execute(testEnv.client);
+            var info = new FileInfoQuery()
+            .setFileId(fileId)
+            .execute(testEnv.client);
 
             assertThat(info.fileId).isEqualTo(fileId);
             assertThat(info.size).isEqualTo(28);

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/IntegrationTestEnv.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/IntegrationTestEnv.java
@@ -21,7 +21,6 @@ package com.hedera.hashgraph.sdk.test.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.AccountBalanceQuery;
 import com.hedera.hashgraph.sdk.AccountCreateTransaction;
 import com.hedera.hashgraph.sdk.AccountId;
@@ -88,7 +87,7 @@ public class IntegrationTestEnv implements AutoCloseable {
         var network = new HashMap<String, AccountId>();
 
         var nodeCount = Math.min(client.getNetwork().size(), maxNodesPerTransaction);
-        for (@Var int i = 0; i < nodeCount; i++) {
+        for (int i = 0; i < nodeCount; i++) {
             nodeGetter.nextNode(network);
         }
         client.setNetwork(network);
@@ -172,7 +171,6 @@ public class IntegrationTestEnv implements AutoCloseable {
     private static class TestEnvNodeGetter {
         private final Client client;
         private final List<Map.Entry<String, AccountId>> nodes;
-        @Var
         private int index = 0;
 
         public TestEnvNodeGetter(Client client) {

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ScheduleCreateIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ScheduleCreateIntegrationTest.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.AccountBalanceQuery;
 import com.hedera.hashgraph.sdk.AccountCreateTransaction;
 import com.hedera.hashgraph.sdk.AccountDeleteTransaction;
@@ -166,7 +165,7 @@ public class ScheduleCreateIntegrationTest {
                 .execute(testEnv.client);
 
             // This will wait for the receipt to become available
-            @Var TransactionReceipt receipt = response.getReceipt(testEnv.client);
+            TransactionReceipt receipt = response.getReceipt(testEnv.client);
 
             AccountId accountId = Objects.requireNonNull(receipt.accountId);
 
@@ -189,9 +188,9 @@ public class ScheduleCreateIntegrationTest {
             ScheduleId scheduleId = Objects.requireNonNull(receipt.scheduleId);
 
             // Get the schedule info to see if `signatories` is populated with 2/3 signatures
-            @Var ScheduleInfo info = new ScheduleInfoQuery()
-                .setScheduleId(scheduleId)
-                .execute(testEnv.client);
+            ScheduleInfo info = new ScheduleInfoQuery()
+            .setScheduleId(scheduleId)
+            .execute(testEnv.client);
 
             assertThat(info.executedAt).isNull();
 
@@ -392,9 +391,9 @@ public class ScheduleCreateIntegrationTest {
                 .getReceipt(testEnv.client).scheduleId);
 
             // verify schedule has been created and has 1 of 2 signatures
-            @Var var info = new ScheduleInfoQuery()
-                .setScheduleId(scheduleId)
-                .execute(testEnv.client);
+            var info = new ScheduleInfoQuery()
+            .setScheduleId(scheduleId)
+            .execute(testEnv.client);
 
             assertThat(info).isNotNull();
             assertThat(info.scheduleId).isEqualTo(scheduleId);

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/SystemIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/SystemIntegrationTest.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.ContractCreateTransaction;
 import com.hedera.hashgraph.sdk.ContractFunctionParameters;
 import com.hedera.hashgraph.sdk.FileCreateTransaction;

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/TokenFeeScheduleUpdateIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/TokenFeeScheduleUpdateIntegrationTest.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.CustomFee;
 import com.hedera.hashgraph.sdk.CustomFixedFee;
 import com.hedera.hashgraph.sdk.CustomFractionalFee;
@@ -62,9 +61,9 @@ class TokenFeeScheduleUpdateIntegrationTest {
 
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
-            @Var var info = new TokenInfoQuery()
-                .setTokenId(tokenId)
-                .execute(testEnv.client);
+            var info = new TokenInfoQuery()
+            .setTokenId(tokenId)
+            .execute(testEnv.client);
 
             assertThat(info.tokenId).isEqualTo(tokenId);
             assertThat(info.name).isEqualTo("ffff");
@@ -134,27 +133,27 @@ class TokenFeeScheduleUpdateIntegrationTest {
 
             var fees = info.customFees;
             assertThat(fees.size()).isEqualTo(2);
-            @Var int fixedCount = 0;
-            @Var int fractionalCount = 0;
-            for (var fee : fees) {
-                if (fee instanceof CustomFixedFee) {
-                    fixedCount++;
-                    var fixed = (CustomFixedFee) fee;
-                    assertThat(fixed.getAmount()).isEqualTo(10);
-                    assertThat(fixed.getFeeCollectorAccountId()).isEqualTo(testEnv.operatorId);
-                    assertThat(fixed.getDenominatingTokenId()).isNull();
-                } else if (fee instanceof CustomFractionalFee) {
-                    fractionalCount++;
-                    var fractional = (CustomFractionalFee) fee;
-                    assertThat(fractional.getNumerator()).isEqualTo(1);
-                    assertThat(fractional.getDenominator()).isEqualTo(20);
-                    assertThat(fractional.getMin()).isEqualTo(1);
-                    assertThat(fractional.getMax()).isEqualTo(10);
-                    assertThat(fractional.getFeeCollectorAccountId()).isEqualTo(testEnv.operatorId);
-                }
+            int fixedCount = 0;
+        int fractionalCount = 0;
+        for (var fee : fees) {
+            if (fee instanceof CustomFixedFee) {
+                fixedCount++;
+                var fixed = (CustomFixedFee) fee;
+                assertThat(fixed.getAmount()).isEqualTo(10);
+                assertThat(fixed.getFeeCollectorAccountId()).isEqualTo(testEnv.operatorId);
+                assertThat(fixed.getDenominatingTokenId()).isNull();
+            } else if (fee instanceof CustomFractionalFee) {
+                fractionalCount++;
+                var fractional = (CustomFractionalFee) fee;
+                assertThat(fractional.getNumerator()).isEqualTo(1);
+                assertThat(fractional.getDenominator()).isEqualTo(20);
+                assertThat(fractional.getMin()).isEqualTo(1);
+                assertThat(fractional.getMax()).isEqualTo(10);
+                assertThat(fractional.getFeeCollectorAccountId()).isEqualTo(testEnv.operatorId);
             }
-            assertThat(fixedCount).isEqualTo(1);
-            assertThat(fractionalCount).isEqualTo(1);
+        }
+        assertThat(fixedCount).isEqualTo(1);
+        assertThat(fractionalCount).isEqualTo(1);
 
         }
     }

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/TokenNftTransferIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/TokenNftTransferIntegrationTest.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.AccountCreateTransaction;
 import com.hedera.hashgraph.sdk.Hbar;
 import com.hedera.hashgraph.sdk.PrivateKey;
@@ -50,10 +49,10 @@ class TokenNftTransferIntegrationTest {
 
             var key = PrivateKey.generateED25519();
 
-            @Var TransactionResponse response = new AccountCreateTransaction()
-                .setKey(key)
-                .setInitialBalance(new Hbar(1))
-                .execute(testEnv.client);
+            TransactionResponse response = new AccountCreateTransaction()
+            .setKey(key)
+            .setInitialBalance(new Hbar(1))
+            .execute(testEnv.client);
 
             var accountId = response.getReceipt(testEnv.client).accountId;
             assertThat(accountId).isNotNull();
@@ -119,10 +118,10 @@ class TokenNftTransferIntegrationTest {
 
             var key = PrivateKey.generateED25519();
 
-            @Var TransactionResponse response = new AccountCreateTransaction()
-                .setKey(key)
-                .setInitialBalance(new Hbar(1))
-                .execute(testEnv.client);
+            TransactionResponse response = new AccountCreateTransaction()
+            .setKey(key)
+            .setInitialBalance(new Hbar(1))
+            .execute(testEnv.client);
 
             var accountId = response.getReceipt(testEnv.client).accountId;
             assertThat(accountId).isNotNull();

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/TokenTransferIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/TokenTransferIntegrationTest.java
@@ -19,9 +19,7 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.AccountCreateTransaction;
-import com.hedera.hashgraph.sdk.AccountDeleteTransaction;
 import com.hedera.hashgraph.sdk.CustomFixedFee;
 import com.hedera.hashgraph.sdk.Hbar;
 import com.hedera.hashgraph.sdk.PrivateKey;
@@ -49,10 +47,10 @@ class TokenTransferIntegrationTest {
 
             var key = PrivateKey.generateED25519();
 
-            @Var TransactionResponse response = new AccountCreateTransaction()
-                .setKey(key)
-                .setInitialBalance(new Hbar(1))
-                .execute(testEnv.client);
+            TransactionResponse response = new AccountCreateTransaction()
+            .setKey(key)
+            .setInitialBalance(new Hbar(1))
+            .execute(testEnv.client);
 
             var accountId = response.getReceipt(testEnv.client).accountId;
             assertThat(accountId).isNotNull();

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/TokenUpdateIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/TokenUpdateIntegrationTest.java
@@ -22,7 +22,6 @@ package com.hedera.hashgraph.sdk.test.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.KeyList;
 import com.hedera.hashgraph.sdk.PrecheckStatusException;
 import com.hedera.hashgraph.sdk.PrivateKey;
@@ -63,9 +62,9 @@ class TokenUpdateIntegrationTest {
 
             var tokenId = Objects.requireNonNull(response.getReceipt(testEnv.client).tokenId);
 
-            @Var var info = new TokenInfoQuery()
-                .setTokenId(tokenId)
-                .execute(testEnv.client);
+            var info = new TokenInfoQuery()
+            .setTokenId(tokenId)
+            .execute(testEnv.client);
 
             assertThat(info.tokenId).isEqualTo(tokenId);
             assertThat(info.name).isEqualTo("ffff");

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/TopicMessageSubmitIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/TopicMessageSubmitIntegrationTest.java
@@ -19,9 +19,7 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.hedera.hashgraph.sdk.PrecheckStatusException;
-import com.hedera.hashgraph.sdk.ReceiptStatusException;
 import com.hedera.hashgraph.sdk.Status;
 import com.hedera.hashgraph.sdk.TopicCreateTransaction;
 import com.hedera.hashgraph.sdk.TopicDeleteTransaction;
@@ -52,9 +50,9 @@ public class TopicMessageSubmitIntegrationTest {
 
             var topicId = Objects.requireNonNull(response.getReceipt(testEnv.client).topicId);
 
-            @Var var info = new TopicInfoQuery()
-                    .setTopicId(topicId)
-                    .execute(testEnv.client);
+            var info = new TopicInfoQuery()
+            .setTopicId(topicId)
+            .execute(testEnv.client);
 
             assertThat(info.topicId).isEqualTo(topicId);
             assertThat(info.topicMemo).isEqualTo("[e2e::TopicCreateTransaction]");
@@ -102,9 +100,9 @@ public class TopicMessageSubmitIntegrationTest {
 
                 Thread.sleep(5000);
 
-                @Var var info = new TopicInfoQuery()
-                        .setTopicId(topicId)
-                        .execute(testEnv.client);
+                var info = new TopicInfoQuery()
+                .setTopicId(topicId)
+                .execute(testEnv.client);
 
                 assertThat(info.topicId).isEqualTo(topicId);
                 assertThat(info.topicMemo).isEqualTo("[e2e::TopicCreateTransaction]");

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/TransactionIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/TransactionIntegrationTest.java
@@ -19,7 +19,6 @@
  */
 package com.hedera.hashgraph.sdk.test.integration;
 
-import com.google.errorprone.annotations.Var;
 import com.google.protobuf.ByteString;
 import com.hedera.hashgraph.sdk.AccountCreateTransaction;
 import com.hedera.hashgraph.sdk.AccountDeleteTransaction;
@@ -386,7 +385,6 @@ public class TransactionIntegrationTest {
 
             var expectedHash = transaction.getTransactionHashPerNode();
 
-            @Var
             var response = transaction.execute(testEnv.client);
 
             var record = response.getRecord(testEnv.client);
@@ -434,10 +432,9 @@ public class TransactionIntegrationTest {
 
             Thread.sleep(5000);
 
-            @Var
             var info = new FileInfoQuery()
-                    .setFileId(fileId)
-                    .execute(testEnv.client);
+            .setFileId(fileId)
+            .execute(testEnv.client);
 
             assertThat(info.fileId).isEqualTo(fileId);
             assertThat(info.size).isEqualTo(28);
@@ -480,10 +477,9 @@ public class TransactionIntegrationTest {
 
             Thread.sleep(5000);
 
-            @Var
             var info = new FileInfoQuery()
-                    .setFileId(fileId)
-                    .execute(testEnv.client);
+            .setFileId(fileId)
+            .execute(testEnv.client);
 
             assertThat(info.fileId).isEqualTo(fileId);
             assertThat(info.size).isEqualTo(28);
@@ -549,10 +545,9 @@ public class TransactionIntegrationTest {
 
             Thread.sleep(5000);
 
-            @Var
             var info = new FileInfoQuery()
-                    .setFileId(fileId)
-                    .execute(testEnv.client);
+            .setFileId(fileId)
+            .execute(testEnv.client);
 
             assertThat(info.fileId).isEqualTo(fileId);
             assertThat(info.size).isEqualTo(28);
@@ -620,10 +615,9 @@ public class TransactionIntegrationTest {
 
             Thread.sleep(5000);
 
-            @Var
             var info = new TopicInfoQuery()
-                    .setTopicId(topicId)
-                    .execute(testEnv.client);
+            .setTopicId(topicId)
+            .execute(testEnv.client);
 
             assertThat(info.topicId).isEqualTo(topicId);
             assertThat(info.topicMemo).isEqualTo("[e2e::TopicCreateTransaction]");
@@ -670,10 +664,9 @@ public class TransactionIntegrationTest {
 
             Thread.sleep(5000);
 
-            @Var
             var info = new TopicInfoQuery()
-                    .setTopicId(topicId)
-                    .execute(testEnv.client);
+            .setTopicId(topicId)
+            .execute(testEnv.client);
 
             assertThat(info.topicId).isEqualTo(topicId);
             assertThat(info.topicMemo).isEqualTo("[e2e::TopicCreateTransaction]");
@@ -733,10 +726,9 @@ public class TransactionIntegrationTest {
 
             Thread.sleep(5000);
 
-            @Var
             var info = new TopicInfoQuery()
-                    .setTopicId(topicId)
-                    .execute(testEnv.client);
+            .setTopicId(topicId)
+            .execute(testEnv.client);
 
             assertThat(info.topicId).isEqualTo(topicId);
             assertThat(info.topicMemo).isEqualTo("[e2e::TopicCreateTransaction]");
@@ -881,7 +873,6 @@ public class TransactionIntegrationTest {
                                     .setEd25519(ByteString.copyFrom(signature5))
                                     .setPubKeyPrefix(ByteString.copyFrom(publicKey5.toBytes()))
                                     .build()));
-            @Var
             var byts = signedBuilder.build().toByteString();
 
             byts = TransactionList.newBuilder()

--- a/sdk/src/testIntegration/java/module-info.java
+++ b/sdk/src/testIntegration/java/module-info.java
@@ -25,6 +25,5 @@ open module com.hedera.hashgraph.sdk.test.integration {
     requires org.bouncycastle.provider;
     requires org.junit.jupiter.api;
 
-    requires static com.google.errorprone.annotations;
     requires static java.annotation;
 }


### PR DESCRIPTION
**Description**:
Addresses the following items in #1794 

- Introduce Guava fix, which should be in plugin in the future
- Get rid of `mergeJar("com.google.code.findbugs:jsr305")`
- _(Partially)_ Adjust the code style rules and tools to what its done in _hedera-services_

This removes the setups for: sonar, error prone, spotbugs. Justification:
- Spotbugs does not run as part of the pipeline, but if you run it it gives a ton of errors
- Instead of sonar, we should use **codacy** as we do in `hedera-servcies` once we have the same Gradle setup
- Error prone did not really run, because it is an annotation processor that produces warnings but all warnings were turned off with this comment (??):

``` 
    // Disable warnings because I'm tired of them :P
    options.isWarnings = false
```

As we also do not use (and configure) these tools in _hedera-services_, my suggestion is to remove them for now. We can  re-introduce one of these tools later again, but then with proper configuration that checks what you want to check and that works with errors (and not warnings).

Instead, the `javac` linting capabilities are now configured similar to how it is done in _hedera-services_. As preparation for sharing this configuration in the next step (https://github.com/hashgraph/hedera-services/issues/14255).

**Related issue(s)**:

#1794 / https://github.com/hashgraph/hedera-services/issues/14255

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
