### PR TITLE
docs: fix typo in Status enum javadoc

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/Status.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/Status.java
@@ -1367,7 +1367,7 @@ public enum Status {
     DELEGATING_SPENDER_CANNOT_GRANT_APPROVE_FOR_ALL(ResponseCodeEnum.DELEGATING_SPENDER_CANNOT_GRANT_APPROVE_FOR_ALL),
 
     /**
-     * The delegating Spender cannot grant allowance on a NFT serial for another spender as it doesnt not have approveForAll
+     * The delegating Spender cannot grant allowance on a NFT serial for another spender as it does not have approveForAll
      * granted on token-owner.
      */
     DELEGATING_SPENDER_DOES_NOT_HAVE_APPROVE_FOR_ALL(ResponseCodeEnum.DELEGATING_SPENDER_DOES_NOT_HAVE_APPROVE_FOR_ALL),


### PR DESCRIPTION
## Description

Fixes a small typo in the Javadoc of the `Status` enum.

On line 1370 of `Status.java` (the `DELEGATING_SPENDER_DOES_NOT_HAVE_APPROVE_FOR_ALL` constant), the doc comment read `...as it doesnt not have approveForAll`. Corrected to `...as it does not have approveForAll`.

## Related issue

Fixes #2796

## Checklist
- [x] Single-line documentation change, no functional impact
- [x] Commit is DCO signed-off
- [x] PR title follows Conventional Commits