### PR TITLE
build: standardize dependency declaration in 'tck'

### DIFF
--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -9,8 +9,7 @@ mainModuleInfo {
     runtimeOnly("org.slf4j.simple")
 }
 
-// 'com.google.protobuf' implementation is provided through 'sdk' as it differs between 'sdk' and
-// 'sdk-full'
+// 'protobuf' implementation provided through 'sdk' as it differs between 'sdk' and 'sdk-full'
 dependencyAnalysis {
     issues {
         all { onUsedTransitiveDependencies { exclude("com.google.protobuf:protobuf-javalite") } }

--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 dependencies {
     implementation(project(":sdk"))
+    implementation(project(":tck"))
     implementation("io.grpc:grpc-protobuf")
 }
 

--- a/gradle/modules.properties
+++ b/gradle/modules.properties
@@ -1,0 +1,10 @@
+# Jars that are not yet modules used in the 'tck' project
+com.thetransactioncompany.jsonrpc2.base=com.thetransactioncompany:jsonrpc2-base
+com.thetransactioncompany.jsonrpc2.server=com.thetransactioncompany:jsonrpc2-server
+net.minidev.json.smart=net.minidev:json-smart
+spring.boot.autoconfigure= org.springframework.boot:spring-boot-autoconfigure
+spring.boot.starter.web=org.springframework.boot:spring-boot-starter-web
+spring.boot=org.springframework.boot:spring-boot
+spring.context=org.springframework:spring-context
+spring.web=org.springframework:spring-web
+spring.webmvc=org.springframework:spring-webmvc

--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -13,6 +13,8 @@ val grpc = "1.69.0"
 val protobuf = "4.29.3"
 val slf4j = "2.0.16"
 
+dependencies { api(platform("org.springframework.boot:spring-boot-dependencies:3.2.3")) }
+
 dependencies.constraints {
     api("com.esaulpaugh:headlong:12.3.3") { because("com.esaulpaugh.headlong") }
     api("com.google.code.findbugs:jsr305:3.0.2") { because("java.annotation") }
@@ -44,6 +46,8 @@ dependencies.constraints {
 
     api("com.google.protobuf:protoc:$protobuf")
     api("io.grpc:protoc-gen-grpc-java:$grpc")
+
+    api("com.thetransactioncompany:jsonrpc2-server:2.0")
 
     // Examples
     api("org.jetbrains.kotlin:kotlin-stdlib:2.1.0") { because("kotlin.stdlib") }

--- a/tck/build.gradle.kts
+++ b/tck/build.gradle.kts
@@ -1,69 +1,52 @@
 // SPDX-License-Identifier: Apache-2.0
-import org.springframework.boot.gradle.plugin.ResolveMainClassName
-import org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
-
 plugins {
     id("org.springframework.boot") version "3.2.3"
-    id("java")
-    id("com.autonomousapps.dependency-analysis")
-    id("org.hiero.gradle.base.lifecycle")
-    id("org.hiero.gradle.check.javac-lint")
-    id("org.hiero.gradle.check.spotless")
-    id("org.hiero.gradle.check.spotless-java")
-    id("org.hiero.gradle.check.spotless-kotlin")
-    id("org.hiero.gradle.feature.git-properties-file")
-    id("org.hiero.gradle.feature.java-compile")
-    id("org.hiero.gradle.feature.java-doc")
-    id("org.hiero.gradle.feature.java-execute")
-    id("org.hiero.gradle.feature.test")
-    id("org.hiero.gradle.report.test-logger")
+    id("org.hiero.gradle.module.application")
+    id("org.gradlex.java-module-dependencies")
 }
 
 description = "Hiero SDK TCK Server"
 
 version = "0.0.1"
 
-dependencies {
-    annotationProcessor(platform(BOM_COORDINATES))
-    annotationProcessor("org.projectlombok:lombok")
-
-    implementation(platform(BOM_COORDINATES))
-    implementation(platform(project(":hiero-dependency-versions")))
-    implementation(project(":sdk"))
-    implementation("com.thetransactioncompany:jsonrpc2-base")
-    implementation("com.thetransactioncompany:jsonrpc2-server:2.0")
-    implementation("net.minidev:json-smart")
-    implementation("org.apache.tomcat.embed:tomcat-embed-core")
-    implementation("org.bouncycastle:bcprov-jdk18on")
-    implementation("org.slf4j:slf4j-api")
-    implementation("org.springframework.boot:spring-boot")
-    implementation("org.springframework.boot:spring-boot-autoconfigure")
-    implementation("org.springframework:spring-context")
-    implementation("org.springframework:spring-web")
-    implementation("org.springframework:spring-webmvc")
-    runtimeOnly("io.grpc:grpc-netty-shaded")
-    runtimeOnly("org.springframework.boot:spring-boot-starter-web")
-    compileOnly("org.projectlombok:lombok")
-
-    testImplementation("org.junit.jupiter:junit-jupiter-api")
-    testImplementation("org.mockito:mockito-core")
-    testImplementation("org.mockito:mockito-junit-jupiter")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+// Allow non-module Jars
+extraJavaModuleInfo {
+    failOnMissingModuleInfo = false
+    failOnAutomaticModules = false
 }
 
-tasks.withType<ResolveMainClassName> { setGroup(null) }
+mainModuleInfo {
+    requires("com.thetransactioncompany.jsonrpc2.base")
+    requires("com.thetransactioncompany.jsonrpc2.server")
+    requires("net.minidev.json.smart")
+    requires("org.apache.tomcat.embed.core")
+    requires("org.bouncycastle.provider")
+    requires("org.hiero.sdk")
+    requires("org.slf4j")
+    requires("spring.boot")
+    requires("spring.boot.autoconfigure")
+    requires("spring.context")
+    requires("spring.web")
+    requires("spring.webmvc")
+    requiresStatic("lombok")
+    annotationProcessor("lombok")
+    runtimeOnly("io.grpc.netty.shaded")
+    runtimeOnly("spring.boot.starter.web")
+}
 
-// Configure dependency analysis without using Java Modules
-tasks.qualityGate { dependsOn(tasks.named("projectHealth")) }
+testModuleInfo {
+    requires("org.junit.jupiter.api")
+    requires("org.mockito")
+    requires("org.mockito.junit.jupiter")
+}
 
-tasks.qualityCheck { dependsOn(tasks.named("projectHealth")) }
-
+// 'protobuf' implementation provided through 'sdk' as it differs between 'sdk' and 'sdk-full'
 dependencyAnalysis {
-    issues {
-        onAny {
-            severity("fail")
-            exclude("com.google.protobuf:protobuf-javalite")
-            onUnusedDependencies { exclude(":sdk") }
-        }
-    }
+    issues { onUsedTransitiveDependencies { exclude("com.google.protobuf:protobuf-javalite") } }
+}
+
+// Configure spring boot specific classpath to access module versions
+configurations.productionRuntimeClasspath {
+    @Suppress("UnstableApiUsage")
+    shouldResolveConsistentlyWith(configurations.mainRuntimeClasspath.get())
 }


### PR DESCRIPTION
**Description**:

Uses dependency notation via Module Names in `tck` project to align with other places.

The project does not have a `module-info.java`, because it uses Spring Boot which does not yet fully support the Module System. Still, this makes the setup more consistent with elsewhere and we are prepared to move to a real Java Module Setup with future Spring versions. 

Part of #1794