### PR TITLE
feat: init client with mirror network

### DIFF
--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/InitializeClientWithMirrorNetworkExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/InitializeClientWithMirrorNetworkExample.java
@@ -1,0 +1,92 @@
+/*-
+ *
+ * Hedera Java SDK
+ *
+ * Copyright (C) 2020 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hedera.hashgraph.sdk.examples;
+
+import com.hedera.hashgraph.sdk.AccountCreateTransaction;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.logger.LogLevel;
+import com.hedera.hashgraph.sdk.logger.Logger;
+import io.github.cdimascio.dotenv.Dotenv;
+import java.util.List;
+import java.util.Objects;
+
+public class InitializeClientWithMirrorNetworkExample {
+    /*
+     * See .env.sample in the examples folder root for how to specify values below
+     * or set environment variables with the same names.
+     */
+
+    /**
+     * Operator's account ID. Used to sign and pay for operations on Hedera.
+     */
+    private static final AccountId OPERATOR_ID = AccountId.fromString(
+        Objects.requireNonNull(Dotenv.load().get("OPERATOR_ID")));
+
+    /**
+     * Operator's private key.
+     */
+    private static final PrivateKey OPERATOR_KEY = PrivateKey.fromString(
+        Objects.requireNonNull(Dotenv.load().get("OPERATOR_KEY")));
+
+    /**
+     * SDK_LOG_LEVEL defaults to SILENT if not specified in dotenv file. Log levels can be: TRACE, DEBUG, INFO, WARN,
+     * ERROR, SILENT.
+     * <p>
+     * Important pre-requisite: set simple logger log level to same level as the SDK_LOG_LEVEL, for example via VM
+     * options: -Dorg.slf4j.simpleLogger.log.com.hedera.hashgraph=trace
+     */
+    private static final String SDK_LOG_LEVEL = Dotenv.load().get("SDK_LOG_LEVEL", "SILENT");
+
+    public static void main(String[] args) throws Exception {
+        /*
+         * Step 0:
+         * Create and configure the SDK Client.
+         */
+        Client client = Client.forMirrorNetwork(List.of("testnet.mirrornode.hedera.com:443"));
+        // All generated transactions will be paid by this account and signed by this key.
+        client.setOperator(OPERATOR_ID, OPERATOR_KEY);
+        // Attach logger to the SDK Client.
+        client.setLogger(new Logger(LogLevel.valueOf(SDK_LOG_LEVEL)));
+
+        /*
+         * Step 1:
+         * Generate ED25519 key pair.
+         */
+        System.out.println("Generating ED25519 key pair...");
+        PrivateKey privateKey = PrivateKey.generateED25519();
+
+        /*
+         * Step 2:
+         * Create account
+         */
+        AccountId aliceId = new AccountCreateTransaction()
+            .setKey(privateKey)
+            .setInitialBalance(Hbar.from(5))
+            .execute(client)
+            .getReceipt(client)
+            .accountId;
+        Objects.requireNonNull(aliceId);
+        System.out.println("Alice's account ID: " + aliceId);
+    }
+}

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.examples.java.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.examples.java.gradle.kts
@@ -69,6 +69,7 @@ abstract class RunAllExample : DefaultTask() {
             .map { it.name.replace(".java", "") }
             .filter { it != "ValidateChecksumExample" } // disabled this example, because it needs user input (but it WORKS)
             .filter { it != "ConsensusPubSubChunkedExample" } // is flaky on local-node env, will be investigated
+            .filter { it != "InitializeClientWithMirrorNetworkExample" } // disabled - cannot run on localnode
             .toList()
 
         exampleClasses.forEach { className ->

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Client.java
@@ -186,6 +186,24 @@ public final class Client implements AutoCloseable {
     }
 
     /**
+     * Set up the client from selected mirror network.
+     *
+     * @param mirrorNetworkList
+     * @return
+     */
+    public static Client forMirrorNetwork(List<String> mirrorNetworkList) throws InterruptedException, TimeoutException {
+        var executor = createExecutor();
+        var network = Network.forNetwork(executor, new HashMap<>());
+        var mirrorNetwork = MirrorNetwork.forNetwork(executor, mirrorNetworkList);
+        var client = new Client(executor, network, mirrorNetwork, null, true, null);
+        var addressBook = new AddressBookQuery()
+            .setFileId(FileId.ADDRESS_BOOK)
+            .execute(client);
+        client.setNetworkFromAddressBook(addressBook);
+        return client;
+    }
+
+    /**
      * Set up the client for the selected network.
      *
      * @param name the selected network
@@ -1418,8 +1436,8 @@ public final class Client implements AutoCloseable {
         private Client initializeWithNetwork() throws Exception {
             if (network == null) {
                 throw new Exception("Network is not set in provided json object");
-            }  
-            
+            }
+
             Client client;
             if (network.isJsonObject()) {
                 client = clientFromNetworkJson();
@@ -1501,7 +1519,6 @@ public final class Client implements AutoCloseable {
             if (operator != null) {
                 AccountId operatorAccount = AccountId.fromString(operator.accountId);
                 PrivateKey privateKey = PrivateKey.fromString(operator.privateKey);
-        
                 client.setOperator(operatorAccount, privateKey);
             }
         }

--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ClientIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ClientIntegrationTest.java
@@ -21,6 +21,7 @@ package com.hedera.hashgraph.sdk.test.integration;
 
 import com.hedera.hashgraph.sdk.*;
 import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import java.time.Duration;
@@ -247,5 +248,18 @@ public class ClientIntegrationTest {
                 .execute(testEnv.client);
 
         }
+    }
+
+    @Test
+    @DisplayName("`forMirrorNetwork()`")
+    void testClientInitWithMirrorNetwork() throws Exception {
+        var mirrorNetworkString = "testnet.mirrornode.hedera.com:443";
+        var client = Client.forMirrorNetwork(List.of(mirrorNetworkString));
+        var mirrorNetwork = client.getMirrorNetwork();
+
+        assertThat(mirrorNetwork).hasSize(1);
+        assertThat(mirrorNetwork.get(0)).isEqualTo(mirrorNetworkString);
+        assertThat(client.getNetwork()).isNotNull();
+        assertThat(client.getNetwork()).isNotEmpty();
     }
 }


### PR DESCRIPTION
**Description**:

There should be an option that allows for the initialization of the Client's consensus node network automatically with an AddressBookQuery to the mirror node.

**Related issue(s)**:

Fixes #2058

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
