### PR TITLE
docs: correct typo Mionnet -> Mainnet in LedgerId javadoc

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/LedgerId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/LedgerId.java
@@ -14,7 +14,7 @@ public class LedgerId {
     /**
      * The mainnet ledger id
      */
-    public static final LedgerId MAINNET = new LedgerId(new byte[] {0});
+    public static final LedgerId MAINNET = new LedgerId(new byte[] {0});h
 
     /**
      * The testnet ledger id
@@ -95,7 +95,7 @@ public class LedgerId {
     }
 
     /**
-     * Are we on Mionnet?
+     * Are we on Mainnet?
      *
      * @return                          is it mainnet
      */

--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/LedgerId.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/LedgerId.java
@@ -14,7 +14,7 @@ public class LedgerId {
     /**
      * The mainnet ledger id
      */
-    public static final LedgerId MAINNET = new LedgerId(new byte[] {0});h
+    public static final LedgerId MAINNET = new LedgerId(new byte[] {0});
 
     /**
      * The testnet ledger id


### PR DESCRIPTION
**Description**:
Fix typo in `isMainnet()` javadoc comment in `LedgerId.java` where 'Mionnet' was incorrectly written instead of 'Mainnet'.

**Related issue(s)**:
Fixes #2775

**Notes for reviewer**:
Simple one-line javadoc typo fix. No functional changes.

**Checklist**
- [x] I have read the [contributing guidelines](https://github.com/hiero-ledger/hiero/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] This PR has a small, focused scope (single bug fix or feature)