### PR TITLE
feat: Add validation for creating `PublicKey` from bytes.

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Key.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Key.java
@@ -61,7 +61,7 @@ public abstract class Key {
                 if (key.getECDSASecp256K1().size() == 20) {
                     return new EvmAddress(key.getECDSASecp256K1().toByteArray());
                 } else {
-                    return new PublicKeyECDSA(key.getECDSASecp256K1().toByteArray());
+                    return PublicKeyECDSA.fromBytesInternal(key.getECDSASecp256K1().toByteArray());
                 }
             }
             case KEYLIST -> {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Key.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Key.java
@@ -55,7 +55,7 @@ public abstract class Key {
     static Key fromProtobufKey(com.hedera.hashgraph.sdk.proto.Key key) {
         switch (key.getKeyCase()) {
             case ED25519 -> {
-                return new PublicKeyED25519(key.getEd25519().toByteArray());
+                return PublicKeyED25519.fromBytesInternal(key.getEd25519().toByteArray());
             }
             case ECDSA_SECP256K1 -> {
                 if (key.getECDSASecp256K1().size() == 20) {

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/PrivateKeyECDSA.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/PrivateKeyECDSA.java
@@ -218,7 +218,7 @@ public class PrivateKeyECDSA extends PrivateKey {
 
         var q = ECDSA_SECP256K1_DOMAIN.getG().multiply(keyData);
         var publicParams = new ECPublicKeyParameters(q, ECDSA_SECP256K1_DOMAIN);
-        publicKey = new PublicKeyECDSA(publicParams.getQ().getEncoded(true));
+        publicKey = PublicKeyECDSA.fromBytesInternal(publicParams.getQ().getEncoded(true));
         return publicKey;
     }
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/PrivateKeyED25519.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/PrivateKeyED25519.java
@@ -221,7 +221,7 @@ class PrivateKeyED25519 extends PrivateKey {
         byte[] publicKeyData = new byte[Ed25519.PUBLIC_KEY_SIZE];
         Ed25519.generatePublicKey(keyData, 0, publicKeyData, 0);
 
-        publicKey = new PublicKeyED25519(publicKeyData);
+        publicKey = PublicKeyED25519.fromBytesInternal(publicKeyData);
         return publicKey;
     }
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/PrivateKeyED25519.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/PrivateKeyED25519.java
@@ -20,6 +20,12 @@
 package com.hedera.hashgraph.sdk;
 
 import com.hedera.hashgraph.sdk.utils.Bip32Utils;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import javax.annotation.Nullable;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
@@ -29,13 +35,6 @@ import org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator;
 import org.bouncycastle.crypto.macs.HMac;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.math.ec.rfc8032.Ed25519;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 /**
  * Encapsulate the ED25519 private key.
@@ -52,7 +51,7 @@ class PrivateKeyED25519 extends PrivateKey {
      * @param keyData                   the key data
      * @param chainCode                 the chain code
      */
-    PrivateKeyED25519(byte[] keyData, @Nullable KeyParameter chainCode) {
+    private PrivateKeyED25519(byte[] keyData, @Nullable KeyParameter chainCode) {
         this.keyData = keyData;
         this.chainCode = chainCode;
     }
@@ -126,7 +125,10 @@ class PrivateKeyED25519 extends PrivateKey {
         if ((privateKey.length == Ed25519.SECRET_KEY_SIZE)
             || (privateKey.length == Ed25519.SECRET_KEY_SIZE + Ed25519.PUBLIC_KEY_SIZE)) {
             // If this is a 32 or 64 byte string, assume an Ed25519 private key
-            return new PrivateKeyED25519(Arrays.copyOfRange(privateKey, 0, Ed25519.SECRET_KEY_SIZE), null);
+            // TODO
+            var pk = new PrivateKeyED25519(Arrays.copyOfRange(privateKey, 0, Ed25519.SECRET_KEY_SIZE), null);
+            pk.getPublicKey();
+            return pk;
         }
 
         // Assume a DER-encoded private key descriptor

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/PrivateKeyED25519.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/PrivateKeyED25519.java
@@ -51,7 +51,7 @@ class PrivateKeyED25519 extends PrivateKey {
      * @param keyData                   the key data
      * @param chainCode                 the chain code
      */
-    private PrivateKeyED25519(byte[] keyData, @Nullable KeyParameter chainCode) {
+    PrivateKeyED25519(byte[] keyData, @Nullable KeyParameter chainCode) {
         this.keyData = keyData;
         this.chainCode = chainCode;
     }
@@ -125,10 +125,7 @@ class PrivateKeyED25519 extends PrivateKey {
         if ((privateKey.length == Ed25519.SECRET_KEY_SIZE)
             || (privateKey.length == Ed25519.SECRET_KEY_SIZE + Ed25519.PUBLIC_KEY_SIZE)) {
             // If this is a 32 or 64 byte string, assume an Ed25519 private key
-            // TODO
-            var pk = new PrivateKeyED25519(Arrays.copyOfRange(privateKey, 0, Ed25519.SECRET_KEY_SIZE), null);
-            pk.getPublicKey();
-            return pk;
+            return new PrivateKeyED25519(Arrays.copyOfRange(privateKey, 0, Ed25519.SECRET_KEY_SIZE), null);
         }
 
         // Assume a DER-encoded private key descriptor

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/PublicKey.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/PublicKey.java
@@ -46,10 +46,10 @@ public abstract class PublicKey extends Key {
             return new PublicKeyED25519(publicKey);
         } else if (publicKey.length == 33) {
             // compressed 33 byte raw form
-            return new PublicKeyECDSA(publicKey);
+            return PublicKeyECDSA.fromBytesInternal(publicKey);
         } else if (publicKey.length == 65) {
             // compress the 65 byte form
-            return new PublicKeyECDSA(
+            return PublicKeyECDSA.fromBytesInternal(
                 Key.ECDSA_SECP256K1_CURVE.getCurve().decodePoint(publicKey).getEncoded(true)
             );
         }

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/PublicKey.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/PublicKey.java
@@ -43,7 +43,7 @@ public abstract class PublicKey extends Key {
     public static PublicKey fromBytes(byte[] publicKey) {
         if (publicKey.length == Ed25519.PUBLIC_KEY_SIZE) {
             // If this is a 32 byte string, assume an Ed25519 public key
-            return new PublicKeyED25519(publicKey);
+            return PublicKeyED25519.fromBytesInternal(publicKey);
         } else if (publicKey.length == 33) {
             // compressed 33 byte raw form
             return PublicKeyECDSA.fromBytesInternal(publicKey);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/PublicKeyECDSA.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/PublicKeyECDSA.java
@@ -19,18 +19,17 @@
  */
 package com.hedera.hashgraph.sdk;
 
+import static com.hedera.hashgraph.sdk.Crypto.calcKeccak256;
+
 import com.google.protobuf.ByteString;
 import com.hedera.hashgraph.sdk.proto.SignaturePair;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Arrays;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.crypto.params.ECPublicKeyParameters;
 import org.bouncycastle.crypto.signers.ECDSASigner;
-
-import java.io.IOException;
-import java.math.BigInteger;
-import java.util.Arrays;
-
-import static com.hedera.hashgraph.sdk.Crypto.calcKeccak256;
 
 /**
  * Encapsulate the ECDSA public key.
@@ -44,7 +43,7 @@ public class PublicKeyECDSA extends PublicKey {
      *
      * @param keyData                   the byte array representing the key
      */
-    PublicKeyECDSA(byte[] keyData) {
+    private PublicKeyECDSA(byte[] keyData) {
         this.keyData = keyData;
     }
 
@@ -55,14 +54,10 @@ public class PublicKeyECDSA extends PublicKey {
      * @return                          the new key
      */
     static PublicKeyECDSA fromBytesInternal(byte[] publicKey) {
-        if (publicKey.length == 33) {
-            // compressed 33 byte raw form
-            return new PublicKeyECDSA(publicKey);
-        } else if (publicKey.length == 65) {
-            // compress the 65 byte form
+        if (publicKey.length == 33 || publicKey.length == 65) {
             return new PublicKeyECDSA(
-                Key.ECDSA_SECP256K1_CURVE.getCurve().decodePoint(publicKey).getEncoded(true)
-            );
+                // compress the key
+                Key.ECDSA_SECP256K1_CURVE.getCurve().decodePoint(publicKey).getEncoded(true));
         }
 
         // Assume a DER-encoded public key descriptor

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/PublicKeyECDSA.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/PublicKeyECDSA.java
@@ -56,7 +56,7 @@ public class PublicKeyECDSA extends PublicKey {
     static PublicKeyECDSA fromBytesInternal(byte[] publicKey) {
         if (publicKey.length == 33 || publicKey.length == 65) {
             return new PublicKeyECDSA(
-                // compress the key
+                // compress and validate the key
                 Key.ECDSA_SECP256K1_CURVE.getCurve().decodePoint(publicKey).getEncoded(true));
         }
 

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/PublicKeyED25519.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/PublicKeyED25519.java
@@ -53,7 +53,7 @@ class PublicKeyED25519 extends PublicKey {
      */
     static PublicKeyED25519 fromBytesInternal(byte[] publicKey) {
         if (publicKey.length == Ed25519.PUBLIC_KEY_SIZE) {
-            // Will throw if the keys is invalid
+            // Will throw if the key is invalid
             new Ed25519PublicKeyParameters(publicKey, 0);
             // If this is a 32 byte string, assume an Ed25519 public key
             return new PublicKeyED25519(publicKey);

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/PublicKeyED25519.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/PublicKeyED25519.java
@@ -23,6 +23,7 @@ import com.google.protobuf.ByteString;
 import com.hedera.hashgraph.sdk.proto.SignaturePair;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
 import org.bouncycastle.math.ec.rfc8032.Ed25519;
 
 import javax.annotation.Nullable;
@@ -40,7 +41,7 @@ class PublicKeyED25519 extends PublicKey {
      *
      * @param keyData                   the byte array representing the key
      */
-    PublicKeyED25519(byte[] keyData) {
+    private PublicKeyED25519(byte[] keyData) {
         this.keyData = keyData;
     }
 
@@ -52,6 +53,8 @@ class PublicKeyED25519 extends PublicKey {
      */
     static PublicKeyED25519 fromBytesInternal(byte[] publicKey) {
         if (publicKey.length == Ed25519.PUBLIC_KEY_SIZE) {
+            // Will throw if the keys is invalid
+            new Ed25519PublicKeyParameters(publicKey, 0);
             // If this is a 32 byte string, assume an Ed25519 public key
             return new PublicKeyED25519(publicKey);
         }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ECDSAPublicKeyTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ECDSAPublicKeyTest.java
@@ -77,7 +77,7 @@ public class ECDSAPublicKeyTest {
         assertThatExceptionOfType(IllegalArgumentException.class)
             .isThrownBy(() -> PublicKey.fromBytesECDSA(invalidKeyECDSA));
 
-        byte[] malformedKey = new byte[]{0x00, 0x01, 0x02}; // Malformed key
+        byte[] malformedKey = new byte[]{0x00, 0x01, 0x02};
         assertThatExceptionOfType(IllegalArgumentException.class)
             .isThrownBy(() -> PublicKey.fromBytesECDSA(malformedKey));
 
@@ -90,7 +90,7 @@ public class ECDSAPublicKeyTest {
         };
         assertDoesNotThrow(() -> PublicKey.fromBytesECDSA(validCompressedKey));
 
-        byte[] validDERKey = PrivateKeyECDSA.generateECDSA().getPublicKey().toBytesDER();
+        byte[] validDERKey = PrivateKey.generateECDSA().getPublicKey().toBytesDER();
         assertDoesNotThrow(() -> PublicKey.fromBytesECDSA(validDERKey));
     }
 

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ECDSAPublicKeyTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ECDSAPublicKeyTest.java
@@ -77,6 +77,16 @@ public class ECDSAPublicKeyTest {
         assertThatExceptionOfType(IllegalArgumentException.class)
             .isThrownBy(() -> PublicKey.fromBytesECDSA(invalidKeyECDSA));
 
+        byte[] invalidCompressedKey = new byte[]{
+            0x00,
+            (byte) 0xca, (byte) 0x35, 0x4b, 0x7c, (byte) 0xf4, (byte) 0x87, (byte) 0xd1, (byte) 0xbc, 0x43,
+            0x5a, 0x25, 0x66, 0x77, 0x09, (byte) 0xc1, (byte) 0xab, (byte) 0x98, 0x0c, 0x11, 0x4d,
+            0x35, (byte) 0x94, (byte) 0xe6, 0x25, (byte) 0x9e, (byte) 0x81, 0x2e, 0x6a, 0x70, 0x3d,
+            0x4f, 0x51
+        };
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> PublicKey.fromBytesECDSA(invalidCompressedKey));
+
         byte[] malformedKey = new byte[]{0x00, 0x01, 0x02};
         assertThatExceptionOfType(IllegalArgumentException.class)
             .isThrownBy(() -> PublicKey.fromBytesECDSA(malformedKey));

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/ECDSAPublicKeyTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/ECDSAPublicKeyTest.java
@@ -27,6 +27,8 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class ECDSAPublicKeyTest {
     @Test
@@ -64,6 +66,32 @@ public class ECDSAPublicKeyTest {
         // because they're indistinguishable from ED25519 raw bytes
 
         assertThat(key2Bytes).containsExactly(key1Bytes);
+    }
+
+    @Test
+    void keyByteValidation() {
+        byte[] invalidKeyECDSA = new byte[33];
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> PublicKey.fromBytes(invalidKeyECDSA));
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> PublicKey.fromBytesECDSA(invalidKeyECDSA));
+
+        byte[] malformedKey = new byte[]{0x00, 0x01, 0x02}; // Malformed key
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> PublicKey.fromBytesECDSA(malformedKey));
+
+        byte[] validCompressedKey = new byte[]{
+            0x02, // Prefix for compressed keys
+            (byte) 0xca, (byte) 0x35, 0x4b, 0x7c, (byte) 0xf4, (byte) 0x87, (byte) 0xd1, (byte) 0xbc, 0x43,
+            0x5a, 0x25, 0x66, 0x77, 0x09, (byte) 0xc1, (byte) 0xab, (byte) 0x98, 0x0c, 0x1f, 0x4d,
+            0x35, (byte) 0x94, (byte) 0xe6, 0x25, (byte) 0x9e, (byte) 0x81, 0x2e, 0x6a, 0x75, 0x3d,
+            0x4f, 0x59
+        };
+        assertDoesNotThrow(() -> PublicKey.fromBytesECDSA(validCompressedKey));
+
+        byte[] validDERKey = PrivateKeyECDSA.generateECDSA().getPublicKey().toBytesDER();
+        assertDoesNotThrow(() -> PublicKey.fromBytesECDSA(validDERKey));
     }
 
     @Test

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/Ed25519PublicKeyTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/Ed25519PublicKeyTest.java
@@ -29,6 +29,8 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class Ed25519PublicKeyTest {
     private static final String TEST_KEY_STR = "302a300506032b6570032100e0c8ec2758a5879ffac226a13c0c516b799e72e35141a0dd828f94d37988a4b7";
@@ -48,6 +50,26 @@ class Ed25519PublicKeyTest {
     }
 
     @Test
+    void keyByteValidation() {
+        byte[] invalidKeyED25519 = new byte[32];
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> PublicKey.fromBytes(invalidKeyED25519));
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> PublicKey.fromBytesED25519(invalidKeyED25519));
+
+        byte[] malformedKey = new byte[]{0x00, 0x01, 0x02};
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> PublicKey.fromBytesED25519(malformedKey));
+
+        byte[] validKey = PrivateKey.generateED25519().getPublicKey().toBytes();
+        assertDoesNotThrow(() -> PublicKey.fromBytesED25519(validKey));
+
+        byte[] validDERKey = PrivateKey.generateED25519().getPublicKey().toBytesDER();
+        assertDoesNotThrow(() -> PublicKey.fromBytesED25519(validDERKey));
+    }
+
+        @Test
     @DisplayName("public key can be recovered from bytes")
     void keyByteSerialization() {
         PublicKey key1 = PrivateKey.generateED25519().getPublicKey();

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/Ed25519PublicKeyTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/Ed25519PublicKeyTest.java
@@ -58,6 +58,16 @@ class Ed25519PublicKeyTest {
         assertThatExceptionOfType(IllegalArgumentException.class)
             .isThrownBy(() -> PublicKey.fromBytesED25519(invalidKeyED25519));
 
+        byte[] invalidKey = new byte[]{
+            0x00,
+            (byte) 0xca, (byte) 0x35, 0x4b, 0x7c, (byte) 0xf4, (byte) 0x87, (byte) 0xd1, (byte) 0xbc, 0x43,
+            0x5a, 0x25, 0x66, 0x77, 0x09, (byte) 0xc1, (byte) 0xab, (byte) 0x98, 0x0c, 0x11, 0x4d,
+            0x35, (byte) 0x94, (byte) 0xe6, 0x25, (byte) 0x9e, (byte) 0x81, 0x2e, 0x6a, 0x70, 0x3d,
+            0x4f, 0x51
+        };
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> PublicKey.fromBytesED25519(invalidKey));
+
         byte[] malformedKey = new byte[]{0x00, 0x01, 0x02};
         assertThatExceptionOfType(IllegalArgumentException.class)
             .isThrownBy(() -> PublicKey.fromBytesED25519(malformedKey));
@@ -69,7 +79,7 @@ class Ed25519PublicKeyTest {
         assertDoesNotThrow(() -> PublicKey.fromBytesED25519(validDERKey));
     }
 
-        @Test
+    @Test
     @DisplayName("public key can be recovered from bytes")
     void keyByteSerialization() {
         PublicKey key1 = PrivateKey.generateED25519().getPublicKey();


### PR DESCRIPTION
**Description**:

This PR adds validation for creating ED25519 and ECDSA public keys from bytes. If the bytes are not valid - it throws `IllegalArgumentException`

**Related issue(s)**:

Fixes #2103

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
