### PR TITLE
fix(Android): Executing transaction fails at runtime

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNode.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/BaseNode.java
@@ -363,18 +363,8 @@ abstract class BaseNode<N extends BaseNode<N, KeyT>, KeyT> {
      * @return                          the user agent string
      */
     private String getUserAgent() {
-        var theModule = getClass().getModule();
         var thePackage = getClass().getPackage();
-        String implementationVersion;
-        if (theModule.getName() == null) {
-            // running on classpath
-            implementationVersion =
-                thePackage != null ? thePackage.getImplementationVersion() : null;
-        } else {
-            // running on module path
-            implementationVersion =
-                theModule.getDescriptor().version().map(ModuleDescriptor.Version::toString).orElse(null);
-        }
+        var implementationVersion = thePackage != null ? thePackage.getImplementationVersion() : null;
         return "hedera-sdk-java/" + ((implementationVersion != null) ? ("v" + implementationVersion) : "DEV");
     }
 }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/TransactionId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/TransactionId.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
@@ -69,7 +70,6 @@ public final class TransactionId implements Comparable<TransactionId> {
 
     private static final long NANOSECONDS_TO_REMOVE = 10000000000L;
 
-    private static final Random randomNanosecs = new Random();
     private static final AtomicLong monotonicTime = new AtomicLong();
 
 
@@ -128,7 +128,8 @@ public final class TransactionId implements Comparable<TransactionId> {
             }
         } while (!monotonicTime.compareAndSet(lastTime, currentTime));
 
-        return new TransactionId(accountId, Instant.ofEpochSecond(0, currentTime + randomNanosecs.nextLong(1_000)));
+        // NOTE: using ThreadLocalRandom because it's compatible with Android SDK version 26
+        return new TransactionId(accountId, Instant.ofEpochSecond(0, currentTime + ThreadLocalRandom.current().nextLong(1_000)));
     }
 
     /**


### PR DESCRIPTION
**Description**:

- Replaces `getModule()` and `Random` , because it's not compatible with Android API 26

**Related issue(s)**:

Fixes #2095

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
