### PR TITLE
chore: align CODEOWNERS to shared SDK teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default code owners for entire repository
-*                                               @hiero-ledger/hiero-sdk-java-maintainers @hiero-ledger/hiero-sdk-java-committers
+*                                               @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers
 
 #########################
 #####  Core Files  ######
@@ -9,34 +9,34 @@
 
 # Protection Rules for Github Configuration Files and Actions Workflows
 /.github/                                       @hiero-ledger/github-maintainers 
-/.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-java-maintainers
-/.github/dependabot.yml                         @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-java-maintainers @hiero-ledger/hiero-sdk-java-committers
+/.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers
+/.github/dependabot.yml                         @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers
 
 # Legacy Maven project files
-**/pom.xml                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-java-maintainers
+**/pom.xml                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers
 
 # Gradle project files and inline plugins
 /gradle/                                        @hiero-ledger/github-maintainers 
 gradlew                                         @hiero-ledger/github-maintainers 
 gradlew.bat                                     @hiero-ledger/github-maintainers
-**/build-logic/                                 @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-java-maintainers
+**/build-logic/                                 @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers
 **/gradle.*                                     @hiero-ledger/github-maintainers 
-**/*.gradle.*                                   @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-java-maintainers
+**/*.gradle.*                                   @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers
 
 # Codacy Tool Configurations
-/config/                                        @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-java-maintainers
-.remarkrc                                       @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-java-maintainers
+/config/                                        @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers
+.remarkrc                                       @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                     @hiero-ledger/github-maintainers
 
 # Protect the repository root files
-/README.md                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-java-maintainers @hiero-ledger/hiero-sdk-java-committers
-**/LICENSE                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-java-maintainers
+/README.md                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers
+**/LICENSE                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers
 
 # CodeCov configuration
 **/codecov.yml                                  @hiero-ledger/github-maintainers 
 
 # Git Ignore definitions
-**/.gitignore                                   @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-java-maintainers @hiero-ledger/hiero-sdk-java-committers
-**/.gitignore.*                                 @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-java-maintainers @hiero-ledger/hiero-sdk-java-committers
+**/.gitignore                                   @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers
+**/.gitignore.*                                 @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers


### PR DESCRIPTION
## What
Updates `.github/CODEOWNERS` to reference the shared SDK teams introduced by the team merge:
- `@hiero-ledger/hiero-sdk-java-maintainers` → `@hiero-ledger/hiero-sdk-maintainers`
- `@hiero-ledger/hiero-sdk-java-committers` → `@hiero-ledger/hiero-sdk-committers`

`@hiero-ledger/github-maintainers` and `@hiero-ledger/tsc` are intentionally left unchanged — they are not part of the SDK team merge.

## ⚠️ DO NOT MERGE YET
The shared teams `hiero-sdk-maintainers` / `hiero-sdk-committers` **do not exist yet**. Per the guide (§4) a CODEOWNERS team only takes effect once it exists and has write access in `governance/config.yaml`. This PR must land **together** with the governance PR that creates and grants those teams (§7) — merging it earlier would point `*` at a non-existent team and break code-owner enforcement.

Reference: https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/guides/sdk-team-structure-and-codeowners.md
