### PR TITLE
docs: add explanation for token transfer example

### DIFF
--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/TransferTokensExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/TransferTokensExample.java
@@ -9,7 +9,20 @@ import java.util.Collections;
 import java.util.Objects;
 
 /**
- * How to transfer tokens between accounts.
+ * FULL TOKEN TRANSFER
+ *
+ * This example demonstrates the complete lifecycle of a Hedera token transfer:
+ *
+ * Step 1: Create and configure the SDK Client
+ * Step 2: Generate ED25519 key pairs
+ * Step 3: Create accounts (Alice and Bob)
+ * Step 4: Create a fungible token
+ * Step 5: Associate the token with accounts
+ * Step 6: Grant KYC permissions
+ * Step 7: Transfer tokens from treasury to Alice
+ * Step 8: Transfer tokens between Alice and Bob
+ *
+ * This helps developers understand the full token workflow using the SDK.
  */
 class TransferTokensExample {
 


### PR DESCRIPTION
What does this PR do?

Adds a file-level comment to the token transfer example to explain the full workflow.

Why is this needed?

The example currently has no explanation, which makes it hard to understand what each step is doing, especially for new contributors.

What is included?

- Added a clear, step-by-step description of the token transfer lifecycle:
  - Client setup
  - Key generation
  - Account creation
  - Token creation
  - Token association
  - KYC grant
  - Transfers between accounts
  
Fixes #2554 

Notes

- No changes to existing logic
- Only documentation improvement