### PR TITLE
docs: fix typo "guidelies" → "guidelines" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Join our [community discussions](https://discord.lfdecentralizedtrust.org/) on d
 
 ## About Users and Maintainers
 
-Users and Maintainers guidelies are located in **[Hiero-Ledger's roles and groups guidelines](https://github.com/hiero-ledger/governance/blob/main/roles-and-groups.md#maintainers).**
+Users and Maintainers guidelines are located in **[Hiero-Ledger's roles and groups guidelines](https://github.com/hiero-ledger/governance/blob/main/roles-and-groups.md#maintainers).**
 
 ## Code of Conduct
 


### PR DESCRIPTION
Fixes the typo on line 49 of `README.md` (`guidelies` → `guidelines`).

Closes #2821

Signed-off-by: Jay Spark <yasiralsadoon@gmail.com>