### PR TITLE
chore: remove `IllegalStateException` when specific node id is not present in address book

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
@@ -616,8 +616,7 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
             @Nullable
             var nodeProxies = client.network.getNodeProxies(accountId);
             if (nodeProxies == null || nodeProxies.size() == 0) {
-                throw new IllegalStateException(
-                    "Some node account IDs did not map to valid nodes in the client's network");
+                continue;
             }
 
             var node = nodeProxies.get(random.nextInt(nodeProxies.size()));

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Executable.java
@@ -601,7 +601,7 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
         // failure the system can retry with different proxy on each attempt
         if (nodeAccountIds.size() == 1) {
             var nodeProxies = client.network.getNodeProxies(nodeAccountIds.get(0));
-            if (nodeProxies == null || nodeProxies.size() == 0) {
+            if (nodeProxies == null || nodeProxies.isEmpty()) {
                 throw new IllegalStateException("Account ID did not map to valid node in the client's network");
             }
 
@@ -615,13 +615,17 @@ abstract class Executable<SdkRequestT, ProtoRequestT extends MessageLite, Respon
         for (var accountId : nodeAccountIds) {
             @Nullable
             var nodeProxies = client.network.getNodeProxies(accountId);
-            if (nodeProxies == null || nodeProxies.size() == 0) {
+            if (nodeProxies == null || nodeProxies.isEmpty()) {
                 continue;
             }
 
             var node = nodeProxies.get(random.nextInt(nodeProxies.size()));
 
             nodes.add(Objects.requireNonNull(node));
+        }
+        if (nodes.isEmpty()) {
+            throw new IllegalStateException(
+                "All node account IDs did not map to valid nodes in the client's network");
         }
     }
 


### PR DESCRIPTION
**Description**:

This PR ignores a node when the node is not present in the address book, instead of throwing an exception.
This helps with wallets not having to update the SDK every time the address book gets changed.

**Related issue(s)**:

Fixes #2044

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
