### PR TITLE
fix: Do not override service port

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Endpoint.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Endpoint.java
@@ -53,10 +53,6 @@ public class Endpoint implements Cloneable {
     static Endpoint fromProtobuf(ServiceEndpoint serviceEndpoint) {
         var port = (int) (serviceEndpoint.getPort() & 0x00000000ffffffffL);
 
-        if (port == 0 || port == 50111) {
-            port = 50211;
-        }
-
         return new Endpoint()
             .setAddress(serviceEndpoint.getIpAddressV4().toByteArray())
             .setPort(port)

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeCreateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeCreateTransactionTest.java
@@ -123,13 +123,23 @@ public class NodeCreateTransactionTest {
     }
 
     @Test
-    void testSerializeDeserialize() throws Exception {
-        var tx = new NodeCreateTransaction().setDescription(TEST_DESCRIPTION);
-        var tx2 = new NodeCreateTransaction().setDescription(TEST_DESCRIPTION);
-        var tx2Bytes = tx2.toBytes();
-        NodeCreateTransaction deserializedTx2 = (NodeCreateTransaction) Transaction.fromBytes(tx2Bytes);
-        assertThat(tx.getGossipCaCertificate()).isEqualTo(deserializedTx2.getGossipCaCertificate());
-        assertThat(tx.getGrpcCertificateHash()).isEqualTo(deserializedTx2.getGrpcCertificateHash());
+    void testUnrecognizedServicePort() throws Exception {
+        var tx = new NodeCreateTransaction()
+            .setServiceEndpoints(
+         List.of(new Endpoint()
+            .setAddress(new byte[] {0x00, 0x01, 0x02, 0x03})
+            .setDomainName("unit.test.com")
+            .setPort(50111)));
+        var tx2Bytes = tx.toBytes();
+        NodeCreateTransaction deserializedTx = (NodeCreateTransaction) Transaction.fromBytes(tx2Bytes);
+        assertThat(tx.getServiceEndpoints()).isEqualTo(deserializedTx.getServiceEndpoints());
+    }
+
+    @Test
+    void testNullOptionalValues() throws Exception {
+        var tx = new NodeCreateTransaction();
+        var tx2 = NodeCreateTransaction.fromBytes(tx.toBytes());
+        assertThat(tx2.toString()).isEqualTo(tx.toString());
     }
 
     @Test

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeCreateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeCreateTransactionTest.java
@@ -61,7 +61,7 @@ public class NodeCreateTransactionTest {
     private static final byte[] TEST_GRPC_CERTIFICATE_HASH = new byte[]{5, 6, 7, 8, 9};
 
     private static final PublicKey TEST_ADMIN_KEY = PrivateKey.fromString(
-        "302e020100300506032b65700422042062c4b69e9f45a554e5424fb5a6fe5e6ac1f19ead31dc7718c2d980fd1f998d4b")
+            "302e020100300506032b65700422042062c4b69e9f45a554e5424fb5a6fe5e6ac1f19ead31dc7718c2d980fd1f998d4b")
         .getPublicKey();
 
     final Instant TEST_VALID_START = Instant.ofEpochSecond(1554158542);
@@ -83,7 +83,7 @@ public class NodeCreateTransactionTest {
 
     private static Endpoint spawnTestEndpoint(byte offset) {
         return new Endpoint()
-            .setAddress(new byte[] {0x00, 0x01, 0x02, 0x03})
+            .setAddress(new byte[]{0x00, 0x01, 0x02, 0x03})
             .setDomainName(offset + "unit.test.com")
             .setPort(42 + offset);
     }
@@ -126,13 +126,12 @@ public class NodeCreateTransactionTest {
     void testUnrecognizedServicePort() throws Exception {
         var tx = new NodeCreateTransaction()
             .setServiceEndpoints(
-         List.of(new Endpoint()
-            .setAddress(new byte[] {0x00, 0x01, 0x02, 0x03})
-            .setDomainName("unit.test.com")
-            .setPort(50111)));
-        var tx2Bytes = tx.toBytes();
-        NodeCreateTransaction deserializedTx = (NodeCreateTransaction) Transaction.fromBytes(tx2Bytes);
-        assertThat(tx.getServiceEndpoints()).isEqualTo(deserializedTx.getServiceEndpoints());
+                List.of(new Endpoint()
+                    .setAddress(new byte[]{0x00, 0x01, 0x02, 0x03})
+                    .setDomainName("unit.test.com")
+                    .setPort(50111)));
+        var tx2 = NodeCreateTransaction.fromBytes(tx.toBytes());
+        assertThat(tx2.toString()).isEqualTo(tx.toString());
     }
 
     @Test
@@ -143,7 +142,7 @@ public class NodeCreateTransactionTest {
     }
 
     @Test
-    void testSetNull()  {
+    void testSetNull() {
         new NodeCreateTransaction()
             .setDescription(null)
             .setAccountId(null)

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeUpdateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeUpdateTransactionTest.java
@@ -87,7 +87,7 @@ public class NodeUpdateTransactionTest {
 
     private static Endpoint spawnTestEndpoint(byte offset) {
         return new Endpoint()
-            .setAddress(new byte[] {0x00, 0x01, 0x02, 0x03})
+            .setAddress(new byte[]{0x00, 0x01, 0x02, 0x03})
             .setDomainName(offset + "unit.test.com")
             .setPort(42 + offset);
     }
@@ -129,7 +129,7 @@ public class NodeUpdateTransactionTest {
         var tx = new NodeUpdateTransaction()
             .setServiceEndpoints(
                 List.of(new Endpoint()
-                    .setAddress(new byte[] {0x00, 0x01, 0x02, 0x03})
+                    .setAddress(new byte[]{0x00, 0x01, 0x02, 0x03})
                     .setDomainName("unit.test.com")
                     .setPort(50111)));
         var tx2 = NodeUpdateTransaction.fromBytes(tx.toBytes());
@@ -148,7 +148,7 @@ public class NodeUpdateTransactionTest {
     }
 
     @Test
-    void testSetNull()  {
+    void testSetNull() {
         new NodeUpdateTransaction()
             .setDescription(null)
             .setAccountId(null)

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeUpdateTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/NodeUpdateTransactionTest.java
@@ -120,11 +120,20 @@ public class NodeUpdateTransactionTest {
     @Test
     void testNullOptionalValues() throws Exception {
         var tx = new NodeUpdateTransaction();
-        var tx2Bytes = tx.toBytes();
-        NodeUpdateTransaction deserializedTx = (NodeUpdateTransaction) Transaction.fromBytes(tx2Bytes);
-        assertThat(deserializedTx.getGossipCaCertificate()).isNull();
-        assertThat(deserializedTx.getGrpcCertificateHash()).isNull();
-        assertThat(deserializedTx.getDescription()).isNull();
+        var tx2 = NodeUpdateTransaction.fromBytes(tx.toBytes());
+        assertThat(tx2.toString()).isEqualTo(tx.toString());
+    }
+
+    @Test
+    void testUnrecognizedServicePort() throws Exception {
+        var tx = new NodeUpdateTransaction()
+            .setServiceEndpoints(
+                List.of(new Endpoint()
+                    .setAddress(new byte[] {0x00, 0x01, 0x02, 0x03})
+                    .setDomainName("unit.test.com")
+                    .setPort(50111)));
+        var tx2 = NodeUpdateTransaction.fromBytes(tx.toBytes());
+        assertThat(tx2.toString()).isEqualTo(tx.toString());
     }
 
     @Test


### PR DESCRIPTION
**Description**:

This PR fixes `Endpoint` overriding the port if it is 0 or 50111

**Related issue(s)**:

Fixes #2098

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
