### PR TITLE
docs: fix typo in FileInfo.java ("ptotobuf" -> "protobuf")

### DIFF
--- a/sdk/src/main/java/com/hedera/hashgraph/sdk/FileInfo.java
+++ b/sdk/src/main/java/com/hedera/hashgraph/sdk/FileInfo.java
@@ -68,7 +68,7 @@ public final class FileInfo {
     }
 
     /**
-     * Create a file info object from a ptotobuf.
+     * Create a file info object from a protobuf.
      *
      * @param fileInfo                  the protobuf
      * @return                          the new file info object


### PR DESCRIPTION
Fixes the typo reported in #2822: `ptotobuf` → `protobuf` on line 71 of `FileInfo.java`.

Note: includes DCO sign-off (`-s`) but not GPG-signed (`-S`) — no GPG key registered. Please enable commit signing if required.

Closes #2822