### PR TITLE
docs: corrected the spelling of "Creat" to "Create" on line 135

### DIFF
--- a/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ScheduleCreateIntegrationTest.java
+++ b/sdk/src/testIntegration/java/com/hedera/hashgraph/sdk/test/integration/ScheduleCreateIntegrationTest.java
@@ -132,7 +132,7 @@ class ScheduleCreateIntegrationTest {
             keyList.add(key2.getPublicKey());
             keyList.add(key3.getPublicKey());
 
-            // Creat the account with the `KeyList`
+            // Create the account with the `KeyList`
             TransactionResponse response = new AccountCreateTransaction()
                     .setKeyWithoutAlias(keyList)
                     .setInitialBalance(new Hbar(10))


### PR DESCRIPTION
**Description**:

Fix typo on line 135 in ScheduleCreateIntegrationTest documentation.
"Creat" -> "Create"

No functional changes.

Fixes #2797 