### PR TITLE
fix: Serialization for TokenClaimAirdropTransaction on `fromScheduledTransaction`

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Transaction.java
@@ -585,7 +585,7 @@ public abstract class Transaction<T extends Transaction<T>>
                 new TokenCancelAirdropTransaction(body.setTokenCancelAirdrop(scheduled.getTokenCancelAirdrop())
                         .build());
             case TOKENCLAIMAIRDROP ->
-                new TokenClaimAirdropTransaction(body.setTokenCancelAirdrop(scheduled.getTokenCancelAirdrop())
+                new TokenClaimAirdropTransaction(body.setTokenClaimAirdrop(scheduled.getTokenClaimAirdrop())
                         .build());
             case SCHEDULEDELETE ->
                 new ScheduleDeleteTransaction(

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenCancelAirdropTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenCancelAirdropTransactionTest.java
@@ -155,4 +155,21 @@ class TokenCancelAirdropTransactionTest {
 
         Assertions.assertTrue(scheduled.hasTokenCancelAirdrop());
     }
+
+    @Test
+    void testFromScheduledTransaction() {
+        var pending = new PendingAirdropId(new AccountId(0, 0, 457), new AccountId(0, 0, 456), new TokenId(0, 0, 123));
+
+        var transactionBody = SchedulableTransactionBody.newBuilder()
+                .setTokenCancelAirdrop(TokenCancelAirdropTransactionBody.newBuilder()
+                        .addPendingAirdrops(pending.toProtobuf())
+                        .build())
+                .build();
+
+        var tx = Transaction.fromScheduledTransaction(transactionBody);
+
+        assertThat(tx).isInstanceOf(TokenCancelAirdropTransaction.class);
+        assertThat(((TokenCancelAirdropTransaction) tx).getPendingAirdropIds()).isNotEmpty();
+        assertThat(((TokenCancelAirdropTransaction) tx).getPendingAirdropIds()).hasSize(1);
+    }
 }

--- a/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenClaimAirdropTransactionTest.java
+++ b/sdk/src/test/java/com/hedera/hashgraph/sdk/TokenClaimAirdropTransactionTest.java
@@ -155,4 +155,21 @@ class TokenClaimAirdropTransactionTest {
 
         Assertions.assertTrue(scheduled.hasTokenClaimAirdrop());
     }
+
+    @Test
+    void testFromScheduledTransaction() {
+        var pending = new PendingAirdropId(new AccountId(0, 0, 457), new AccountId(0, 0, 456), new TokenId(0, 0, 123));
+
+        var transactionBody = SchedulableTransactionBody.newBuilder()
+                .setTokenClaimAirdrop(TokenClaimAirdropTransactionBody.newBuilder()
+                        .addPendingAirdrops(pending.toProtobuf())
+                        .build())
+                .build();
+
+        var tx = Transaction.fromScheduledTransaction(transactionBody);
+
+        assertThat(tx).isInstanceOf(TokenClaimAirdropTransaction.class);
+        assertThat(((TokenClaimAirdropTransaction) tx).getPendingAirdropIds()).isNotEmpty();
+        assertThat(((TokenClaimAirdropTransaction) tx).getPendingAirdropIds()).hasSize(1);
+    }
 }


### PR DESCRIPTION
**Description**:
This PR fix the serialization for the TokenClaimAirdropTransaction when call `fromScheduledTransaction()`

**Related issue(s)**:

Fixes #2701

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
