### PR TITLE
chore: update gradlew command in developer guide

### DIFF
--- a/docs/sdk/developer-guide.md
+++ b/docs/sdk/developer-guide.md
@@ -127,7 +127,8 @@ More details about how to add/modify dependencies are found in the Hiero Gradle 
 ### Updating proto files
 
 ```sh
-./gradlew updateSnapshots
+./gradlew updateProto
+Note: checkout_ref variable in update_protobufs.py should be updated with the version with needed protobufs before running the command
 ```
 
 ### Updating address books


### PR DESCRIPTION
This PR fixes the incorrect gradlew command in developer-guide.md.

Changes:
- Replaced `./gradlew updateSnapshots` with `./gradlew updateProto`
- Added note about `checkout_ref` variable in update_protobufs.py

Fixes #2694 