### PR TITLE
build: update test-only dependency - Jackson

### DIFF
--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.patch-modules.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.patch-modules.gradle.kts
@@ -138,13 +138,6 @@ extraJavaModuleInfo {
     module("com.google.api.grpc:proto-google-common-protos", "com.google.api.grpc.common")
 
     // Testing only
-    module("com.fasterxml.jackson.core:jackson-annotations", "com.fasterxml.jackson.annotations")
-    module("com.fasterxml.jackson.core:jackson-core", "com.fasterxml.jackson.core")
-    module("com.fasterxml.jackson.core:jackson-databind", "com.fasterxml.jackson.databind") {
-        exportAllPackages()
-        requireAllDefinedDependencies()
-        requires("java.sql")
-    }
     module("io.grpc:grpc-netty-shaded", "io.grpc.netty.shaded") {
         exportAllPackages()
         requireAllDefinedDependencies()

--- a/sdk-dependency-versions/build.gradle.kts
+++ b/sdk-dependency-versions/build.gradle.kts
@@ -75,6 +75,9 @@ dependencies.constraints {
     }
 
     // Testing
+    api("com.fasterxml.jackson.core:jackson-core:2.18.0") {
+        because("com.fasterxml.jackson.core")
+    }
     api("io.github.cdimascio:java-dotenv:5.3.1") {
         because("java.dotenv")
     }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountAllowanceApproveTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountAllowanceApproveTransactionTest.java
@@ -47,7 +47,7 @@ public class AccountAllowanceApproveTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountAllowanceDeleteTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountAllowanceDeleteTransactionTest.java
@@ -39,7 +39,7 @@ public class AccountAllowanceDeleteTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountBalanceQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountBalanceQueryTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class AccountBalanceQueryTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountCreateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountCreateTransactionTest.java
@@ -40,7 +40,7 @@ public class AccountCreateTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountDeleteTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountDeleteTransactionTest.java
@@ -39,7 +39,7 @@ public class AccountDeleteTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountIdTest.java
@@ -39,7 +39,7 @@ class AccountIdTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
         mainnetClient = Client.forMainnet();
         testnetClient = Client.forTestnet();
         previewnetClient = Client.forPreviewnet();

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountInfoQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountInfoQueryTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class AccountInfoQueryTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountInfoTest.java
@@ -60,7 +60,7 @@ public class AccountInfoTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountRecordsQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountRecordsQueryTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class AccountRecordsQueryTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountStakersQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountStakersQueryTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class AccountStakersQueryTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountUpdateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/AccountUpdateTransactionTest.java
@@ -40,7 +40,7 @@ public class AccountUpdateTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/AllowancesTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/AllowancesTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AllowancesTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/AssessedCustomFeeTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/AssessedCustomFeeTest.java
@@ -30,7 +30,7 @@ public class AssessedCustomFeeTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractByteCodeQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractByteCodeQueryTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class ContractByteCodeQueryTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractCallQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractCallQueryTest.java
@@ -35,7 +35,7 @@ public class ContractCallQueryTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractCreateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractCreateTransactionTest.java
@@ -41,7 +41,7 @@ public class ContractCreateTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractDeleteTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractDeleteTransactionTest.java
@@ -39,7 +39,7 @@ public class ContractDeleteTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractExecuteTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractExecuteTransactionTest.java
@@ -40,7 +40,7 @@ public class ContractExecuteTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractFunctionParametersTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractFunctionParametersTest.java
@@ -44,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 public class ContractFunctionParametersTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractIdTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ContractIdTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractInfoQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractInfoQueryTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class ContractInfoQueryTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractInfoTest.java
@@ -47,7 +47,7 @@ public class ContractInfoTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractLogInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractLogInfoTest.java
@@ -21,7 +21,7 @@ public class ContractLogInfoTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractNonceInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractNonceInfoTest.java
@@ -16,7 +16,7 @@ public class ContractNonceInfoTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractUpdateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ContractUpdateTransactionTest.java
@@ -40,7 +40,7 @@ public class ContractUpdateTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/CryptoTransferTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/CryptoTransferTransactionTest.java
@@ -42,7 +42,7 @@ public class CryptoTransferTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/CustomFeeListTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/CustomFeeListTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CustomFeeListTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/CustomFixedFeeTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/CustomFixedFeeTest.java
@@ -40,7 +40,7 @@ public class CustomFixedFeeTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/CustomFractionalFeeTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/CustomFractionalFeeTest.java
@@ -27,7 +27,7 @@ public class CustomFractionalFeeTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/CustomRoyaltyFeeTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/CustomRoyaltyFeeTest.java
@@ -43,7 +43,7 @@ public class CustomRoyaltyFeeTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/DelegateContractIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/DelegateContractIdTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 class DelegateContractIdTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/EthereumTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/EthereumTransactionTest.java
@@ -19,7 +19,7 @@ public class EthereumTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/FeeSchedulesTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/FeeSchedulesTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class FeeSchedulesTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/FileAppendTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/FileAppendTransactionTest.java
@@ -91,7 +91,7 @@ public class FileAppendTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/FileContentsQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/FileContentsQueryTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class FileContentsQueryTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/FileCreateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/FileCreateTransactionTest.java
@@ -39,7 +39,7 @@ public class FileCreateTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/FileDeleteTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/FileDeleteTransactionTest.java
@@ -39,7 +39,7 @@ public class FileDeleteTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/FileIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/FileIdTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 class FileIdTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/FileInfoQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/FileInfoQueryTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class FileInfoQueryTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/FileInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/FileInfoTest.java
@@ -47,7 +47,7 @@ public class FileInfoTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/FileUpdateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/FileUpdateTransactionTest.java
@@ -39,7 +39,7 @@ public class FileUpdateTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/FreezeTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/FreezeTransactionTest.java
@@ -49,7 +49,7 @@ public class FreezeTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/LiveHashAddTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/LiveHashAddTransactionTest.java
@@ -21,7 +21,7 @@ class LiveHashAddTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/LiveHashDeleteTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/LiveHashDeleteTransactionTest.java
@@ -20,7 +20,7 @@ class LiveHashDeleteTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/LiveHashQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/LiveHashQueryTest.java
@@ -11,7 +11,7 @@ public class LiveHashQueryTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/MessageSubmitTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/MessageSubmitTransactionTest.java
@@ -39,7 +39,7 @@ public class MessageSubmitTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/NetworkVersionInfoQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/NetworkVersionInfoQueryTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 public class NetworkVersionInfoQueryTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/NetworkVersionInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/NetworkVersionInfoTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class NetworkVersionInfoTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/NftIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/NftIdTest.java
@@ -38,7 +38,7 @@ class NftIdTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
         mainnetClient = Client.forMainnet();
         testnetClient = Client.forTestnet();
         previewnetClient = Client.forPreviewnet();

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeCreateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeCreateTransactionTest.java
@@ -68,7 +68,7 @@ public class NodeCreateTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeDeleteTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeDeleteTransactionTest.java
@@ -43,7 +43,7 @@ public class NodeDeleteTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeUpdateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeUpdateTransactionTest.java
@@ -72,7 +72,7 @@ public class NodeUpdateTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/PrngTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/PrngTransactionTest.java
@@ -36,7 +36,7 @@ public class PrngTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ProxyStakerTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ProxyStakerTest.java
@@ -14,7 +14,7 @@ public class ProxyStakerTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ScheduleCreateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ScheduleCreateTransactionTest.java
@@ -37,7 +37,7 @@ public class ScheduleCreateTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ScheduleDeleteTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ScheduleDeleteTransactionTest.java
@@ -39,7 +39,7 @@ public class ScheduleDeleteTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ScheduleInfoQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ScheduleInfoQueryTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class ScheduleInfoQueryTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ScheduleInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ScheduleInfoTest.java
@@ -20,7 +20,7 @@ public class ScheduleInfoTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ScheduleSignTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ScheduleSignTransactionTest.java
@@ -37,7 +37,7 @@ public class ScheduleSignTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/Snapshot.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/Snapshot.java
@@ -1,0 +1,75 @@
+package com.hedera.hashgraph.sdk;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.PrettyPrinter;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.core.util.Separators;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+final class Snapshot {
+    private static final ObjectMapper objectMapper = buildObjectMapper();
+
+    /**
+     * Workaround for an incompatibility between latest Jackson and json-snapshot libs.
+     * <p>
+     * Intended to replace {@code io.github.jsonSnapshot.SnapshotMatcher#defaultJsonFunction}
+     *
+     * @see <a href="https://github.com/json-snapshot/json-snapshot.github.io/issues/27">Issue in json-snapshot project</a>
+     */
+    static String asJsonString(Object object) {
+        try {
+            return objectMapper.writer(buildDefaultPrettyPrinter()).writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Unmodified copy of {@code io.github.jsonSnapshot.SnapshotMatcher#buildObjectMapper}
+     */
+    private static ObjectMapper buildObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        objectMapper.setVisibility(
+            objectMapper
+                .getSerializationConfig()
+                .getDefaultVisibilityChecker()
+                .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
+        return objectMapper;
+    }
+
+    /**
+     * Modified copy of {@code io.github.jsonSnapshot.SnapshotMatcher#buildDefaultPrettyPrinter}
+     */
+    private static PrettyPrinter buildDefaultPrettyPrinter() {
+        DefaultPrettyPrinter pp =
+            new DefaultPrettyPrinter() {
+                @Override
+                @Nonnull
+                public DefaultPrettyPrinter createInstance() {
+                    return this;
+                }
+                @Override
+                public void writeObjectFieldValueSeparator(JsonGenerator jg) throws IOException {
+                    jg.writeRaw(": ");
+                }
+            };
+        DefaultPrettyPrinter.Indenter lfOnlyIndenter = new DefaultIndenter("  ", "\n");
+        pp.indentArraysWith(lfOnlyIndenter);
+        pp.indentObjectsWith(lfOnlyIndenter);
+        return pp;
+    }
+}

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/StakingInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/StakingInfoTest.java
@@ -14,7 +14,7 @@ public class StakingInfoTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/SystemDeleteTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/SystemDeleteTransactionTest.java
@@ -46,7 +46,7 @@ public class SystemDeleteTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/SystemUndeleteTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/SystemUndeleteTransactionTest.java
@@ -39,7 +39,7 @@ public class SystemUndeleteTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenAirdropTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenAirdropTransactionTest.java
@@ -52,7 +52,7 @@ class TokenAirdropTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenAssociateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenAssociateTransactionTest.java
@@ -46,7 +46,7 @@ public class TokenAssociateTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenAssociationTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenAssociationTest.java
@@ -16,7 +16,7 @@ public class TokenAssociationTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenBurnTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenBurnTransactionTest.java
@@ -45,7 +45,7 @@ public class TokenBurnTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenCancelAirdropTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenCancelAirdropTransactionTest.java
@@ -43,7 +43,7 @@ class TokenCancelAirdropTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenClaimAirdropTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenClaimAirdropTransactionTest.java
@@ -43,7 +43,7 @@ class TokenClaimAirdropTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenCreateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenCreateTransactionTest.java
@@ -84,7 +84,7 @@ public class TokenCreateTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenDeleteTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenDeleteTransactionTest.java
@@ -41,7 +41,7 @@ public class TokenDeleteTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenDissociateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenDissociateTransactionTest.java
@@ -46,7 +46,7 @@ public class TokenDissociateTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenFeeScheduleUpdateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenFeeScheduleUpdateTransactionTest.java
@@ -38,7 +38,7 @@ public class TokenFeeScheduleUpdateTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenFreezeTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenFreezeTransactionTest.java
@@ -39,7 +39,7 @@ public class TokenFreezeTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenGrantKycTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenGrantKycTransactionTest.java
@@ -43,7 +43,7 @@ public class TokenGrantKycTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenInfoQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenInfoQueryTest.java
@@ -32,7 +32,7 @@ public class TokenInfoQueryTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenInfoTest.java
@@ -93,7 +93,7 @@ public class TokenInfoTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenMintTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenMintTransactionTest.java
@@ -28,7 +28,7 @@ public class TokenMintTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenNftInfoQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenNftInfoQueryTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TokenNftInfoQueryTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenNftInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenNftInfoTest.java
@@ -16,7 +16,7 @@ public class TokenNftInfoTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenPauseTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenPauseTransactionTest.java
@@ -41,7 +41,7 @@ public class TokenPauseTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenRejectTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenRejectTransactionTest.java
@@ -54,7 +54,7 @@ public class TokenRejectTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenRelationshipTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenRelationshipTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TokenRelationshipTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenRevokeKycTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenRevokeKycTransactionTest.java
@@ -43,7 +43,7 @@ public class TokenRevokeKycTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenSupplyTypeTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenSupplyTypeTest.java
@@ -14,7 +14,7 @@ public class TokenSupplyTypeTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenTypeTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenTypeTest.java
@@ -32,7 +32,7 @@ public class TokenTypeTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenUnfreezeTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenUnfreezeTransactionTest.java
@@ -39,7 +39,7 @@ public class TokenUnfreezeTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenUnpauseTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenUnpauseTransactionTest.java
@@ -42,7 +42,7 @@ public class TokenUnpauseTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenUpdateNftsTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenUpdateNftsTransactionTest.java
@@ -45,7 +45,7 @@ public class TokenUpdateNftsTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenUpdateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenUpdateTransactionTest.java
@@ -78,7 +78,7 @@ public class TokenUpdateTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenWipeTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenWipeTransactionTest.java
@@ -47,7 +47,7 @@ public class TokenWipeTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicCreateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicCreateTransactionTest.java
@@ -40,7 +40,7 @@ public class TopicCreateTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicDeleteTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicDeleteTransactionTest.java
@@ -39,7 +39,7 @@ public class TopicDeleteTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicIdTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 class TopicIdTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicInfoQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicInfoQueryTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class TopicInfoQueryTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicInfoTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicInfoTest.java
@@ -55,7 +55,7 @@ public class TopicInfoTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageQueryTest.java
@@ -76,7 +76,7 @@ class TopicMessageQueryTest {
 
     @BeforeAll
     static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageSubmitTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicMessageSubmitTransactionTest.java
@@ -24,7 +24,7 @@ public class TopicMessageSubmitTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicUpdateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TopicUpdateTransactionTest.java
@@ -55,7 +55,7 @@ public class TopicUpdateTransactionTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TransactionIdTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TransactionIdTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 class TransactionIdTest {
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TransactionReceiptQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TransactionReceiptQueryTest.java
@@ -35,7 +35,7 @@ public class TransactionReceiptQueryTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TransactionReceiptTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TransactionReceiptTest.java
@@ -19,7 +19,7 @@ public class TransactionReceiptTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TransactionRecordQueryTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TransactionRecordQueryTest.java
@@ -35,7 +35,7 @@ public class TransactionRecordQueryTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TransactionRecordTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TransactionRecordTest.java
@@ -44,7 +44,7 @@ public class TransactionRecordTest {
 
     @BeforeAll
     public static void beforeAll() {
-        SnapshotMatcher.start();
+        SnapshotMatcher.start(Snapshot::asJsonString);
     }
 
     @AfterAll


### PR DESCRIPTION
**Description**:

Jackson is a transitive dependency of 'json-snapshot'. In order to use Jackson as Java Module, we update it to the latest version instead of patching it.

Unfortunately, 'json-snapshot' has not been updated in years and the way we used it is not compatible with the latest Jackson version.

By adjusting the test setup as described here, we make it work: https://github.com/json-snapshot/json-snapshot.github.io/issues/27#issuecomment-583307554

**Related issue(s)**:

This is (also) done to allow us to use the same Jackson versions across multiple hedera repositories in the context of https://github.com/hashgraph/hedera-services/issues/14255.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
