### PR TITLE
fix: scope generated protobuf classes under SDK namespace to avoid FQCN conflicts

### DIFF
--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -41,6 +41,31 @@ testIntegrationModuleInfo {
     runtimeOnly("org.slf4j.simple")
 }
 
+// Remap protobuf java_package to SDK namespace to avoid FQCN conflicts
+// when used alongside hedera-protobuf-java-api
+val transformProtos by tasks.registering(Copy::class) {
+    from("src/main/proto")
+    into(layout.buildDirectory.dir("transformed-protos"))
+    filter { line ->
+        if (line.trim().startsWith("option java_package")) {
+            line.replace("com.hedera.hapi", "com.hedera.hashgraph.sdk.proto")
+                .replace("com.hederahashgraph.api.proto.java", "com.hedera.hashgraph.sdk.proto")
+                .replace("com.hederahashgraph.service.proto.java", "com.hedera.hashgraph.sdk.proto")
+                .replace("com.hedera.mirror.api.proto", "com.hedera.hashgraph.sdk.proto.mirror")
+        } else {
+            line
+        }
+    }
+}
+
+sourceSets {
+    main {
+        proto {
+            setSrcDirs(listOf(transformProtos))
+        }
+    }
+}
+
 protobuf {
     generateProtoTasks {
         all().configureEach {


### PR DESCRIPTION
What does this PR do?

Scopes generated protobuf classes under an SDK-specific namespace to avoid FQCN conflicts when the SDK is used alongside `hedera-protobuf-java-api`.

Why is this needed?

Some protobuf files define their own `java_package` (e.g. `com.hedera.hapi.*`), which can lead to classpath conflicts if both SDK and protobuf artifacts are present in a project.

What is included?

1. Adds a build-level transformation step that remaps `java_package` values during generation
2. Leaves upstream `.proto` files unchanged
3. Ensures all generated classes are placed under `com.hedera.hashgraph.sdk.proto.*`

Notes :- 

1. No changes to protobuf source files
2. Minimal, build-only change for safer maintenance
3. Verified with `./gradlew :sdk:assemble`