### PR TITLE
fix: correct 'Creat' to 'Create' in ScheduleCreateIntegrationTest

### DIFF
--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ScheduleCreateIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ScheduleCreateIntegrationTest.java
@@ -132,7 +132,7 @@ class ScheduleCreateIntegrationTest {
             keyList.add(key2.getPublicKey());
             keyList.add(key3.getPublicKey());
 
-            // Creat the account with the `KeyList`
+            // Create the account with the `KeyList`
             TransactionResponse response = new AccountCreateTransaction()
                     .setKeyWithoutAlias(keyList)
                     .setInitialBalance(new Hbar(10))


### PR DESCRIPTION
## Summary
Fix typo on line 135 in ScheduleCreateIntegrationTest.java:
- `// Creat the account with the `KeyList`` → `// Create the account with the `KeyList`

Fixes #2797

## Verification
- Documentation-only change (comment fix)
- No code logic changed