### PR TITLE
build: remove duplicated dependency versions

### DIFF
--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -8,36 +8,42 @@ plugins {
 
 group = "com.hedera.hashgraph"
 
+val bouncycastle = "1.79"
+val grpc = "1.69.0"
+val protobuf = "4.29.1"
+val slf4j = "2.0.16"
+
 dependencies.constraints {
     api("com.esaulpaugh:headlong:12.3.3") { because("com.esaulpaugh.headlong") }
-    api("com.google.code.gson:gson:2.11.0") { because("com.google.gson") }
-    api("com.google.protobuf:protobuf-java:4.29.1") { because("com.google.protobuf") }
-    api("com.google.protobuf:protobuf-javalite:4.29.1") { because("com.google.protobuf") }
-    api("io.grpc:grpc-api:1.69.0") { because("io.grpc") }
-    api("io.grpc:grpc-inprocess:1.67.1") { because("io.grpc.inprocess") }
-    api("io.grpc:grpc-protobuf:1.69.0") { because("io.grpc.protobuf") }
-    api("io.grpc:grpc-protobuf-lite:1.69.0") { because("io.grpc.protobuf.lite") }
-    api("io.grpc:grpc-stub:1.68.2") { because("io.grpc.stub") }
     api("com.google.code.findbugs:jsr305:3.0.2") { because("java.annotation") }
-    api("org.bouncycastle:bcpkix-jdk18on:1.79") { because("org.bouncycastle.pkix") }
-    api("org.bouncycastle:bcprov-jdk18on:1.79") { because("org.bouncycastle.provider") }
-    api("org.slf4j:slf4j-api:2.0.9") { because("org.slf4j") }
-    api("org.slf4j:slf4j-simple:2.0.16") { because("org.slf4j.simple") }
-    api("com.google.code.findbugs:jsr305:3.0.2") { because("javax.annotation") }
+    api("com.google.code.gson:gson:2.11.0") { because("com.google.gson") }
+    api("com.google.protobuf:protobuf-java:$protobuf") { because("com.google.protobuf") }
+    api("com.google.protobuf:protobuf-javalite:$protobuf") { because("com.google.protobuf") }
+    api("io.grpc:grpc-api:$grpc") { because("io.grpc") }
+    api("io.grpc:grpc-inprocess:$grpc") { because("io.grpc.inprocess") }
+    api("io.grpc:grpc-protobuf-lite:$grpc") { because("io.grpc.protobuf.lite") }
+    api("io.grpc:grpc-protobuf:$grpc") { because("io.grpc.protobuf") }
+    api("io.grpc:grpc-stub:$grpc") { because("io.grpc.stub") }
+    api("io.grpc:grpc-netty:$grpc")
+    api("io.grpc:grpc-netty-shaded:$grpc")
+    api("io.grpc:grpc-okhttp:$grpc")
+    api("org.bouncycastle:bcpkix-jdk18on:$bouncycastle") { because("org.bouncycastle.pkix") }
+    api("org.bouncycastle:bcprov-jdk18on:$bouncycastle") { because("org.bouncycastle.provider") }
+    api("org.slf4j:slf4j-api:$slf4j") { because("org.slf4j") }
+    api("org.slf4j:slf4j-simple:$slf4j") { because("org.slf4j.simple") }
 
     // Testing
     api("com.fasterxml.jackson.core:jackson-core:2.18.2") { because("com.fasterxml.jackson.core") }
+    api("com.google.guava:guava:33.3.1-android") { because("com.google.common") }
     api("io.github.cdimascio:java-dotenv:5.3.1") { because("java.dotenv") }
     api("io.github.json-snapshot:json-snapshot:1.0.17") { because("json.snapshot") }
     api("org.apache.commons:commons-lang3:3.17.0") { because("org.apache.commons.lang3") }
     api("org.assertj:assertj-core:3.26.3") { because("org.assertj.core") }
     api("org.junit.jupiter:junit-jupiter-api:5.11.3") { because("org.junit.jupiter.api") }
     api("org.mockito:mockito-core:5.14.2") { because("org.mockito") }
-    api("com.google.guava:guava:33.3.1-android") { because("com.google.common") }
-    api("com.fasterxml.jackson.core:jackson-core:2.18.2") { because("com.fasterxml.jackson.core") }
 
-    api("com.google.protobuf:protoc:4.29.1")
-    api("io.grpc:protoc-gen-grpc-java:1.69.0")
+    api("com.google.protobuf:protoc:$protobuf")
+    api("io.grpc:protoc-gen-grpc-java:$grpc")
 
     // Examples
     api("org.jetbrains.kotlin:kotlin-stdlib:2.1.0") { because("kotlin.stdlib") }

--- a/sdk-full/build.gradle.kts
+++ b/sdk-full/build.gradle.kts
@@ -6,12 +6,35 @@ plugins {
 
 description = "Hedera™ Hashgraph SDK for Java"
 
+// TODO following block to be extracted into a plugin
+//      https://github.com/hiero-ledger/hiero-gradle-conventions/issues/41
+val publishDependencyConstraint =
+    configurations.create("publishDependencyConstraint") {
+        extendsFrom(configurations.internal.get())
+        dependencies.all {
+            val addedDependency = this
+            project.dependencies.constraints.add(
+                "api",
+                incoming.resolutionResult.rootComponent.map {
+                    (it.dependencies.single {
+                            it is ResolvedDependencyResult &&
+                                it.selected.moduleVersion?.group == addedDependency.group &&
+                                it.selected.moduleVersion?.name == addedDependency.name
+                        } as ResolvedDependencyResult)
+                        .selected
+                        .moduleVersion
+                        .toString()
+                }
+            )
+        }
+    }
+
 // Define dependency constraints for gRPC implementations so that clients automatically get the
 // correct version
-dependencies.constraints {
-    api("io.grpc:grpc-netty:1.64.0")
-    api("io.grpc:grpc-netty-shaded:1.64.0")
-    api("io.grpc:grpc-okhttp:1.64.0")
+dependencies {
+    publishDependencyConstraint("io.grpc:grpc-netty")
+    publishDependencyConstraint("io.grpc:grpc-netty-shaded")
+    publishDependencyConstraint("io.grpc:grpc-okhttp")
 }
 
 javaModuleDependencies.moduleNameToGA.put(


### PR DESCRIPTION
**Description**:

Some versions for _dependency groups_ – such as all `io.grpc:*` dependencies – were defined multiple times. This let to multiple Dependabot PRs for the same versions, leading to inconsistencies between merging of the several PRs.

Each repeated version is now only defined once in a `val` in the `hiero-dependency-versions/build.gradle.kts` file. This notation is supported by Dependabot.

This also addresses the point **Resolve duplication in constraints publishing (right now there is some duplication)** of issue #1794.

**Related issue(s)**:

#1794


**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (manually)
