### PR TITLE
build: repair running test AND testIntegration with code coverage on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
           OPERATOR_ID: '0.0.1022'
           HEDERA_NETWORK: 'localhost'
         run: |
-          ./gradlew -POPERATOR_ID=$OPERATOR_ID -POPERATOR_KEY=$OPERATOR_KEY -PHEDERA_NETWORK=$HEDERA_NETWORK jacocoTestReport --scan
+          ./gradlew -POPERATOR_ID=$OPERATOR_ID -POPERATOR_KEY=$OPERATOR_KEY -PHEDERA_NETWORK=$HEDERA_NETWORK :aggregation:testCodeCoverageReport --scan
 
       - name: Upload coverage to Codecov
         if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,8 @@ jobs:
       - name: Upload coverage to Codecov
         if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
         uses: codecov/codecov-action@5c47607acb93fed5485fdbf7232e8a31425f672a # v5.0.2
+        with:
+            files: gradle/aggregation/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
 
       - name: Stop the local node
         run: npx @hashgraph/hedera-local stop

--- a/.github/workflows/disabled/testnet.yml
+++ b/.github/workflows/disabled/testnet.yml
@@ -93,7 +93,7 @@ jobs:
           OPERATOR_ID: ${{ secrets.TESTNET_OPERATOR_ID }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
-          ./gradlew -POPERATOR_ID=$OPERATOR_ID -POPERATOR_KEY=$OPERATOR_KEY -PHEDERA_NETWORK=testnet jacocoTestReport && bash <(curl -s https://codecov.io/bash)
+          ./gradlew -POPERATOR_ID=$OPERATOR_ID -POPERATOR_KEY=$OPERATOR_KEY -PHEDERA_NETWORK=testnet :aggregation:testCodeCoverageReport && bash <(curl -s https://codecov.io/bash)
       - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -10,3 +10,31 @@ dependencies {
     implementation(project(":sdk"))
     implementation("io.grpc:grpc-protobuf")
 }
+
+tasks.testCodeCoverageReport {
+    // Integrate coverage data from integration tests into the report
+    @Suppress("UnstableApiUsage")
+    val testIntegrationExecutionData =
+        configurations.aggregateCodeCoverageReportResults
+            .get()
+            .incoming
+            .artifactView {
+                withVariantReselection()
+                componentFilter { id -> id is ProjectComponentIdentifier }
+                attributes.attribute(
+                    Category.CATEGORY_ATTRIBUTE,
+                    objects.named(Category.VERIFICATION)
+                )
+                attributes.attribute(
+                    VerificationType.VERIFICATION_TYPE_ATTRIBUTE,
+                    objects.named(VerificationType.JACOCO_RESULTS)
+                )
+                attributes.attribute(
+                    TestSuiteType.TEST_SUITE_TYPE_ATTRIBUTE,
+                    objects.named(TestSuiteType.INTEGRATION_TEST)
+                )
+            }
+            .files
+
+    executionData.from(testIntegrationExecutionData)
+}


### PR DESCRIPTION
**Description**:

This now follows a similar setup as in hedera-services. This update was missed in #2033.

