### PR TITLE
chore: fix serialize/deserialize for `NodeUpdate` and `NodeCreate`

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/NodeCreateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/NodeCreateTransaction.java
@@ -194,7 +194,6 @@ public class NodeCreateTransaction extends Transaction<NodeCreateTransaction> {
      * @return {@code this}
      */
     public NodeCreateTransaction setAccountId(AccountId accountId) {
-        Objects.requireNonNull(accountId);
         requireNotFrozen();
         this.accountId = accountId;
         return this;
@@ -215,7 +214,6 @@ public class NodeCreateTransaction extends Transaction<NodeCreateTransaction> {
      */
     public NodeCreateTransaction setDescription(String description) {
         requireNotFrozen();
-        Objects.requireNonNull(description);
         this.description = description;
         return this;
     }
@@ -288,7 +286,7 @@ public class NodeCreateTransaction extends Transaction<NodeCreateTransaction> {
      */
     @Nullable
     public byte[] getGossipCaCertificate() {
-        return gossipCaCertificate != null ? Arrays.copyOf(gossipCaCertificate, gossipCaCertificate.length) : null;
+        return gossipCaCertificate;
     }
 
     /**
@@ -299,9 +297,8 @@ public class NodeCreateTransaction extends Transaction<NodeCreateTransaction> {
      * @return {@code this}
      */
     public NodeCreateTransaction setGossipCaCertificate(byte[] gossipCaCertificate) {
-        Objects.requireNonNull(gossipCaCertificate);
         requireNotFrozen();
-        this.gossipCaCertificate = Arrays.copyOf(gossipCaCertificate, gossipCaCertificate.length);
+        this.gossipCaCertificate = gossipCaCertificate;
         return this;
     }
 
@@ -311,7 +308,7 @@ public class NodeCreateTransaction extends Transaction<NodeCreateTransaction> {
      */
     @Nullable
     public byte[] getGrpcCertificateHash() {
-        return grpcCertificateHash != null ? Arrays.copyOf(grpcCertificateHash, grpcCertificateHash.length) : null;
+        return grpcCertificateHash;
     }
 
     /**
@@ -322,9 +319,8 @@ public class NodeCreateTransaction extends Transaction<NodeCreateTransaction> {
      * @return {@code this}
      */
     public NodeCreateTransaction setGrpcCertificateHash(byte[] grpcCertificateHash) {
-        Objects.requireNonNull(grpcCertificateHash);
         requireNotFrozen();
-        this.grpcCertificateHash = Arrays.copyOf(grpcCertificateHash, grpcCertificateHash.length);
+        this.grpcCertificateHash = grpcCertificateHash;
         return this;
     }
 
@@ -343,7 +339,6 @@ public class NodeCreateTransaction extends Transaction<NodeCreateTransaction> {
      * @return {@code this}
      */
     public NodeCreateTransaction setAdminKey(Key adminKey) {
-        Objects.requireNonNull(adminKey);
         requireNotFrozen();
         this.adminKey = adminKey;
         return this;
@@ -406,9 +401,11 @@ public class NodeCreateTransaction extends Transaction<NodeCreateTransaction> {
             serviceEndpoints.add(Endpoint.fromProtobuf(serviceEndpoint));
         }
 
-        gossipCaCertificate = body.getGossipCaCertificate().toByteArray();
+        var protobufGossipCert = body.getGossipCaCertificate();
+        gossipCaCertificate = protobufGossipCert.equals(ByteString.empty()) ? null : protobufGossipCert.toByteArray();
 
-        grpcCertificateHash = body.getGrpcCertificateHash().toByteArray();
+        var protobufGrpcCert = body.getGrpcCertificateHash();
+        grpcCertificateHash = protobufGrpcCert.equals(ByteString.empty()) ? null : protobufGrpcCert.toByteArray();
 
         if (body.hasAdminKey()) {
             adminKey = Key.fromProtobufKey(body.getAdminKey());

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/NodeUpdateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/NodeUpdateTransaction.java
@@ -464,13 +464,13 @@ public class NodeUpdateTransaction extends Transaction<NodeUpdateTransaction> {
             serviceEndpoints.add(Endpoint.fromProtobuf(serviceEndpoint));
         }
 
-        var protobufGossipCert = body.getGossipCaCertificate();
-        gossipCaCertificate = protobufGossipCert.equals(BytesValue.getDefaultInstance()) ?
-            null : protobufGossipCert.getValue().toByteArray();
+        if (body.hasGossipCaCertificate()) {
+            gossipCaCertificate = body.getGossipCaCertificate().getValue().toByteArray();
+        }
 
-        var protobufGrpcCert = body.getGrpcCertificateHash();
-        grpcCertificateHash = protobufGrpcCert.equals(BytesValue.getDefaultInstance()) ?
-            null : protobufGrpcCert.getValue().toByteArray();
+        if (body.hasGrpcCertificateHash()) {
+            grpcCertificateHash = body.getGrpcCertificateHash().getValue().toByteArray();
+        }
 
         if (body.hasAdminKey()) {
             adminKey = Key.fromProtobufKey(body.getAdminKey());

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/NodeUpdateTransaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/NodeUpdateTransaction.java
@@ -240,7 +240,6 @@ public class NodeUpdateTransaction extends Transaction<NodeUpdateTransaction> {
      * @return {@code this}
      */
     public NodeUpdateTransaction setAccountId(AccountId accountId) {
-        Objects.requireNonNull(accountId);
         requireNotFrozen();
         this.accountId = accountId;
         return this;
@@ -262,7 +261,6 @@ public class NodeUpdateTransaction extends Transaction<NodeUpdateTransaction> {
      */
     public NodeUpdateTransaction setDescription(String description) {
         requireNotFrozen();
-        Objects.requireNonNull(description);
         this.description = description;
         return this;
     }
@@ -345,7 +343,7 @@ public class NodeUpdateTransaction extends Transaction<NodeUpdateTransaction> {
      */
     @Nullable
     public byte[] getGossipCaCertificate() {
-        return gossipCaCertificate != null ? Arrays.copyOf(gossipCaCertificate, gossipCaCertificate.length) : null;
+        return gossipCaCertificate;
     }
 
     /**
@@ -356,9 +354,8 @@ public class NodeUpdateTransaction extends Transaction<NodeUpdateTransaction> {
      * @return {@code this}
      */
     public NodeUpdateTransaction setGossipCaCertificate(byte[] gossipCaCertificate) {
-        Objects.requireNonNull(gossipCaCertificate);
         requireNotFrozen();
-        this.gossipCaCertificate = Arrays.copyOf(gossipCaCertificate, gossipCaCertificate.length);
+        this.gossipCaCertificate = gossipCaCertificate;
         return this;
     }
 
@@ -368,7 +365,7 @@ public class NodeUpdateTransaction extends Transaction<NodeUpdateTransaction> {
      */
     @Nullable
     public byte[] getGrpcCertificateHash() {
-        return grpcCertificateHash != null ? Arrays.copyOf(grpcCertificateHash, grpcCertificateHash.length) : null;
+        return grpcCertificateHash;
     }
 
     /**
@@ -379,9 +376,8 @@ public class NodeUpdateTransaction extends Transaction<NodeUpdateTransaction> {
      * @return {@code this}
      */
     public NodeUpdateTransaction setGrpcCertificateHash(byte[] grpcCertificateHash) {
-        Objects.requireNonNull(grpcCertificateHash);
         requireNotFrozen();
-        this.grpcCertificateHash = Arrays.copyOf(grpcCertificateHash, grpcCertificateHash.length);
+        this.grpcCertificateHash = grpcCertificateHash;
         return this;
     }
 
@@ -400,7 +396,6 @@ public class NodeUpdateTransaction extends Transaction<NodeUpdateTransaction> {
      * @return {@code this}
      */
     public NodeUpdateTransaction setAdminKey(Key adminKey) {
-        Objects.requireNonNull(adminKey);
         requireNotFrozen();
         this.adminKey = adminKey;
         return this;
@@ -469,9 +464,13 @@ public class NodeUpdateTransaction extends Transaction<NodeUpdateTransaction> {
             serviceEndpoints.add(Endpoint.fromProtobuf(serviceEndpoint));
         }
 
-        gossipCaCertificate = body.getGossipCaCertificate().getValue().toByteArray();
+        var protobufGossipCert = body.getGossipCaCertificate();
+        gossipCaCertificate = protobufGossipCert.equals(BytesValue.getDefaultInstance()) ?
+            null : protobufGossipCert.getValue().toByteArray();
 
-        grpcCertificateHash = body.getGrpcCertificateHash().getValue().toByteArray();
+        var protobufGrpcCert = body.getGrpcCertificateHash();
+        grpcCertificateHash = protobufGrpcCert.equals(BytesValue.getDefaultInstance()) ?
+            null : protobufGrpcCert.getValue().toByteArray();
 
         if (body.hasAdminKey()) {
             adminKey = Key.fromProtobufKey(body.getAdminKey());

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeCreateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeCreateTransactionTest.java
@@ -123,6 +123,27 @@ public class NodeCreateTransactionTest {
     }
 
     @Test
+    void testSerializeDeserialize() throws Exception {
+        var tx = new NodeCreateTransaction().setDescription(TEST_DESCRIPTION);
+        var tx2 = new NodeCreateTransaction().setDescription(TEST_DESCRIPTION);
+        var tx2Bytes = tx2.toBytes();
+        NodeCreateTransaction deserializedTx2 = (NodeCreateTransaction) Transaction.fromBytes(tx2Bytes);
+        assertThat(tx.getGossipCaCertificate()).isEqualTo(deserializedTx2.getGossipCaCertificate());
+        assertThat(tx.getGrpcCertificateHash()).isEqualTo(deserializedTx2.getGrpcCertificateHash());
+    }
+
+    @Test
+    void testSetNull()  {
+        new NodeCreateTransaction()
+            .setDescription(null)
+            .setAccountId(null)
+            .setGossipCaCertificate(null)
+            .setGrpcCertificateHash(null)
+            .setAdminKey(null);
+    }
+
+
+    @Test
     void constructNodeCreateTransactionFromTransactionBodyProtobuf() {
         var transactionBodyBuilder = NodeCreateTransactionBody.newBuilder();
 

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeUpdateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeUpdateTransactionTest.java
@@ -116,14 +116,25 @@ public class NodeUpdateTransactionTest {
         var tx2 = NodeUpdateTransaction.fromBytes(tx.toBytes());
         assertThat(tx2.toString()).isEqualTo(tx.toString());
     }
+
     @Test
-    void testSerializeDeserialize() throws Exception {
-        var tx = new NodeUpdateTransaction().setDescription(TEST_DESCRIPTION);
-        var tx2 = new NodeUpdateTransaction().setDescription(TEST_DESCRIPTION);
-        var tx2Bytes = tx2.toBytes();
-        NodeUpdateTransaction deserializedTx2 = (NodeUpdateTransaction) Transaction.fromBytes(tx2Bytes);
-        assertThat(tx.getGossipCaCertificate()).isEqualTo(deserializedTx2.getGossipCaCertificate());
-        assertThat(tx.getGrpcCertificateHash()).isEqualTo(deserializedTx2.getGrpcCertificateHash());
+    void testNullCertificates() throws Exception {
+        var tx = new NodeUpdateTransaction();
+        var tx2Bytes = tx.toBytes();
+        NodeUpdateTransaction deserializedTx = (NodeUpdateTransaction) Transaction.fromBytes(tx2Bytes);
+        assertThat(deserializedTx.getGossipCaCertificate()).isNull();
+        assertThat(deserializedTx.getGrpcCertificateHash()).isNull();
+    }
+
+    @Test
+    void testEmptyCertificates() throws Exception {
+        var tx = new NodeUpdateTransaction()
+            .setGossipCaCertificate(new byte[]{})
+            .setGrpcCertificateHash(new byte[]{});
+        var tx2Bytes = tx.toBytes();
+        NodeUpdateTransaction deserializedTx = (NodeUpdateTransaction) Transaction.fromBytes(tx2Bytes);
+        assertThat(deserializedTx.getGossipCaCertificate()).isEqualTo(new byte[]{});
+        assertThat(deserializedTx.getGrpcCertificateHash()).isEqualTo(new byte[]{});
     }
 
     @Test

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeUpdateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeUpdateTransactionTest.java
@@ -99,7 +99,6 @@ public class NodeUpdateTransactionTest {
             .setTransactionId(TransactionId.withValidStart(AccountId.fromString("0.0.5006"), TEST_VALID_START))
             .setNodeId(TEST_NODE_ID)
             .setAccountId(TEST_ACCOUNT_ID)
-            .setAccountId(TEST_ACCOUNT_ID)
             .setDescription(TEST_DESCRIPTION)
             .setGossipEndpoints(TEST_GOSSIP_ENDPOINTS)
             .setServiceEndpoints(TEST_SERVICE_ENDPOINTS)
@@ -116,6 +115,25 @@ public class NodeUpdateTransactionTest {
         var tx = spawnTestTransaction();
         var tx2 = NodeUpdateTransaction.fromBytes(tx.toBytes());
         assertThat(tx2.toString()).isEqualTo(tx.toString());
+    }
+    @Test
+    void testSerializeDeserialize() throws Exception {
+        var tx = new NodeUpdateTransaction().setDescription(TEST_DESCRIPTION);
+        var tx2 = new NodeUpdateTransaction().setDescription(TEST_DESCRIPTION);
+        var tx2Bytes = tx2.toBytes();
+        NodeUpdateTransaction deserializedTx2 = (NodeUpdateTransaction) Transaction.fromBytes(tx2Bytes);
+        assertThat(tx.getGossipCaCertificate()).isEqualTo(deserializedTx2.getGossipCaCertificate());
+        assertThat(tx.getGrpcCertificateHash()).isEqualTo(deserializedTx2.getGrpcCertificateHash());
+    }
+
+    @Test
+    void testSetNull()  {
+        new NodeUpdateTransaction()
+            .setDescription(null)
+            .setAccountId(null)
+            .setGossipCaCertificate(null)
+            .setGrpcCertificateHash(null)
+            .setAdminKey(null);
     }
 
     @Test


### PR DESCRIPTION
**Description**:

This PR fixes:
1. `NodeCreate` and NodeUpdate have nullable fields that cannot be set to null.
2. `NodeUpdateTransaction` gossip and grpc certificate bytes deserialize to empty `ByteValue`/`ByteString`

**Related issue(s)**:

Fixes #2090 #2091

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
