### PR TITLE
chore(codeowners): Add maintainers for workflows and build logic

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 
 # Protection Rules for Github Configuration Files and Actions Workflows
 /.github/                                       @hiero-ledger/github-maintainers 
-/.github/workflows/                             @hiero-ledger/github-maintainers 
+/.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-java-maintainers
 /.github/dependabot.yml                         @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-java-maintainers @hiero-ledger/hiero-sdk-java-committers
 
 # Legacy Maven project files
@@ -18,10 +18,10 @@
 # Gradle project files and inline plugins
 /gradle/                                        @hiero-ledger/github-maintainers 
 gradlew                                         @hiero-ledger/github-maintainers 
-gradlew.bat                                     @hiero-ledger/github-maintainers 
-**/build-logic/                                 @hiero-ledger/github-maintainers 
+gradlew.bat                                     @hiero-ledger/github-maintainers
+**/build-logic/                                 @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-java-maintainers
 **/gradle.*                                     @hiero-ledger/github-maintainers 
-**/*.gradle.*                                   @hiero-ledger/github-maintainers 
+**/*.gradle.*                                   @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-java-maintainers
 
 # Codacy Tool Configurations
 /config/                                        @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-java-maintainers


### PR DESCRIPTION
## Description

This pull request updates the `.github/CODEOWNERS` file to expand code ownership for key configuration and build files. The main change is the addition of the `@hiero-ledger/hiero-sdk-java-maintainers` team as co-owners for several important directories and file patterns, ensuring broader coverage and responsibility.

**CODEOWNERS updates:**

* Added `@hiero-ledger/hiero-sdk-java-maintainers` as codeowner for the `.github/workflows/` directory, alongside the existing maintainers.
* Added `@hiero-ledger/hiero-sdk-java-maintainers` as codeowner for all `build-logic` directories and all Gradle-related files (e.g., `**/build-logic/`, `**/*.gradle.*`).

## Related Issue(s)

Closes #2799