### PR TITLE
java.annotation must not be transitive dependency

### DIFF
--- a/sdk/src/main/java/module-info.java
+++ b/sdk/src/main/java/module-info.java
@@ -12,7 +12,7 @@ module com.hedera.hashgraph.sdk {
     requires org.bouncycastle.pkix;
     requires org.bouncycastle.provider;
     requires org.slf4j;
-    requires static transitive java.annotation;
+    requires static java.annotation;
 
     exports com.hedera.hashgraph.sdk;
     exports com.hedera.hashgraph.sdk.proto;


### PR DESCRIPTION
This pull request makes a minor change to the module dependencies in `module-info.java`, specifically updating how the `java.annotation` module is required.

* Changed the `module-info.java` file to require `java.annotation` as a static dependency instead of a static transitive dependency.