### PR TITLE
refactor: replace wildcard imports in example files

### DIFF
--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/AccountAliasExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/AccountAliasExample.java
@@ -1,7 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.sdk.examples;
 
-import com.hedera.hashgraph.sdk.*;
+import com.hedera.hashgraph.sdk.AccountBalance;
+import com.hedera.hashgraph.sdk.AccountBalanceQuery;
+import com.hedera.hashgraph.sdk.AccountDeleteTransaction;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.AccountInfo;
+import com.hedera.hashgraph.sdk.AccountInfoQuery;
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.ClientHelper;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.PublicKey;
+import com.hedera.hashgraph.sdk.TransferTransaction;
 import com.hedera.hashgraph.sdk.logger.LogLevel;
 import com.hedera.hashgraph.sdk.logger.Logger;
 import io.github.cdimascio.dotenv.Dotenv;

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/AccountAliasExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/AccountAliasExample.java
@@ -48,6 +48,56 @@ class AccountAliasExample {
      */
 
     /**
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.hashgraph.sdk.examples;
+
+import com.hedera.hashgraph.sdk.AccountBalance;
+import com.hedera.hashgraph.sdk.AccountBalanceQuery;
+import com.hedera.hashgraph.sdk.AccountDeleteTransaction;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.AccountInfo;
+import com.hedera.hashgraph.sdk.AccountInfoQuery;
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.ClientHelper;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.PublicKey;
+import com.hedera.hashgraph.sdk.TransferTransaction;
+import com.hedera.hashgraph.sdk.logger.LogLevel;
+import com.hedera.hashgraph.sdk.logger.Logger;
+import io.github.cdimascio.dotenv.Dotenv;
+import java.util.Objects;
+
+/**
+ * How to use auto account creation (HIP-32).
+ * <p>
+ * You can "create" an account by generating a private key, and then deriving the public key,
+ * without any need to interact with the Hedera network. The public key more or less acts as the user's
+ * account ID. This public key is an account's aliasKey: a public key that aliases (or will eventually alias)
+ * to a Hedera account.
+ * <p>
+ * An AccountId takes one of two forms: a normal AccountId with a null aliasKey member takes the form 0.0.123,
+ * while an account ID with a non-null aliasKey member takes the form
+ * 0.0.302a300506032b6570032100114e6abc371b82dab5c15ea149f02d34a012087b163516dd70f44acafabf7777
+ * Note the prefix of "0.0." indicating the shard and realm. Also note that the aliasKey is stringified
+ * as a hex-encoded ASN1 DER representation of the key.
+ * <p>
+ * An AccountId with an aliasKey can be used just like a normal AccountId for the purposes of queries and
+ * transactions, however most queries and transactions involving such an AccountId won't work until Hbar has
+ * been transferred to the aliasKey account.
+ * <p>
+ * There is no record in the Hedera network of an account associated with a given aliasKey
+ * until an amount of Hbar is transferred to the account. The moment that Hbar is transferred to that aliasKey
+ * AccountId is the moment that that account actually begins to exist in the Hedera ledger.
+ */
+class AccountAliasExample {
+
+    /*
+     * See .env.sample in the examples folder root for how to specify values below
+     * or set environment variables with the same names.
+     */
+
+    /**
      * Operator's account ID.
      * Used to sign and pay for operations on Hedera.
      */
@@ -83,9 +133,7 @@ class AccountAliasExample {
          * Create and configure the SDK Client.
          */
         Client client = ClientHelper.forName(HEDERA_NETWORK);
-        // All generated transactions will be paid by this account and signed by this key.
         client.setOperator(OPERATOR_ID, OPERATOR_KEY);
-        // Attach logger to the SDK Client.
         client.setLogger(new Logger(LogLevel.valueOf(SDK_LOG_LEVEL)));
 
         /*
@@ -99,40 +147,24 @@ class AccountAliasExample {
         /*
          * Step 2:
          * Create a couple of example Account Ids.
-         *
-         * Note that no queries or transactions have taken place yet.
-         * This account "creation" process is entirely local.
-         *
-         * AccountId.fromString() can construct an AccountId with an aliasKey.
-         * It expects a string of the form 0.0.123 in the case of a normal AccountId, or of the form
-         * 0.0.302a300506032b6570032100114e6abc371b82dab5c15ea149f02d34a012087b163516dd70f44acafabf7777
-         * in the case of an AccountId with aliasKey. Note the prefix of '0.0.' to indicate the shard and realm.
-         *
-         * If the shard and realm are known, you may use PublicKey.fromString().toAccountId() to construct the
-         * aliasKey AccountId.
          */
         System.out.println("\"Creating\" new account...");
 
-        // Assuming that the target shard and realm are known.
-        // For now, they are virtually always 0 and 0.
         AccountId aliasAccountId = publicKey.toAccountId(0, 0);
 
         System.out.println("New account ID: " + aliasAccountId);
         System.out.println("Just the aliasKey: " + aliasAccountId.aliasKey);
 
-        AccountId fromStringExample = AccountId.fromString(
-                "0.0.302a300506032b6570032100114e6abc371b82dab5c15ea149f02d34a012087b163516dd70f44acafabf7777");
+        System.out.println(AccountId.fromString(
+                "0.0.302a300506032b6570032100114e6abc371b82dab5c15ea149f02d34a012087b163516dd70f44acafabf7777"));
 
-        AccountId fromKeyStringExample = PublicKey.fromString(
-                        "302a300506032b6570032100114e6abc371b82dab5c15ea149f02d34a012087b163516dd70f44acafabf7777")
-                .toAccountId(0, 0);
+        System.out.println(PublicKey.fromString(
+                "302a300506032b6570032100114e6abc371b82dab5c15ea149f02d34a012087b163516dd70f44acafabf7777")
+                .toAccountId(0, 0));
 
         /*
          * Step 3:
          * Transfer Hbar to the new account.
-         *
-         * Transfer will actually create an actual Hedera account,
-         * deducting the creation fee from the amount transferred.
          */
         System.out.println("Transferring Hbar to the new account...");
         new TransferTransaction()
@@ -144,12 +176,6 @@ class AccountAliasExample {
         /*
          * Step 4:
          * Query and output info about the new account.
-         *
-         * Note that once an account exists in the ledger, it is assigned a normal AccountId, which can be retrieved
-         * via an AccountInfoQuery.
-         *
-         * Users may continue to refer to the account by its aliasKey AccountId, but they may also
-         * now refer to it by its normal AccountId
          */
         AccountBalance newAccountBalance =
                 new AccountBalanceQuery().setAccountId(aliasAccountId).execute(client);

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/ConsensusPubSubChunkedExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/ConsensusPubSubChunkedExample.java
@@ -2,8 +2,17 @@
 package com.hedera.hashgraph.sdk.examples;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-
-import com.hedera.hashgraph.sdk.*;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.ClientHelper;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.PublicKey;
+import com.hedera.hashgraph.sdk.TopicCreateTransaction;
+import com.hedera.hashgraph.sdk.TopicDeleteTransaction;
+import com.hedera.hashgraph.sdk.TopicId;
+import com.hedera.hashgraph.sdk.TopicMessageQuery;
+import com.hedera.hashgraph.sdk.TopicMessageSubmitTransaction;
+import com.hedera.hashgraph.sdk.Transaction;
 import com.hedera.hashgraph.sdk.logger.LogLevel;
 import com.hedera.hashgraph.sdk.logger.Logger;
 import io.github.cdimascio.dotenv.Dotenv;

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/CreateTopicExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/CreateTopicExample.java
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.sdk.examples;
 
-import com.hedera.hashgraph.sdk.*;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.ClientHelper;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.PublicKey;
+import com.hedera.hashgraph.sdk.TopicCreateTransaction;
+import com.hedera.hashgraph.sdk.TopicId;
 import com.hedera.hashgraph.sdk.logger.LogLevel;
 import com.hedera.hashgraph.sdk.logger.Logger;
 import io.github.cdimascio.dotenv.Dotenv;

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/MultiAppTransferExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/MultiAppTransferExample.java
@@ -1,7 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.sdk.examples;
 
-import com.hedera.hashgraph.sdk.*;
+import com.hedera.hashgraph.sdk.AccountBalance;
+import com.hedera.hashgraph.sdk.AccountBalanceQuery;
+import com.hedera.hashgraph.sdk.AccountCreateTransaction;
+import com.hedera.hashgraph.sdk.AccountDeleteTransaction;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.ClientHelper;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.TransferTransaction;
 import com.hedera.hashgraph.sdk.logger.LogLevel;
 import com.hedera.hashgraph.sdk.logger.Logger;
 import io.github.cdimascio.dotenv.Dotenv;

--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/ScheduledTransferExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/ScheduledTransferExample.java
@@ -1,7 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.hashgraph.sdk.examples;
 
-import com.hedera.hashgraph.sdk.*;
+import com.hedera.hashgraph.sdk.AccountBalance;
+import com.hedera.hashgraph.sdk.AccountBalanceQuery;
+import com.hedera.hashgraph.sdk.AccountCreateTransaction;
+import com.hedera.hashgraph.sdk.AccountDeleteTransaction;
+import com.hedera.hashgraph.sdk.AccountId;
+import com.hedera.hashgraph.sdk.Client;
+import com.hedera.hashgraph.sdk.ClientHelper;
+import com.hedera.hashgraph.sdk.Hbar;
+import com.hedera.hashgraph.sdk.PrivateKey;
+import com.hedera.hashgraph.sdk.PublicKey;
+import com.hedera.hashgraph.sdk.ScheduleCreateTransaction;
+import com.hedera.hashgraph.sdk.ScheduleId;
+import com.hedera.hashgraph.sdk.ScheduleInfo;
+import com.hedera.hashgraph.sdk.ScheduleInfoQuery;
+import com.hedera.hashgraph.sdk.ScheduleSignTransaction;
+import com.hedera.hashgraph.sdk.Transaction;
+import com.hedera.hashgraph.sdk.TransferTransaction;
 import com.hedera.hashgraph.sdk.logger.LogLevel;
 import com.hedera.hashgraph.sdk.logger.Logger;
 import io.github.cdimascio.dotenv.Dotenv;


### PR DESCRIPTION
## Summary
Replaced wildcard (`*`) imports with explicit class imports in the specified example files for issue #2727.

## Files Updated
- ScheduledTransferExample
- AccountAliasExample
- ConsensusPubSubChunkedExample
- CreateTopicExample
- MultiAppTransferExample