### PR TITLE
docs: add top-level explanation for TokenRejectExample

### DIFF
--- a/examples/src/main/java/com/hedera/hashgraph/sdk/examples/TokenRejectExample.java
+++ b/examples/src/main/java/com/hedera/hashgraph/sdk/examples/TokenRejectExample.java
@@ -10,7 +10,24 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * How to reject a token (part of HIP-904).
+ * Example demonstrating how to reject both fungible tokens (FTs)
+ * and non-fungible tokens (NFTs).
+ *
+ * <p>This example walks through the complete workflow, including:
+ * <ul>
+ *   <li>Client configuration using operator credentials</li>
+ *   <li>Creating accounts with ED25519 keys</li>
+ *   <li>Creating fungible and non-fungible tokens</li>
+ *   <li>Associating tokens with accounts</li>
+ *   <li>Performing token rejection operations</li>
+ *   <li>Cleaning up resources (accounts and tokens)</li>
+ * </ul>
+ *
+ * <p>Environment variables required:
+ * <ul>
+ *   <li><b>OPERATOR_ID</b> - Account ID for transactions</li>
+ *   <li><b>OPERATOR_KEY</b> - Private key for signing transactions</li>
+ * </ul>
  */
 class TokenRejectExample {
 


### PR DESCRIPTION
What does this PR do?

Adds a class-level explanation to the TokenRejectExample to describe what the example does and the overall workflow.

Why is this needed?

The example already has inline comments, but it was missing a top-level overview. This makes it harder to quickly understand the purpose and flow of the example.

What is included?

- Added a structured JavaDoc comment explaining:
  - What token rejection is (for FTs and NFTs)
  - The main steps involved in the workflow
  - Required environment variables

Fixes #2553 

Notes

- No changes to existing logic
- Only documentation improvements