### PR TITLE
fix:reset setFileId and setContractId #1596

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/SystemDeleteTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/SystemDeleteTransaction.java
@@ -100,9 +100,9 @@ public final class SystemDeleteTransaction extends Transaction<SystemDeleteTrans
      * @return {@code this}
      */
     public SystemDeleteTransaction setFileId(FileId fileId) {
-        Objects.requireNonNull(fileId);
         requireNotFrozen();
         this.fileId = fileId;
+        this.contractId = null; // Reset contractId
         return this;
     }
 
@@ -125,9 +125,9 @@ public final class SystemDeleteTransaction extends Transaction<SystemDeleteTrans
      * @return {@code this}
      */
     public SystemDeleteTransaction setContractId(ContractId contractId) {
-        Objects.requireNonNull(contractId);
         requireNotFrozen();
         this.contractId = contractId;
+        this.fileId = null; // Reset fileId
         return this;
     }
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/SystemDeleteTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/SystemDeleteTransaction.java
@@ -100,6 +100,7 @@ public final class SystemDeleteTransaction extends Transaction<SystemDeleteTrans
      * @return {@code this}
      */
     public SystemDeleteTransaction setFileId(FileId fileId) {
+        Objects.requireNonNull(fileId);
         requireNotFrozen();
         this.fileId = fileId;
         this.contractId = null; // Reset contractId
@@ -125,6 +126,7 @@ public final class SystemDeleteTransaction extends Transaction<SystemDeleteTrans
      * @return {@code this}
      */
     public SystemDeleteTransaction setContractId(ContractId contractId) {
+        Objects.requireNonNull(contractId);
         requireNotFrozen();
         this.contractId = contractId;
         this.fileId = null; // Reset fileId

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/SystemDeleteTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/SystemDeleteTransactionTest.java
@@ -171,9 +171,7 @@ public class SystemDeleteTransactionTest {
         assertThrows(IllegalStateException.class, () -> tx.setExpirationTime(validStart));
     }
 
-    // ported from C++ SDK, in Java it does not pass
     @Test
-    @Disabled
     void resetFileId() {
         var systemDeleteTransaction = new SystemDeleteTransaction();
         systemDeleteTransaction.setFileId(testFileId);
@@ -183,9 +181,7 @@ public class SystemDeleteTransactionTest {
         assertNotNull(systemDeleteTransaction.getContractId());
     }
 
-    // ported from C++ SDK, in Java it does not pass
     @Test
-    @Disabled
     void resetContractId() {
         var systemDeleteTransaction = new SystemDeleteTransaction();
         systemDeleteTransaction.setContractId(testContractId);


### PR DESCRIPTION
**Description**:

The setter methods setFileId and setContractId in SystemDeleteTransaction.java are not behaving as expected. This pr uses proposed solution
- code is working
- disable annotation and related comments removed from tests
- tests passes

**Related issue(s)**:

Fixes #1596

![image](https://github.com/user-attachments/assets/325608f1-15d8-4a6e-a8c0-cfb8b416d1b1)



**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
