### PR TITLE
docs: fix broken roles-and-groups link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Join our [community discussions](https://discord.lfdecentralizedtrust.org/) on d
 
 ## About Users and Maintainers
 
-Users and Maintainers guidelies are located in **[Hiero-Ledger's roles and groups guidelines](https://github.com/hiero-ledger/governance/blob/main/roles-and-groups.md#maintainers).**
+Users and Maintainers guidelies are located in **[Hiero-Ledger's roles and groups guidelines](https://github.com/hiero-ledger/governance/blob/main/roles/roles-and-groups.md).**
 
 ## Code of Conduct
 


### PR DESCRIPTION
## Summary

The "About Users and Maintainers" section in `README.md` linked to `governance/roles-and-groups.md`, which now lives under `governance/roles/roles-and-groups.md`. The old URL returned a 404, so contributors looking up roles/groups info hit a dead end.

Updated the link to point at the new location (verified it resolves).

Closes #2849