### PR TITLE
chore: Rename devops-ci to platform-ci

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,34 +8,34 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/devops-ci @hashgraph/release-engineering-managers
-/.github/workflows/                             @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
+/.github/                                       @hashgraph/platform-ci @hashgraph/release-engineering-managers
+/.github/workflows/                             @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
 
 # Legacy Maven project files
-**/pom.xml                                      @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-sdk-java-maintainers
+**/pom.xml                                      @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-sdk-java-maintainers
 
 # Gradle project files and inline plugins
-/gradle/                                        @hashgraph/devops-ci @hashgraph/devops-ci-committers
-gradlew                                         @hashgraph/devops-ci @hashgraph/devops-ci-committers
-gradlew.bat                                     @hashgraph/devops-ci @hashgraph/devops-ci-committers
-**/build-logic/                                 @hashgraph/devops-ci @hashgraph/devops-ci-committers
-**/gradle.*                                     @hashgraph/devops-ci @hashgraph/devops-ci-committers
-**/*.gradle.*                                   @hashgraph/devops-ci @hashgraph/devops-ci-committers
+/gradle/                                        @hashgraph/platform-ci @hashgraph/platform-ci-committers
+gradlew                                         @hashgraph/platform-ci @hashgraph/platform-ci-committers
+gradlew.bat                                     @hashgraph/platform-ci @hashgraph/platform-ci-committers
+**/build-logic/                                 @hashgraph/platform-ci @hashgraph/platform-ci-committers
+**/gradle.*                                     @hashgraph/platform-ci @hashgraph/platform-ci-committers
+**/*.gradle.*                                   @hashgraph/platform-ci @hashgraph/platform-ci-committers
 
 # Codacy Tool Configurations
-/config/                                        @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-sdk-java-maintainers
-.remarkrc                                       @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-sdk-java-maintainers
+/config/                                        @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-sdk-java-maintainers
+.remarkrc                                       @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-sdk-java-maintainers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                      @hashgraph/release-engineering-managers
 
 # Protect the repository root files
-/README.md                                      @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-sdk-java-maintainers
+/README.md                                      @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-sdk-java-maintainers
 **/LICENSE                                      @hashgraph/release-engineering-managers
 
 # CodeCov configuration
-**/codecov.yml                                  @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
+**/codecov.yml                                  @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
 
 # Git Ignore definitions
-**/.gitignore                                   @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
-**/.gitignore.*                                 @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
+**/.gitignore                                   @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
+**/.gitignore.*                                 @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers


### PR DESCRIPTION
**Description**:

Renames devops-ci to platform-ci

**Related issue(s)**:

Fixes #2173
